### PR TITLE
SCA configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ env:
   - DISPLAY=:99.0
 before_install:
   - sh -e /etc/init.d/xvfb start
-script: mvn clean verify -f ./ddk-parent/pom.xml
+  - export WORKSPACE=${PWD}
+script: mvn clean verify checkstyle:check pmd:check pmd:cpd-check findbugs:check -f ./ddk-parent/pom.xml --batch-mode --fail-at-end

--- a/ddk-configuration/checkstyle/avaloq.xml
+++ b/ddk-configuration/checkstyle/avaloq.xml
@@ -54,8 +54,10 @@
     <module name="IllegalThrows"/>
     <module name="InterfaceIsType"/>
     <module name="JavadocMethod">
+      <property name="allowedAnnotations" value="Override,Inject"/>
       <property name="allowMissingPropertyJavadoc" value="true"/>
       <property name="logLoadErrors" value="true"/>
+      <property name="scope" value="package"/>
       <property name="suppressLoadErrors" value="true"/>
       <property name="tokens" value="METHOD_DEF"/>
     </module>

--- a/ddk-configuration/launches/Maven Verify.launch
+++ b/ddk-configuration/launches/Maven Verify.launch
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
 <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-<stringAttribute key="M2_GOALS" value="clean verify -f ddk-parent/pom.xml"/>
+<stringAttribute key="M2_GOALS" value="clean verify checkstyle:check pmd:check pmd:cpd-check findbugs:check -f ddk-parent/pom.xml --batch-mode --fail-at-end"/>
 <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
 <booleanAttribute key="M2_OFFLINE" value="false"/>
 <stringAttribute key="M2_PROFILES" value=""/>
 <listAttribute key="M2_PROPERTIES"/>
-<stringAttribute key="M2_RUNTIME" value="apache-maven-3.0.4"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
 <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
 <intAttribute key="M2_THREADS" value="1"/>
 <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -34,11 +34,9 @@
     <compiler.showWarnings>true</compiler.showWarnings>
     <pmd.ruleset>${workspace}/ddk-configuration/pmd/ruleset.xml</pmd.ruleset>
     <pmd.test.ruleset>${workspace}/ddk-configuration/pmd/ruleset-test.xml</pmd.test.ruleset>
-    <checkstyle.skip>false</checkstyle.skip>
     <checkstyle.configLocation>${workspace}/ddk-configuration/checkstyle/avaloq.xml</checkstyle.configLocation>
     <checkstyle.test.configLocation>${workspace}/ddk-configuration/checkstyle/avaloq-test.xml</checkstyle.test.configLocation>
     <findbugs.excludeFilterFile>${workspace}/ddk-configuration/findbugs/exclusion-filter.xml</findbugs.excludeFilterFile>
-    <findbugs.skip>false</findbugs.skip>
     <findbugs.maxHeap>2048</findbugs.maxHeap>
 
     <!-- test parameter-->
@@ -281,8 +279,10 @@
         <configuration>
           <targetJdk>1.8</targetJdk>
           <minimumTokens>100</minimumTokens>
-          <format>xml</format>
-          <failOnViolation>false</failOnViolation>
+          <aggregate>true</aggregate>
+          <failOnViolation>true</failOnViolation>
+          <printFailingErrors>true</printFailingErrors>
+          <verbose>true</verbose>
           <linkXRef>false</linkXRef>
           <rulesets>
             <ruleset>${pmd.ruleset}</ruleset>
@@ -306,7 +306,10 @@
           </dependency>
         </dependencies>
         <configuration>
-          <skip>${checkstyle.skip}</skip>
+          <violationSeverity>warning</violationSeverity>
+          <failOnViolation>true</failOnViolation>
+          <logViolationsToConsole>true</logViolationsToConsole>
+          <consoleOutput>true</consoleOutput>
           <linkXRef>false</linkXRef>
           <sourceDirectory>src</sourceDirectory>
           <configLocation>${checkstyle.configLocation}</configLocation>
@@ -318,13 +321,12 @@
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>${findbugs.plugin.version}</version>
         <configuration>
-          <findbugsXmlOutput>true</findbugsXmlOutput>
-          <failOnError>false</failOnError>
+          <findbugsXmlOutput>false</findbugsXmlOutput>
+          <failOnError>true</failOnError>
           <maxHeap>${findbugs.maxHeap}</maxHeap>
           <maxRank>15</maxRank>
           <threshold>Low</threshold>
           <excludeFilterFile>${findbugs.excludeFilterFile}</excludeFilterFile>
-          <skip>${findbugs.skip}</skip>
           <maxHeap>1024</maxHeap>
         </configuration>
       </plugin>

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -277,6 +277,7 @@
         <artifactId>maven-pmd-plugin</artifactId>
         <version>${pmd.plugin.version}</version>
         <configuration>
+          <skip>true</skip><!-- Remove this once all PMD violations have been fixed -->
           <targetJdk>1.8</targetJdk>
           <minimumTokens>100</minimumTokens>
           <aggregate>true</aggregate>
@@ -321,6 +322,7 @@
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>${findbugs.plugin.version}</version>
         <configuration>
+          <skip>true</skip><!-- Remove this once all Findbugs violations have been fixed -->
           <findbugsXmlOutput>false</findbugsXmlOutput>
           <failOnError>true</failOnError>
           <maxHeap>${findbugs.maxHeap}</maxHeap>


### PR DESCRIPTION
This series of commits fixes SCA configuration and adjusts Checkstyle configuration (no Checkstyle violations afterwards). It skips PMD and Findbugs for now so that we can cleanup these violations separately.