### PR TITLE
Fix name provider to support contributions

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/AbstractExportedNameProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/AbstractExportedNameProvider.java
@@ -40,7 +40,7 @@ public abstract class AbstractExportedNameProvider extends IQualifiedNameProvide
    */
   @Override
   public QualifiedName getFullyQualifiedName(final EObject obj) {
-    return cache.get(Tuples.pair(obj, "fqn"), obj.eResource(), new Provider<QualifiedName>() { //$NON-NLS-1$
+    return cache.get(Tuples.pair(obj, this.getClass()), obj.eResource(), new Provider<QualifiedName>() {
       @Override
       public QualifiedName get() {
         return qualifiedName(obj);


### PR DESCRIPTION
As there can be several name providers, use different cache key for
different class of the name provider.

Issue #46
Change-Id: I1bd922a80219e9ac7e0070449c73f116db67374e