### PR TITLE
Allow custom post format action on the String value of ExtendedLineEntry that has preserve format.

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/formatting/ExtendedLine.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/formatting/ExtendedLine.java
@@ -274,6 +274,10 @@ public class ExtendedLine extends ExtendedFormattingConfigBasedStream.AbstractEx
       }
 
     });
+    String postProcessedValue = getConfigBasedStream().getFormatter().executeCustomPostFormatAction(lineEntry, getEntries());
+    if (postProcessedValue != null) {
+      lineEntry.setValue(postProcessedValue);
+    }
     getEntries().add(lineEntry);
     return this;
   }


### PR DESCRIPTION
This will allow the the elements that has _no_format_ rule to have custom post format action.