### PR TITLE
Improve performance of model associations in binary resources

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingEObjectInputStream.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingEObjectInputStream.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.resource.persistence;
+
+import static com.avaloq.tools.ddk.xtext.resource.persistence.DirectLinkingEObjectOutputStream.LOCAL_EOBJECT;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.BinaryResourceImpl.EObjectInputStream;
+
+
+/**
+ * {@link EObjectInputStream} subclass which provides {@link #readEObject(Resource)} to read the serialization of
+ * {@link DirectLinkingEObjectOutputStream#writeEObjectURI(EObject, Resource)}.
+ */
+class DirectLinkingEObjectInputStream extends EObjectInputStream {
+
+  DirectLinkingEObjectInputStream(final InputStream inputStream, final Map<?, ?> options) throws IOException {
+    super(inputStream, options);
+  }
+
+  /**
+   * Reads an EObject from this input stream.
+   *
+   * @param context
+   *          resource being deserialized, must not be {@code null}
+   * @return corresponding EObject or {@code null} if a lazy-linking proxy was serialized
+   * @see DirectLinkingEObjectOutputStream#writeEObjectURI(EObject, Resource)
+   * @throws IOException
+   *           if an I/O exception occurred
+   */
+  @SuppressWarnings("unchecked")
+  public EObject readEObject(final Resource context) throws IOException {
+    if (readBoolean() == LOCAL_EOBJECT) {
+      int count = readCompressedInt();
+      EObject eObject = context.getContents().get(readCompressedInt());
+      count--;
+      while (count > 0) {
+        EStructuralFeature feature = eObject.eClass().getEStructuralFeature(readCompressedInt());
+        count--;
+        if (feature.isMany()) {
+          eObject = ((EList<EObject>) eObject.eGet(feature, false)).get(readCompressedInt());
+          count--;
+        } else {
+          eObject = (EObject) eObject.eGet(feature, false);
+        }
+      }
+      return eObject;
+    } else {
+      String uriString = readString();
+      return uriString == null ? null : context.getResourceSet().getEObject(URI.createURI(uriString), true);
+    }
+  }
+
+}

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingEObjectOutputStream.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingEObjectOutputStream.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.resource.persistence;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.BinaryResourceImpl.EObjectOutputStream;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.linking.lazy.LazyURIEncoder;
+
+import com.google.common.collect.Lists;
+
+
+/**
+ * {@link EObjectOutputStream} subclass which provides {@link #writeEObjectURI(EObject, Resource)} to serialize an EObject's URI using a compact representation.
+ */
+class DirectLinkingEObjectOutputStream extends EObjectOutputStream {
+
+  static final boolean LOCAL_EOBJECT = true;
+
+  private final List<Integer> list = Lists.newArrayList();
+
+  DirectLinkingEObjectOutputStream(final OutputStream outputStream, final Map<?, ?> options) throws IOException {
+    super(outputStream, options);
+  }
+
+  /**
+   * Writes a binary representation of the given object's URI to this output stream. For objects contained by the given resource the object's
+   * {@link Resource#getURIFragment(EObject) URI fragment} will be used. For objects in other resources the {@link EcoreUtil#getURI(EObject) full URI} will be
+   * written.
+   *
+   * @param obj
+   *          object to write, must not be {@code null}
+   * @param context
+   *          resource being serialized, must not be {@code null}
+   * @throws IOException
+   *           if an I/O exception occurred
+   */
+  public void writeEObjectURI(final EObject obj, final Resource context) throws IOException {
+    Resource resource = obj.eResource();
+    if (resource == context) { // NOPMD
+      writeBoolean(LOCAL_EOBJECT);
+      writeEObjectURIFragmentPath(obj);
+    } else {
+      String uriString = null;
+      if (obj.eIsProxy()) {
+        URI proxyURI = ((InternalEObject) obj).eProxyURI();
+        uriString = proxyURI.fragment().startsWith(LazyURIEncoder.XTEXT_LINK) ? null : proxyURI.toString();
+      } else {
+        uriString = resource.getURI().toString() + '#' + resource.getURIFragment(obj);
+      }
+      writeBoolean(!LOCAL_EOBJECT);
+      writeString(uriString);
+    }
+  }
+
+  /**
+   * Computes a short positional URI fragment path. These are more efficient than fragments returned by {@link org.eclipse.xtext.resource.IFragmentProvider}, as
+   * the latter may contain name-based segments, which require a lookup to resolve.
+   *
+   * @param obj
+   *          object to get URI fragment for, must not be {@code null}
+   * @return URI fragment path, where the segments encode the feature IDs and position in case of multi-valued features, never {@code null}
+   */
+  @SuppressWarnings("unchecked")
+  private void writeEObjectURIFragmentPath(final EObject obj) throws IOException {
+    list.clear();
+    InternalEObject internalEObject = (InternalEObject) obj;
+    for (InternalEObject container = internalEObject.eInternalContainer(); container != null; container = internalEObject.eInternalContainer()) {
+      EStructuralFeature feature = internalEObject.eContainingFeature();
+      if (feature.isMany()) {
+        list.add(((EList<EObject>) container.eGet(feature, false)).indexOf(internalEObject));
+      }
+      list.add(container.eClass().getFeatureID(feature));
+      internalEObject = container;
+    }
+
+    list.add(internalEObject.eResource().getContents().indexOf(internalEObject));
+    writeCompressedInt(list.size());
+    for (int i = list.size() - 1; i >= 0; i--) {
+      writeCompressedInt(list.get(i));
+    }
+  }
+
+}

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
@@ -14,28 +14,19 @@ package com.avaloq.tools.ddk.xtext.resource.persistence;
 import java.io.BufferedOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.Deque;
 import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.apache.log4j.Logger;
