### PR TITLE
Performance: Use Arrays.asList() instead of Lists.newArrayList()

### DIFF
--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopeNameProviderGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopeNameProviderGenerator.xtend
@@ -33,6 +33,8 @@ class ScopeNameProviderGenerator {
     '''
       package «getScopeNameProvider().toJavaPackage()»;
 
+      import java.util.Arrays;
+
       import org.eclipse.emf.ecore.EClass;
       import org.eclipse.emf.ecore.EObject;
 
@@ -44,7 +46,6 @@ class ScopeNameProviderGenerator {
       import com.avaloq.tools.ddk.xtext.scoping.NameFunctions;
 
       import com.google.common.base.Function;
-      import com.google.common.collect.Lists;
       import com.google.inject.Singleton;
 
       @SuppressWarnings("all")
@@ -83,7 +84,7 @@ class ScopeNameProviderGenerator {
   }
 
   def nameFunctions(Naming it, ScopeModel model, String contextName, EClass contextType) {
-    '''Lists.<INameFunction> newArrayList(«FOR n : names SEPARATOR ", "»«nameFunction(n, model, contextName, contextType)»«ENDFOR»)'''
+    '''Arrays.<INameFunction> asList(«FOR n : names SEPARATOR ", "»«nameFunction(n, model, contextName, contextType)»«ENDFOR»)'''
   }
 
   def dispatch String nameFunction(NamingExpression it, ScopeModel model, String contextName, EClass contextType) {

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopeProviderGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopeProviderGenerator.xtend
@@ -55,6 +55,8 @@ class ScopeProviderGenerator {
     '''
       package «getScopeProvider().toJavaPackage()»;
 
+      import java.util.Arrays;
+
       import org.apache.log4j.Logger;
       import org.eclipse.emf.ecore.EClass;
       import org.eclipse.emf.ecore.EObject;
@@ -73,7 +75,6 @@ class ScopeProviderGenerator {
       import com.avaloq.tools.ddk.xtext.scoping.NameFunctions;
 
       import com.google.common.base.Predicate;
-      import com.google.common.collect.Lists;
       «IF it != null && !allInjections().isEmpty»
       import com.google.inject.Inject;
       «ENDIF»
@@ -312,7 +313,7 @@ class ScopeProviderGenerator {
     «val matchData = data.filter(LambdaDataExpression)»
     «IF matchData.isEmpty && prefix == null»newContainerScope(«ELSEIF matchData.isEmpty && prefix != null»newPrefixedContainerScope(«ELSE»newDataMatchScope(«ENDIF»"«it.locatorString()»", scope, ctx, «query (it, model, typeOrRef, scope)», originalResource«
     IF !matchData.isEmpty», //
-      Lists.<Predicate<IEObjectDescription>> newArrayList(
+      Arrays.<Predicate<IEObjectDescription>> asList(
     «FOR d : matchData SEPARATOR ","»
     «val CompilationContext cc = compilationContext.cloneWithVariable('ctx', eContainer(ScopeRule).context.contextType, d.desc, 'org::eclipse::xtext::resource::IEObjectDescription')»
         new Predicate<IEObjectDescription>() {


### PR DESCRIPTION
For fixed-size lists with known elements using Arrays.asList() is faster
than Lists.newArrayList(), as it avoids copying the elements array. This
commit applies this simple change to the Java classes generated by the
Scope DSL generator.