### PR TITLE
#72: Also use insertion ordered sets for "sourceToInferredModelMap"

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
@@ -19,6 +19,7 @@ import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipInputStream;
@@ -43,8 +44,7 @@ import com.avaloq.tools.ddk.xtext.nodemodel.serialization.FixedDeserializationCo
 import com.avaloq.tools.ddk.xtext.tracing.ITraceSet;
 import com.avaloq.tools.ddk.xtext.tracing.ResourceLoadStorageEvent;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 
 
@@ -153,22 +153,22 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
         adapter = new InferredModelAssociator.Adapter();
         resource.eAdapters().add(adapter);
       }
-      Map<EObject, Set<EObject>> destinationMap = adapter.getSourceToInferredModelMap();
+      Map<EObject, List<EObject>> destinationMap = adapter.getSourceToInferredModelMap();
       ObjectInputStream objIn = new ObjectInputStream(stream);
       @SuppressWarnings("unchecked")
       Map<String, Set<String>> sourceToTargetMap = (Map<String, Set<String>>) objIn.readObject();
       for (Map.Entry<String, Set<String>> entry : sourceToTargetMap.entrySet()) {
-        Builder<EObject> setBuilder = ImmutableSet.builder();
-        entry.getValue().forEach(v -> setBuilder.add(getEObject(v, resource)));
-        destinationMap.put(getEObject(entry.getKey(), resource), setBuilder.build());
+        ImmutableList.Builder<EObject> listBuilder = ImmutableList.builder();
+        entry.getValue().forEach(v -> listBuilder.add(getEObject(v, resource)));
+        destinationMap.put(getEObject(entry.getKey(), resource), listBuilder.build());
       }
       destinationMap = adapter.getInferredModelToSourceMap();
       @SuppressWarnings("unchecked")
       Map<String, Set<String>> targetToSourceMap = (Map<String, Set<String>>) objIn.readObject();
       for (Map.Entry<String, Set<String>> entry : targetToSourceMap.entrySet()) {
-        Builder<EObject> setBuilder = ImmutableSet.builder();
-        entry.getValue().forEach(v -> setBuilder.add(getEObject(v, resource)));
-        destinationMap.put(getEObject(entry.getKey(), resource), setBuilder.build());
+        ImmutableList.Builder<EObject> listBuilder = ImmutableList.builder();
+        entry.getValue().forEach(v -> listBuilder.add(getEObject(v, resource)));
+        destinationMap.put(getEObject(entry.getKey(), resource), listBuilder.build());
       }
     } catch (ClassNotFoundException | IOException e) {
       throw new WrappedException(e);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
@@ -20,7 +20,6 @@ import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
@@ -47,9 +46,9 @@ import com.avaloq.tools.ddk.xtext.modelinference.InferredModelAssociator.Adapter
 import com.avaloq.tools.ddk.xtext.nodemodel.serialization.FixedSerializationConversionContext;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.common.io.CharStreams;
 
 
@@ -153,22 +152,22 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
     ObjectOutputStream objOut = new ObjectOutputStream(zipOut);
     try {
       // sourceToTarget
-      Map<String, Set<String>> sourceToTarget = Maps.newHashMap();
+      ImmutableMap.Builder<String, Set<String>> sourceToTarget = ImmutableMap.builder();
       if (adapter != null) {
-        for (Entry<EObject, Set<EObject>> entry : adapter.getSourceToInferredModelMap().entrySet()) {
-          sourceToTarget.put(getURIString(entry.getKey(), resource), Sets.newHashSet(Collections2.filter(Collections2.transform(entry.getValue(), v -> getURIString(v, resource)), Objects::nonNull)));
+        for (Entry<EObject, List<EObject>> entry : adapter.getSourceToInferredModelMap().entrySet()) {
+          sourceToTarget.put(getURIString(entry.getKey(), resource), ImmutableSet.copyOf(Collections2.filter(Collections2.transform(entry.getValue(), v -> getURIString(v, resource)), Objects::nonNull)));
         }
       }
-      objOut.writeObject(sourceToTarget);
+      objOut.writeObject(sourceToTarget.build());
 
       // targetToSource
-      Map<String, Set<String>> targetToSource = Maps.newHashMap();
+      ImmutableMap.Builder<String, Set<String>> targetToSource = ImmutableMap.builder();
       if (adapter != null) {
-        for (Entry<EObject, Set<EObject>> entry : adapter.getInferredModelToSourceMap().entrySet()) {
-          targetToSource.put(getURIString(entry.getKey(), resource), Sets.newHashSet(Collections2.filter(Collections2.transform(entry.getValue(), v -> getURIString(v, resource)), Objects::nonNull)));
+        for (Entry<EObject, List<EObject>> entry : adapter.getInferredModelToSourceMap().entrySet()) {
+          targetToSource.put(getURIString(entry.getKey(), resource), ImmutableSet.copyOf(Collections2.filter(Collections2.transform(entry.getValue(), v -> getURIString(v, resource)), Objects::nonNull)));
         }
       }
-      objOut.writeObject(targetToSource);
+      objOut.writeObject(targetToSource.build());
     } finally {
       objOut.flush();
     }


### PR DESCRIPTION
Since there are clients which rely on the insertion order into
InferedModelAssociator's "sourceToInferredModelMap" and hence the order
of elements in the Set returned by
IInferredModelAssociations#getInferredModelElements(), this commit
changes InferedModelAssociator to use a LinkedHashSet rather than a
regular HashSet to store the inferred model elements.

DirectLinkingResourceStorageWritable has also been changed to serialize
an ImmutableSet rather than a HashSet to make sure that this insertion
order is maintained.

It might make sense to add a method getPrimaryInferredModelElement() to
IInferredModelAssociations, which would also be in line with Xbase's
IJvmModelAssociations#getPrimaryJvmElement(). This would make it more
explicit that this insertion order is maintained.