### PR TITLE
Remove unnecessary empty line in doSetup of generated check code

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGenerator.xtend
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGenerator.xtend
@@ -164,7 +164,6 @@ class CheckGenerator extends JvmModelGenerator {
 
       /** {@inheritDoc} */
       public void doSetup() {
-
         ICheckValidatorRegistry.INSTANCE.registerValidator(«IF catalog.grammar !== null»GRAMMAR_NAME,«ENDIF» new «catalog.validatorClassName»());
         ICheckCatalogRegistry.INSTANCE.registerCatalog(«IF catalog.grammar !== null»GRAMMAR_NAME,«ENDIF» new ModelLocation(
           «catalog.standaloneSetupClassName».class.getClassLoader().getResource(CATALOG_FILE_PATH), CATALOG_FILE_PATH));


### PR DESCRIPTION
This unnecessary newline was recently introduced with commit 614ec85 and
causes lots of unwanted changes to generated code in projects using DDK.