### PR TITLE
Performance: Improve QualifiedNameSegmentTreeLookup#get()

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookup.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookup.java
@@ -341,7 +341,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
     SegmentNode result = root.find(name, 0, true);
     if (result != null && result.values != null) {
       hits++;
-      return Lists.newArrayList(result.values);
+      return Arrays.asList(result.values);
     } else {
       misses++;
       return null;


### PR DESCRIPTION
Slightly improves performance of QualifiedNameSegmentTreeLookup#get() by
using Arrays#asList() instead of Lists#newArrayList().