-import org.eclipse.emf.common.util.EList;
-import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.InternalEObject;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.xtext.linking.lazy.LazyURIEncoder;
 import org.eclipse.xtext.nodemodel.impl.SerializableNodeModel;
 import org.eclipse.xtext.nodemodel.serialization.SerializationConversionContext;
 import org.eclipse.xtext.resource.persistence.ResourceStorageWritable;
@@ -44,11 +35,7 @@ import org.eclipse.xtext.resource.persistence.StorageAwareResource;
 import com.avaloq.tools.ddk.xtext.modelinference.InferredModelAssociator;
 import com.avaloq.tools.ddk.xtext.modelinference.InferredModelAssociator.Adapter;
 import com.avaloq.tools.ddk.xtext.nodemodel.serialization.FixedSerializationConversionContext;
-import com.google.common.base.Joiner;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
+import com.google.common.base.Ascii;
 import com.google.common.io.CharStreams;
 
 
@@ -81,7 +68,6 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
         bufferedOutput.flush();
         zipOut.closeEntry();
       }
-
       if (storeNodeModel) {
         zipOut.putNextEntry(new ZipEntry("source")); //$NON-NLS-1$
         try {
@@ -149,83 +135,39 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
    */
   protected void writeAssociationsAdapter(final StorageAwareResource resource, final OutputStream zipOut) throws IOException {
     InferredModelAssociator.Adapter adapter = (Adapter) EcoreUtil.getAdapter(resource.eAdapters(), InferredModelAssociator.Adapter.class);
-    ObjectOutputStream objOut = new ObjectOutputStream(zipOut);
+    DirectLinkingEObjectOutputStream objOut = new DirectLinkingEObjectOutputStream(zipOut, null);
     try {
       // sourceToTarget
-      ImmutableMap.Builder<String, Set<String>> sourceToTarget = ImmutableMap.builder();
       if (adapter != null) {
-        for (Entry<EObject, List<EObject>> entry : adapter.getSourceToInferredModelMap().entrySet()) {
-          sourceToTarget.put(getURIString(entry.getKey(), resource), ImmutableSet.copyOf(Collections2.filter(Collections2.transform(entry.getValue(), v -> getURIString(v, resource)), Objects::nonNull)));
+        objOut.writeCompressedInt(adapter.getSourceToInferredModelMap().size());
+        for (Entry<EObject, Deque<EObject>> entry : adapter.getSourceToInferredModelMap().entrySet()) {
+          writeMapping(entry, objOut, resource);
         }
-      }
-      objOut.writeObject(sourceToTarget.build());
+        objOut.writeByte(Ascii.GS);
 
-      // targetToSource
-      ImmutableMap.Builder<String, Set<String>> targetToSource = ImmutableMap.builder();
-      if (adapter != null) {
-        for (Entry<EObject, List<EObject>> entry : adapter.getInferredModelToSourceMap().entrySet()) {
-          targetToSource.put(getURIString(entry.getKey(), resource), ImmutableSet.copyOf(Collections2.filter(Collections2.transform(entry.getValue(), v -> getURIString(v, resource)), Objects::nonNull)));
+        // targetToSource
+        boolean anyTargetWithMultipleSources = adapter.getInferredModelToSourceMap().values().stream().anyMatch(c -> c.size() > 1);
+        objOut.writeBoolean(anyTargetWithMultipleSources);
+        if (anyTargetWithMultipleSources) {
+          objOut.writeCompressedInt(adapter.getInferredModelToSourceMap().size());
+          for (Entry<EObject, Deque<EObject>> entry : adapter.getInferredModelToSourceMap().entrySet()) {
+            writeMapping(entry, objOut, resource);
+          }
         }
+      } else {
+        objOut.writeCompressedInt(0);
       }
-      objOut.writeObject(targetToSource.build());
     } finally {
       objOut.flush();
     }
   }
 
-  /**
-   * Returns a string representation of the given object's URI. For objects contained by the given resource the object's {@link Resource#getURIFragment(EObject)
-   * URI fragment} will be returned. For objects in other resources the {@link EcoreUtil#getURI(EObject) full URI} will be returned with an exclamation mark as
-   * prefix.
-   *
-   * @param obj
-   *          object to get URI string for
-   * @param context
-   *          resource being serialized, must not be {@code null}
-   * @return URI string or {@code null} if the object is {@code null}, a lazy-linking proxy, or not a proxy but contained in a resource
-   */
-  protected static String getURIString(final EObject obj, final Resource context) {
-    if (obj == null) {
-      return null;
+  private void writeMapping(final Entry<EObject, Deque<EObject>> entry, final DirectLinkingEObjectOutputStream objOut, final StorageAwareResource resource) throws IOException {
+    objOut.writeEObjectURI(entry.getKey(), resource);
+    objOut.writeCompressedInt(entry.getValue().size());
+    for (EObject target : entry.getValue()) {
+      objOut.writeEObjectURI(target, resource);
     }
-    Resource resource = obj.eResource();
-    if (resource == null) {
-      if (obj.eIsProxy()) {
-        URI proxyURI = ((InternalEObject) obj).eProxyURI();
-        return proxyURI.fragment().startsWith(LazyURIEncoder.XTEXT_LINK) ? null : '!' + proxyURI.toString();
-      }
-      return null;
-    }
-    return resource == context ? getURIFragmentPath(obj, context) : '!' + resource.getURI().toString() + '#' + resource.getURIFragment(obj); // NOPMD
-  }
-
-  /**
-   * Computes a short positional URI fragment path. These are more efficient than fragments returned by {@link org.eclipse.xtext.resource.IFragmentProvider}, as
-   * the latter may contain name-based segments, which require a lookup to resolve.
-   *
-   * @param obj
-   *          object to get URI fragment for, must not be {@code null}
-   * @param resource
-   *          resource containing object, must not be {@code null}
-   * @return URI fragment path, where the segments encode the feature IDs and position in case of multi-valued features, never {@code null}
-   */
-  @SuppressWarnings("unchecked")
-  private static String getURIFragmentPath(final EObject obj, final Resource resource) {
-    List<CharSequence> segments = Lists.newArrayList();
-    InternalEObject internalEObject = (InternalEObject) obj;
-    for (InternalEObject container = internalEObject.eInternalContainer(); container != null; container = internalEObject.eInternalContainer()) {
-      EStructuralFeature feature = internalEObject.eContainingFeature();
-      StringBuilder b = new StringBuilder();
-      b.append(container.eClass().getFeatureID(feature));
-      if (feature.isMany()) {
-        b.append('.').append(((EList<EObject>) container.eGet(feature, false)).indexOf(internalEObject));
-      }
-      segments.add(b);
-      internalEObject = container;
-    }
-
-    segments.add(Integer.toString(resource.getContents().indexOf(internalEObject)));
-    return Joiner.on('/').join(Lists.reverse(segments));
   }
 
 }


### PR DESCRIPTION
Again changes InferredModelAssociator's internal representation of the
model associations. Now the implementation uses ArrayDeques instead of
LinkedLists, as there are more memory-efficient and typically also
perform better (InferredModelAssociator doesn't remove elements in the
middle).

Additionally the serialization of the model associations has been tuned
to use less space (around a factor 7 in uncompressed form) and perform
better (up to 3 times faster serialization and up to 8 times faster
deserialization). Note however that the model associations is only one
of four parts of a binary resource, so the overall improvements are of
course lower.