### PR TITLE
#39: Follow-up change fixing NameFunctions#fromConstant()

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/NameFunctions.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/NameFunctions.java
@@ -129,6 +129,11 @@ public final class NameFunctions {
       public QualifiedName apply(final EObject from) {
         return QualifiedNames.safeQualifiedName(value);
       }
+
+      @Override
+      public QualifiedName apply(final IEObjectDescription from) {
+        return QualifiedNames.safeQualifiedName(value);
+      }
     };
   }
 


### PR DESCRIPTION
The name function returned by NameFunctions#fromConstant() now also
works properly for IEObjectDescriptions.