### PR TITLE
#72: Fix problems with InferredModelAssociator

### DIFF
--- a/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
@@ -13,8 +13,7 @@ Require-Bundle: com.google.guava;bundle-version="[10.0.0,19.0.0)",
  org.eclipse.emf.ecore,
  org.eclipse.xtext,
  org.eclipse.xtext.builder,
- org.eclipse.xtext.util,
- org.eclipse.xtext.xbase
+ org.eclipse.xtext.util
 Export-Package: com.avaloq.tools.ddk.caching,
  com.avaloq.tools.ddk.xtext.build,
  com.avaloq.tools.ddk.xtext.documentation,

--- a/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: com.google.guava;bundle-version="[10.0.0,19.0.0)",
  org.eclipse.emf.ecore,
  org.eclipse.xtext,
  org.eclipse.xtext.builder,
- org.eclipse.xtext.util
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase
 Export-Package: com.avaloq.tools.ddk.caching,
  com.avaloq.tools.ddk.xtext.build,
  com.avaloq.tools.ddk.xtext.documentation,

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
@@ -39,12 +39,12 @@ import org.eclipse.xtext.resource.persistence.StorageAwareResource;
 
 import com.avaloq.tools.ddk.xtext.modelinference.InferredModelAssociator;
 import com.avaloq.tools.ddk.xtext.modelinference.InferredModelAssociator.Adapter;
-import com.avaloq.tools.ddk.xtext.modelinference.InferredModelAssociator.LinkedListBasedSet;
 import com.avaloq.tools.ddk.xtext.nodemodel.serialization.FixedDeserializationConversionContext;
 import com.avaloq.tools.ddk.xtext.tracing.ITraceSet;
 import com.avaloq.tools.ddk.xtext.tracing.ResourceLoadStorageEvent;
 import com.google.common.base.Splitter;
