### PR TITLE
#76: Validate that required name function exists

### DIFF
--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/validation/Messages.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/validation/Messages.java
@@ -25,6 +25,7 @@ public class Messages extends NLS {
   public static String overriddenInheritedScopeRule;
   public static String uriPatternFound;
   public static String typeMismatch;
+  public static String missingNameFunction;
   static {
     // initialize resource bundle
     NLS.initializeMessages(BUNDLE_NAME, Messages.class);
@@ -35,4 +36,3 @@ public class Messages extends NLS {
   }
 }
 // CHECKSTYLE:ON
-

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/validation/messages.properties
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/validation/messages.properties
@@ -7,3 +7,4 @@ extensionNotFound=Extension ''{0}'' not found
 overriddenInheritedScopeRule=Overrides inherited scope rule {0}
 uriPatternFound=Consider replacing URI pattern with a key pattern
 typeMismatch=Type mismatch: Cannot convert from {0} to {1}
+missingNameFunction=No default name function defined matching type ''{0}''


### PR DESCRIPTION
Add a validation which checks that for simple scope expressions there is
a matching default name function if the experssion doesn't have any
explicit name functions.