### PR TITLE
Performance: Minor tweaks in CheckConfigurationStoreService

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/TraceConfiguration.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/TraceConfiguration.java
@@ -11,9 +11,9 @@
 
 package com.avaloq.tools.ddk.xtext.tracing;
 
-import java.util.Arrays;
+import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 
 /**
@@ -58,7 +58,7 @@ public interface TraceConfiguration {
    */
   @SafeVarargs
   static TraceConfiguration enableAllExcept(final Class<? extends TraceEvent>... excludedTraceClasses) {
-    ImmutableSet<Class<? extends TraceEvent>> excludedTraceClassSet = ImmutableSet.copyOf(Arrays.asList(excludedTraceClasses));
+    Set<Class<? extends TraceEvent>> excludedTraceClassSet = Sets.newHashSet(excludedTraceClasses);
     return c -> !excludedTraceClassSet.contains(c);
   }
 
@@ -71,7 +71,7 @@ public interface TraceConfiguration {
    */
   @SafeVarargs
   static TraceConfiguration enableOnly(final Class<? extends TraceEvent>... includedTraceClasses) {
-    ImmutableSet<Class<? extends TraceEvent>> includedTraceClassSet = ImmutableSet.copyOf(Arrays.asList(includedTraceClasses));
+    Set<Class<? extends TraceEvent>> includedTraceClassSet = Sets.newHashSet(includedTraceClasses);
     return c -> includedTraceClassSet.contains(c);
   }
 }


### PR DESCRIPTION
CheckConfigurationStoreService#getLanguage() will now no longer
instantiate a LazyLinkingResource object just to retrieve the qualified
language name for a given URI. Instead the corresponding LANGUAGE_NAME
constant value is retrieved from the injector.

Also TraceConfiguration was changed to use HashSet rather than Guava's
ImmutableSet. Since the Set isn't accessible to client code there is no
need for ImmutableSet. While ImmutableSet#contains(Object) is often
faster when the result is "true", HashSet#contains(Object) is typically
faster when the result is "false". The latter is more important to
optimize, as typically only the less frequent high-level event types are
traced.