### PR TITLE
Provide DirectLinkingResourceStorageFacade#deleteStorage()

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
@@ -15,6 +15,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.generator.IFileSystemAccess;
+import org.eclipse.xtext.generator.IFileSystemAccessExtension3;
 import org.eclipse.xtext.resource.persistence.ResourceStorageFacade;
 import org.eclipse.xtext.resource.persistence.ResourceStorageLoadable;
 import org.eclipse.xtext.resource.persistence.ResourceStorageWritable;
@@ -52,6 +54,40 @@ public class DirectLinkingResourceStorageFacade extends ResourceStorageFacade {
       }
     }
     return doesStorageExist(resource);
+  }
+
+  /**
+   * If the resource contains errors, any existing storage will be deleted.
+   */
+  @Override
+  public void saveResource(final StorageAwareResource resource, final IFileSystemAccessExtension3 fsa) {
+    if (!resource.getErrors().isEmpty()) {
+      deleteStorage(resource.getURI(), (IFileSystemAccess) fsa);
+    } else {
+      super.saveResource(resource, fsa);
+    }
+  }
+
+  /**
+   * Deletes the binary storage for the resource with the given URI, if it exists.
+   *
+   * @param resourceUri
+   *          URI of resource to delete binary storage for, must not be {@code null}
+   * @param fsa
+   *          file system access, must not be {@code null}
+   */
+  public void deleteStorage(final URI resourceUri, final IFileSystemAccess fsa) {
+    fsa.deleteFile(computeOutputPath(resourceUri));
+  }
+
+  private String computeOutputPath(final URI resourceUri) {
+    URI srcContainerURI = getSourceContainerURI(resourceUri);
+    URI uri = getBinaryStorageURI(resourceUri);
+    return uri.deresolve(srcContainerURI, false, false, true).path();
+  }
+
+  private URI getSourceContainerURI(final URI resourceUri) {
+    return resourceUri.trimSegments(1).appendSegment(""); //$NON-NLS-1$
   }
 
   @Override


### PR DESCRIPTION
Adds a new method DirectLinkingResourceStorageFacade#deleteStorage()
which can be used to delete the binary storage for a given resource.
This method is used internally by saveResource() when the resource
contains resource-level errors (e.g. linking errors), just in case
client code calls saveResource() for a resource with errors.