### PR TITLE
Add logging to ExtendableInferredModelAssociator

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/ExtendableInferredModelAssociator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/ExtendableInferredModelAssociator.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.modelinference;
 
+import org.apache.log4j.Logger;
 import org.eclipse.xtext.resource.DerivedStateAwareResource;
 
 import com.google.inject.Inject;
@@ -23,13 +24,21 @@ import com.google.inject.Singleton;
 @Singleton
 public class ExtendableInferredModelAssociator extends InferredModelAssociator {
 
+  private static final Logger LOGGER = Logger.getLogger(ExtendableInferredModelAssociator.class);
+
   @Inject
   private IModelInferrerFeatureExtensionService additionalInferrers;
 
   @Override
   public void installDerivedState(final DerivedStateAwareResource resource, final boolean isPreLinkingPhase) {
     super.installDerivedState(resource, isPreLinkingPhase);
-    additionalInferrers.inferTargetModel(resource.getContents().get(0), createAcceptor(resource), isPreLinkingPhase);
+    try {
+      additionalInferrers.inferTargetModel(resource.getContents().get(0), createAcceptor(resource), isPreLinkingPhase);
+      // CHECKSTYLE:OFF
+    } catch (RuntimeException e) {
+      // CHECKSTYLE:ON
+      LOGGER.error("Failed to install additional derived state for resource " + resource.getURI(), e); //$NON-NLS-1$
+    }
   }
 
 }


### PR DESCRIPTION
ExtendableInferredModelAssociator#installDerivedState() will now catch
and log any RuntimeExceptions thrown by the
IModelInferrerFeatureExtensionService. Otherwise these will never be
seen when a resource is demand-loaded as EcoreUtil#resolve() swallows
them.