### PR TITLE
#74: Fix bug in DirectLinkingResourceStorageWritable

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractSelectorFragmentProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractSelectorFragmentProvider.java
@@ -61,7 +61,7 @@ public abstract class AbstractSelectorFragmentProvider extends AbstractFragmentP
     result.append(container.eClass().getFeatureID(containmentFeature));
     // selector
     final Object selectorValue = obj.eGet(selectorFeature);
-    result.append(SELECTOR_START).append(selectorFeature.getFeatureID()).append(EQ_OP);
+    result.append(SELECTOR_START).append(obj.eClass().getFeatureID(selectorFeature)).append(EQ_OP);
     if (selectorValue != null) {
       result.append(VALUE_SEP).append(escape(selectorValue.toString())).append(VALUE_SEP);
     } else {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
@@ -207,7 +207,7 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
     for (InternalEObject container = internalEObject.eInternalContainer(); container != null; container = internalEObject.eInternalContainer()) {
       EStructuralFeature feature = internalEObject.eContainingFeature();
       StringBuilder b = new StringBuilder();
-      b.append(feature.getFeatureID());
+      b.append(container.eClass().getFeatureID(feature));
       if (feature.isMany()) {
         b.append('.').append(((EList<EObject>) container.eGet(feature, false)).indexOf(internalEObject));
       }


### PR DESCRIPTION
Fixes URI fragment computation in getURIFragmentPath() for cases when an
object is contained by another object where the containment feature is
inherited from a supertype which isn't the first ("left-most")
supertype.