### PR TITLE
Provide better feedback when scoping to types with no 'name'

### DIFF
--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/validation/ScopeJavaValidator.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/validation/ScopeJavaValidator.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.internal.xtend.xtend.XtendFile;
 import org.eclipse.osgi.util.NLS;
@@ -36,6 +37,7 @@ import com.avaloq.tools.ddk.xtext.expression.expression.Expression;
 import com.avaloq.tools.ddk.xtext.scope.ScopeUtil;
 import com.avaloq.tools.ddk.xtext.scope.scope.Extension;
 import com.avaloq.tools.ddk.xtext.scope.scope.GlobalScopeExpression;
+import com.avaloq.tools.ddk.xtext.scope.scope.NamedScopeExpression;
 import com.avaloq.tools.ddk.xtext.scope.scope.ScopeContext;
 import com.avaloq.tools.ddk.xtext.scope.scope.ScopeDefinition;
 import com.avaloq.tools.ddk.xtext.scope.scope.ScopeDelegation;
@@ -337,6 +339,23 @@ public class ScopeJavaValidator extends AbstractScopeJavaValidator {
 
     if (!defaultFound) {
       warning("No matching default scope rule defined", ScopePackage.Literals.SCOPE_RULE__CONTEXT);
+    }
+  }
+
+  /**
+   * Check that naming functions are used when referencing a feature type with no name feature.
+   *
+   * @param scope
+   *          the scope definition to check
+   */
+  @Check
+  public void checkNamingFunctionPresentNoNameFeature(final ScopeDefinition scope) {
+    EReference ref = scope.getReference();
+    if (ref != null && ref.getEReferenceType().getEStructuralFeature("name") == null //$NON-NLS-1$
+        && scope.getRules().stream().flatMap(rule -> rule.getExprs().stream()).anyMatch(expr -> !(expr instanceof NamedScopeExpression)
+            || ((NamedScopeExpression) expr).getNaming() == null)) {
+      error("The referenced type " + ref.getEReferenceType().getName() //$NON-NLS-1$
+          + " has no feature 'name'. A naming function must be specified on all scoping rules.", scope, ScopePackage.Literals.SCOPE_DEFINITION__REFERENCE); //$NON-NLS-1$
     }
   }
 

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AbstractScopeNameProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AbstractScopeNameProvider.java
@@ -81,7 +81,7 @@ public abstract class AbstractScopeNameProvider implements IScopeNameProvider {
       return NameFunctions.fromFeatures(nameFeature);
     }
 
-    throw new IllegalArgumentException("unknown type: " + type); //$NON-NLS-1$
+    throw new IllegalArgumentException("EStructuralFeature 'name' undefined for type: " + type); //$NON-NLS-1$
   }
 
   /**


### PR DESCRIPTION
 - Provide an error when scoping to a type with no name feature,
informing that a naming function must be used
 - Modify the message of the runtime exception when name feature is
missing, to better explain the situation