### PR TITLE
Check > Deploy no longer requires .checkcfg files' extensions to be all-lowercase.

### DIFF
--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/popup/actions/DeployJob.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/popup/actions/DeployJob.java
@@ -226,7 +226,7 @@ public class DeployJob extends Job {
           if (resource instanceof IProject) {
             return true;
           }
-          if (resource instanceof IFile && CheckCfgConstants.FILE_EXTENSION.equals(((IFile) resource).getFileExtension())) {
+          if (resource instanceof IFile && CheckCfgConstants.FILE_EXTENSION.equalsIgnoreCase(((IFile) resource).getFileExtension())) {
             checkCfgFiles.add((IFile) resource);
             return false;
           }


### PR DESCRIPTION
Check > Deploy no longer requires .checkcfg files' extensions to be
all-lowercase.