### PR TITLE
Always delete binary storage before writing

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingEObjectOutputStream.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingEObjectOutputStream.java
@@ -16,6 +16,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
@@ -33,6 +34,8 @@ import com.google.common.collect.Lists;
  * {@link EObjectOutputStream} subclass which provides {@link #writeEObjectURI(EObject, Resource)} to serialize an EObject's URI using a compact representation.
  */
 class DirectLinkingEObjectOutputStream extends EObjectOutputStream {
+
+  private static final Logger LOG = Logger.getLogger(DirectLinkingEObjectOutputStream.class);
 
   static final boolean LOCAL_EOBJECT = true;
 
@@ -64,8 +67,10 @@ class DirectLinkingEObjectOutputStream extends EObjectOutputStream {
       if (obj.eIsProxy()) {
         URI proxyURI = ((InternalEObject) obj).eProxyURI();
         uriString = proxyURI.fragment().startsWith(LazyURIEncoder.XTEXT_LINK) ? null : proxyURI.toString();
-      } else {
+      } else if (resource != null) {
         uriString = resource.getURI().toString() + '#' + resource.getURIFragment(obj);
+      } else {
+        LOG.warn("Encountered dangling object while serializing " + context.getURI() + ": " + obj); //$NON-NLS-1$ //$NON-NLS-2$
       }
       writeBoolean(!LOCAL_EOBJECT);
       writeString(uriString);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
@@ -61,9 +61,9 @@ public class DirectLinkingResourceStorageFacade extends ResourceStorageFacade {
    */
   @Override
   public void saveResource(final StorageAwareResource resource, final IFileSystemAccessExtension3 fsa) {
-    if (!resource.getErrors().isEmpty()) {
-      deleteStorage(resource.getURI(), (IFileSystemAccess) fsa);
-    } else {
+    // delete storage first in case saving fails
+    deleteStorage(resource.getURI(), (IFileSystemAccess) fsa);
+    if (resource.getErrors().isEmpty()) {
       super.saveResource(resource, fsa);
     }
   }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
@@ -155,7 +155,7 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
 
     Map<EObject, Deque<EObject>> destinationMap = adapter.getSourceToInferredModelMap();
     for (int i = 0; i < size; i++) {
-      destinationMap.put(objIn.readEObject(resource), readMappedEObjects(objIn, resource));
+      mapListOfObjects(objIn, destinationMap, resource);
     }
     if (objIn.readByte() != Ascii.GS) {
       LOG.warn("Encountered unexpected data while loading " + resource.getURI()); //$NON-NLS-1$
@@ -166,7 +166,7 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
     if (objIn.readBoolean()) {
       size = objIn.readCompressedInt();
       for (int i = 0; i < size; i++) {
-        destinationMap.put(objIn.readEObject(resource), readMappedEObjects(objIn, resource));
+        mapListOfObjects(objIn, destinationMap, resource);
       }
     } else {
       for (Map.Entry<EObject, Deque<EObject>> entry : adapter.getSourceToInferredModelMap().entrySet()) {
@@ -177,6 +177,14 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
           destinationMap.put(target, singleton);
         }
       }
+    }
+  }
+
+  private void mapListOfObjects(final DirectLinkingEObjectInputStream objIn, final Map<EObject, Deque<EObject>> destinationMap, final StorageAwareResource resource) throws IOException {
+    EObject from = objIn.readEObject(resource);
+    Deque<EObject> to = readMappedEObjects(objIn, resource);
+    if (from != null && !to.isEmpty()) {
+      destinationMap.put(from, to);
     }
   }
 


### PR DESCRIPTION
To be on the safe side the binary storage should always be deleted
first. Otherwise, if an I/O exception occurs during an INCR build the
old storage could still be present.

Also, if the inferred model associations map contains "dangling" objects
(not part of any resource), a warning will be logged instead of an
exception being thrown.