-import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.io.CharStreams;
 
 
@@ -137,7 +137,8 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
   }
 
   /**
-   * Reads the {@link InferredModelAssociator.Adapter#getSourceToTargetMap()} map.
+   * Reads the {@link InferredModelAssociator.Adapter#getSourceToInferredModelMap()} map and the
+   * {@link InferredModelAssociator.Adapter#getInferredModelToSourceMap()} map.
    *
    * @param resource
    *          resource being deserialized, must not be {@code null}
@@ -152,20 +153,22 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
         adapter = new InferredModelAssociator.Adapter();
         resource.eAdapters().add(adapter);
       }
-      Map<EObject, Set<EObject>> destinationMap = adapter.getSourceToTargetMap();
+      Map<EObject, Set<EObject>> destinationMap = adapter.getSourceToInferredModelMap();
       ObjectInputStream objIn = new ObjectInputStream(stream);
       @SuppressWarnings("unchecked")
       Map<String, Set<String>> sourceToTargetMap = (Map<String, Set<String>>) objIn.readObject();
       for (Map.Entry<String, Set<String>> entry : sourceToTargetMap.entrySet()) {
-        EObject source = getEObject(entry.getKey(), resource);
-        destinationMap.put(source, LinkedListBasedSet.of(Collections2.transform(entry.getValue(), v -> getEObject(v, resource))));
+        Builder<EObject> setBuilder = ImmutableSet.builder();
+        entry.getValue().forEach(v -> setBuilder.add(getEObject(v, resource)));
+        destinationMap.put(getEObject(entry.getKey(), resource), setBuilder.build());
       }
-      destinationMap = adapter.getTargetToSourceMap();
+      destinationMap = adapter.getInferredModelToSourceMap();
       @SuppressWarnings("unchecked")
       Map<String, Set<String>> targetToSourceMap = (Map<String, Set<String>>) objIn.readObject();
       for (Map.Entry<String, Set<String>> entry : targetToSourceMap.entrySet()) {
-        EObject target = getEObject(entry.getKey(), resource);
-        destinationMap.put(target, LinkedListBasedSet.of(Collections2.transform(entry.getValue(), v -> getEObject(v, resource))));
+        Builder<EObject> setBuilder = ImmutableSet.builder();
+        entry.getValue().forEach(v -> setBuilder.add(getEObject(v, resource)));
+        destinationMap.put(getEObject(entry.getKey(), resource), setBuilder.build());
       }
     } catch (ClassNotFoundException | IOException e) {
       throw new WrappedException(e);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
@@ -138,7 +138,8 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
   }
 
   /**
-   * Serializes the {@link InferredModelAssociator.Adapter#getSourceToTargetMap() source-to-inferred-element map} for the given resource.
+   * Serializes the {@link InferredModelAssociator.Adapter#getSourceToInferredModelMap() source-to-inferred-element map} and the
+   * {@link InferredModelAssociator.Adapter#getInferredModelToSourceMap() inferred-element-to-source map} for the given resource.
    *
    * @param resource
    *          resource, must not be {@code null}
@@ -154,7 +155,7 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
       // sourceToTarget
       Map<String, Set<String>> sourceToTarget = Maps.newHashMap();
       if (adapter != null) {
-        for (Entry<EObject, Set<EObject>> entry : adapter.getSourceToTargetMap().entrySet()) {
+        for (Entry<EObject, Set<EObject>> entry : adapter.getSourceToInferredModelMap().entrySet()) {
           sourceToTarget.put(getURIString(entry.getKey(), resource), Sets.newHashSet(Collections2.filter(Collections2.transform(entry.getValue(), v -> getURIString(v, resource)), Objects::nonNull)));
         }
       }
@@ -163,7 +164,7 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
       // targetToSource
       Map<String, Set<String>> targetToSource = Maps.newHashMap();
       if (adapter != null) {
-        for (Entry<EObject, Set<EObject>> entry : adapter.getTargetToSourceMap().entrySet()) {
+        for (Entry<EObject, Set<EObject>> entry : adapter.getInferredModelToSourceMap().entrySet()) {
           targetToSource.put(getURIString(entry.getKey(), resource), Sets.newHashSet(Collections2.filter(Collections2.transform(entry.getValue(), v -> getURIString(v, resource)), Objects::nonNull)));
         }
       }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
@@ -19,11 +19,11 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -138,7 +138,7 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
   }
 
   /**
-   * Serializes the {@link InferredModelAssociator.Adapter#getSourceToInferredModelMap() source-to-inferred-element map} for the given resource.
+   * Serializes the {@link InferredModelAssociator.Adapter#getSourceToTargetMap() source-to-inferred-element map} for the given resource.
    *
    * @param resource
    *          resource, must not be {@code null}
@@ -152,13 +152,22 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
     ObjectOutputStream objOut = new ObjectOutputStream(zipOut);
     try {
       // sourceToTarget
-      Map<String, Collection<String>> sourceToTarget = Maps.newHashMap();
+      Map<String, Set<String>> sourceToTarget = Maps.newHashMap();
       if (adapter != null) {
-        for (Entry<EObject, Collection<EObject>> entry : adapter.getSourceToInferredModelMap().asMap().entrySet()) {
+        for (Entry<EObject, Set<EObject>> entry : adapter.getSourceToTargetMap().entrySet()) {
           sourceToTarget.put(getURIString(entry.getKey(), resource), Sets.newHashSet(Collections2.filter(Collections2.transform(entry.getValue(), v -> getURIString(v, resource)), Objects::nonNull)));
         }
       }
       objOut.writeObject(sourceToTarget);
+
+      // targetToSource
+      Map<String, Set<String>> targetToSource = Maps.newHashMap();
+      if (adapter != null) {
+        for (Entry<EObject, Set<EObject>> entry : adapter.getTargetToSourceMap().entrySet()) {
+          targetToSource.put(getURIString(entry.getKey(), resource), Sets.newHashSet(Collections2.filter(Collections2.transform(entry.getValue(), v -> getURIString(v, resource)), Objects::nonNull)));
+        }
+      }
+      objOut.writeObject(targetToSource);
     } finally {
       objOut.flush();
     }
@@ -207,7 +216,7 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
     for (InternalEObject container = internalEObject.eInternalContainer(); container != null; container = internalEObject.eInternalContainer()) {
       EStructuralFeature feature = internalEObject.eContainingFeature();
       StringBuilder b = new StringBuilder();
-      b.append(feature.getFeatureID());
+      b.append(container.eClass().getFeatureID(feature));
       if (feature.isMany()) {
         b.append('.').append(((EList<EObject>) container.eGet(feature, false)).indexOf(internalEObject));
       }


### PR DESCRIPTION
Allow a single source model element to be the primary source for
multiple inferred model elements and also improve the lookup performance
for the primary source of an inferred model element.

These changes to InferredModelAssociator also required corresponding
changes in DirectLinkingResourceStorageLoadable and
DirectLinkingResourceStorageWritable.

Additionally this commit fixes a bug in
DirectLinkingResourceStorageWritable which could cause incorrect
fragments to be computed for the inferred model element associations map
for inherited containment features as EStructuralFeature#getFeatureID()
was called rather than EClass#getFeatureID(EStructuralFeature). This in
turn could lead to ClassCastExceptions in
DirectLinkingResourceStorageLoadable.