### PR TITLE
Performance: Reduce memory footprint of index lookup AST

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookup.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookup.java
@@ -44,13 +44,14 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
    */
   // CHECKSTYLE:CHECK-OFF ParameterAssignmentCheck
   // CHECKSTYLE:CHECK-OFF FinalParametersCheck
-  private class SegmentNode {
+  // CHECKSTYLE:CHECK-OFF VisibilityModifier
+  private static class SegmentNode {
 
-    private static final int DEFAULT_CHILD_CAPACITY = 4;
+    protected static final int DEFAULT_CHILD_CAPACITY = 4;
 
     private final String segment;
-    private T[] values;
-    private List<SegmentNode> children;
+    protected Object[] values;
+    protected List<SegmentNode> children;
 
     /**
      * Creates a new node for the given qualified name segment.
@@ -115,37 +116,20 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
      *          whether duplicate values should be excluded in the result
      * @return collection of all values mapped by the nodes in the given range, never {@code null}
      */
-    public Collection<T> matches(final QualifiedName lower, final int lowerIdx, final SegmentNode upper, final boolean recursive, final boolean excludeDuplicates) {
+    @SuppressWarnings("unchecked")
+    public <T> Collection<T> matches(final QualifiedName lower, final int lowerIdx, final SegmentNode upper, final boolean recursive, final boolean excludeDuplicates) {
       final Collection<T> result = excludeDuplicates ? Sets.<T> newHashSet() : Lists.<T> newArrayList();
-      if (shareValues) {
-        final Set<T[]> arrays = Sets.<T[]> newHashSet();
-        Visitor visitor = new Visitor() {
-          @Override
-          public void visit(final SegmentNode node) {
-            if (node.values != null) {
-              arrays.add(node.values);
+      Visitor visitor = new Visitor() {
+        @Override
+        public void visit(final SegmentNode node) {
+          if (node.values != null) {
+            for (Object value : node.values) {
+              result.add((T) value);
             }
-          }
-        };
-        collectMatches(lower, lowerIdx, upper, recursive, visitor);
-        for (T[] array : arrays) {
-          for (T value : array) {
-            result.add(value);
           }
         }
-      } else {
-        Visitor visitor = new Visitor() {
-          @Override
-          public void visit(final SegmentNode node) {
-            if (node.values != null) {
-              for (T value : node.values) {
-                result.add(value);
-              }
-            }
-          }
-        };
-        collectMatches(lower, lowerIdx, upper, recursive, visitor);
-      }
+      };
+      collectMatches(lower, lowerIdx, upper, recursive, visitor);
       return result;
     }
 
@@ -165,7 +149,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
      * @return {@code false} if marker {@code upper} node was found and search should be stopped
      */
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private boolean collectMatches(final QualifiedName lower, int lowerIdx, final SegmentNode upper, final boolean recursive, final Visitor visitor) {
+    protected boolean collectMatches(final QualifiedName lower, int lowerIdx, final SegmentNode upper, final boolean recursive, final Visitor visitor) {
       if (children == null || this == upper) {
         return false;
       }
@@ -242,7 +226,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
      * @param newValues
      *          new values to associate qualified name with; if mappings already exist any missing mapping will be added
      */
-    public void merge(final QualifiedName name, int segIdx, final T[] newValues) { // NOPMD - varargs doesn't make sense here
+    public void merge(final QualifiedName name, int segIdx, final Object[] newValues) { // NOPMD - varargs doesn't make sense here
       if (children == null) {
         children = new ArrayList<SegmentNode>(DEFAULT_CHILD_CAPACITY);
       }
@@ -253,13 +237,13 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
         idx = -(idx + 1);
         children.add(idx, child);
         if (name.getSegmentCount() == segIdx) {
-          child.values = shareValues && Arrays.equals(values, newValues) ? values : newValues;
+          child.values = newValues;
           return;
         }
         child.merge(name, segIdx, newValues);
       } else if (name.getSegmentCount() == segIdx) {
-        T[] tmp = arrayUtils.addAll(children.get(idx).values, newValues);
-        children.get(idx).values = shareValues && Arrays.equals(values, tmp) ? values : tmp;
+        Object[] tmp = ArrayUtils.addAll(children.get(idx).values, newValues);
+        children.get(idx).values = tmp;
       } else {
         children.get(idx).merge(name, segIdx, newValues);
       }
@@ -280,12 +264,99 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
       }
     }
 
+    /**
+     * Adopted from {@link java.util.Collections#binarySearch(List, Object)} which can't be used here because the element being searched has a different type.
+     *
+     * @param list
+     *          list of nodes to search
+     * @param key
+     *          key, corresponding to {@link SegmentNode#segment}, to search for
+     * @return index of found node or (-(insertion point) - 1)
+     */
+    protected int binarySearch(final List<SegmentNode> list, final String key) {
+      int low = 0;
+      int high = list.size() - 1;
+
+      while (low <= high) {
+        int mid = (low + high) >>> 1;
+        SegmentNode midVal = list.get(mid);
+        int cmp = midVal.segment.compareTo(key);
+
+        if (cmp < 0) {
+          low = mid + 1;
+        } else if (cmp > 0) {
+          high = mid - 1;
+        } else {
+          return mid; // key found
+        }
+      }
+      return -(low + 1); // key not found
+    }
+
     @Override
     public String toString() {
       return "Node(" + segment + ")"; //$NON-NLS-1$ //$NON-NLS-2$
     }
   }
 
+  /**
+   * Subclass which implements value sharing between nodes and child nodes to reduce the memory footprint.
+   */
+  private static class ValueSharingSegmentNode extends SegmentNode {
+
+    ValueSharingSegmentNode(final String segment) {
+      super(segment);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Collection<T> matches(final QualifiedName lower, final int lowerIdx, final SegmentNode upper, final boolean recursive, final boolean excludeDuplicates) {
+      final Collection<T> result = excludeDuplicates ? Sets.<T> newHashSet() : Lists.<T> newArrayList();
+      final Set<Object[]> arrays = Sets.newHashSet();
+      Visitor visitor = new Visitor() {
+        @Override
+        public void visit(final SegmentNode node) {
+          if (node.values != null) {
+            arrays.add(node.values);
+          }
+        }
+      };
+      collectMatches(lower, lowerIdx, upper, recursive, visitor);
+      for (Object[] array : arrays) {
+        for (Object value : array) {
+          result.add((T) value);
+        }
+      }
+      return result;
+    }
+
+    @Override
+    public void merge(final QualifiedName name, int segIdx, final Object[] newValues) { // NOPMD - varargs doesn't make sense here
+      if (children == null) {
+        children = new ArrayList<SegmentNode>(DEFAULT_CHILD_CAPACITY);
+      }
+      String seg = name.getSegment(segIdx++);
+      int idx = binarySearch(children, seg);
+      if (idx < 0) {
+        SegmentNode child = new ValueSharingSegmentNode(seg);
+        idx = -(idx + 1);
+        children.add(idx, child);
+        if (name.getSegmentCount() == segIdx) {
+          child.values = Arrays.equals(values, newValues) ? values : newValues;
+          return;
+        }
+        child.merge(name, segIdx, newValues);
+      } else if (name.getSegmentCount() == segIdx) {
+        Object[] tmp = ArrayUtils.addAll(children.get(idx).values, newValues);
+        children.get(idx).values = Arrays.equals(values, tmp) ? values : tmp;
+      } else {
+        children.get(idx).merge(name, segIdx, newValues);
+      }
+    }
+
+  }
+
+  // CHECKSTYLE:CHECK-ON VisibilityModifier
   // CHECKSTYLE:CHECK-ON ParameterAssignmentCheck
   // CHECKSTYLE:CHECK-ON FinalParametersCheck
 
@@ -293,7 +364,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
    * A visitor to visit the nodes of the tree in a {@link SegmentNode#accept(Visitor) depth-first order}.
    */
   // CHECKSTYLE:CHECK-OFF AbstractClassNameCheck
-  private abstract class Visitor {
+  private abstract static class Visitor {
     // CHECKSTYLE:CHECK-ON AbstractClassNameCheck
     /**
      * Visits the given tree node.
@@ -304,19 +375,14 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
     public abstract void visit(final SegmentNode node);
   }
 
-  private final ArrayUtils<T> arrayUtils;
   private final SegmentNode root;
-  private final boolean shareValues;
 
   private long size;
   private long hits;
   private long misses;
 
-  public QualifiedNameSegmentTreeLookup(final Class<T> elementType, final boolean shareValues) {
-    arrayUtils = ArrayUtils.of(elementType);
-    this.shareValues = shareValues;
-
-    root = new SegmentNode(""); //$NON-NLS-1$
+  public QualifiedNameSegmentTreeLookup(final Class<T> elementType, final boolean shareValues) { // NOPMD
+    root = shareValues ? new ValueSharingSegmentNode("") : new SegmentNode(""); //$NON-NLS-1$ //$NON-NLS-2$
     init();
   }
 
@@ -333,6 +399,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
   }
 
   /** {@inheritDoc} */
+  @SuppressWarnings("unchecked")
   @Override
   public Collection<T> get(final QualifiedName name) {
     if (name.isEmpty()) {
@@ -341,7 +408,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
     SegmentNode result = root.find(name, 0, true);
     if (result != null && result.values != null) {
       hits++;
-      return Arrays.asList(result.values);
+      return (Collection<T>) Arrays.asList(result.values);
     } else {
       misses++;
       return null;
@@ -354,7 +421,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
     root.accept(new Visitor() {
       @Override
       public void visit(final SegmentNode node) {
-        T[] newValues = arrayUtils.remove(node.values, value);
+        Object[] newValues = ArrayUtils.remove(node.values, value);
         if (newValues != node.values) {
           node.values = newValues;
           size--;
@@ -369,35 +436,6 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
     init();
   }
 
-  /**
-   * Adopted from {@link java.util.Collections#binarySearch(List, Object)} which can't be used here because the element being searched has a different type.
-   *
-   * @param list
-   *          list of nodes to search
-   * @param key
-   *          key, corresponding to {@link SegmentNode#segment}, to search for
-   * @return index of found node or (-(insertion point) - 1)
-   */
-  private int binarySearch(final List<SegmentNode> list, final String key) {
-    int low = 0;
-    int high = list.size() - 1;
-
-    while (low <= high) {
-      int mid = (low + high) >>> 1;
-      SegmentNode midVal = list.get(mid);
-      int cmp = midVal.segment.compareTo(key);
-
-      if (cmp < 0) {
-        low = mid + 1;
-      } else if (cmp > 0) {
-        high = mid - 1;
-      } else {
-        return mid; // key found
-      }
-    }
-    return -(low + 1); // key not found
-  }
-
   /** {@inheritDoc} */
   @Override
   public Collection<T> get(final QualifiedNamePattern pattern, final boolean excludeDuplicates) {
@@ -407,7 +445,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
   /** {@inheritDoc} */
   @Override
   public void put(final QualifiedName name, final T value) {
-    T[] values = arrayUtils.newArray(1);
+    Object[] values = ArrayUtils.newArray(1);
     values[0] = value;
     size++;
     root.merge(name, 0, values);
@@ -417,7 +455,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
   @Override
   public void putAll(final QualifiedName name, final Collection<T> values) {
     size += values.size();
-    root.merge(name, 0, values.toArray(arrayUtils.newArray(values.size())));
+    root.merge(name, 0, values.toArray(ArrayUtils.newArray(values.size())));
   }
 
   /** {@inheritDoc} */
@@ -425,7 +463,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
   public void remove(final QualifiedName name, final T value) {
     SegmentNode node = root.find(name, 0, true);
     if (node != null) {
-      T[] newValues = arrayUtils.remove(node.values, value);
+      Object[] newValues = ArrayUtils.remove(node.values, value);
       if (newValues != node.values) {
         node.values = newValues;
         size--;

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/util/ArrayUtils.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/util/ArrayUtils.java
@@ -10,35 +10,13 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.util;
 
-import com.google.common.collect.ObjectArrays;
-
-
 /**
  * Collects various utility operations on arrays.
- *
- * @param <T>
- *          generic element type
  */
-public final class ArrayUtils<T> {
+public final class ArrayUtils {
 
-  private final Class<T> componentType;
-
-  private ArrayUtils(final Class<T> componentType) {
-    this.componentType = componentType;
-  }
-
-  /**
-   * Creates a new instance of ArrayUtils for the given component type.
-   *
-   * @param <T>
-   *          generic element type
-   * @param componentType
-   *          component type, must not be {@code null}
-   * @return new ArrayUtils instance, never {@code null}
-   */
-  @SuppressWarnings("PMD.ShortMethodName")
-  public static <T> ArrayUtils<T> of(final Class<T> componentType) {
-    return new ArrayUtils<T>(componentType);
+  private ArrayUtils() {
+    // not instantiatable
   }
 
   /**
@@ -48,8 +26,8 @@ public final class ArrayUtils<T> {
    *          length of array to create
    * @return new array, never {@code null}
    */
-  public T[] newArray(final int length) {
-    return ObjectArrays.newArray(componentType, length);
+  public static Object[] newArray(final int length) {
+    return new Object[length];
   }
 
   /**
@@ -65,16 +43,16 @@ public final class ArrayUtils<T> {
    *         If the array already contained the new value, the return value is == identical
    *         to the array passed in.
    */
-  public T[] add(final T[] array, final T value) {
+  public static Object[] add(final Object[] array, final Object value) {
     if (array == null || array.length == 0) {
-      T[] result = ObjectArrays.newArray(componentType, 1);
+      Object[] result = newArray(1);
       result[0] = value;
       return result;
     }
     int i = find(array, value);
     if (i < 0) {
       // Not found: add value
-      T[] newArray = ObjectArrays.newArray(componentType, array.length + 1);
+      Object[] newArray = newArray(array.length + 1);
       System.arraycopy(array, 0, newArray, 0, array.length);
       newArray[array.length] = value;
       return newArray;
@@ -95,17 +73,17 @@ public final class ArrayUtils<T> {
    *         If the array already contained the new value, the return value is == identical
    *         to the array passed in.
    */
-  @SuppressWarnings(value="PMD.UseVarargs")
-  public T[] addAll(final T[] array, final T[] values) {
+  @SuppressWarnings(value = "PMD.UseVarargs")
+  public static Object[] addAll(final Object[] array, final Object[] values) {
     if (array == null || array.length == 0) {
       return values;
     }
-    T[] result = array;
-    for (T value : values) {
+    Object[] result = array;
+    for (Object value : values) {
       int i = find(array, value);
       if (i < 0) {
         // Not found: add value
-        T[] tmp = ObjectArrays.newArray(componentType, result.length + 1);
+        Object[] tmp = newArray(result.length + 1);
         System.arraycopy(result, 0, tmp, 0, result.length);
         tmp[result.length] = value;
         result = tmp;
@@ -126,7 +104,7 @@ public final class ArrayUtils<T> {
    *         the original array. If the original array does not contain the given value, the returned
    *         array is == identical to the array passed in.
    */
-  public T[] remove(final T[] array, final T value) {
+  public static Object[] remove(final Object[] array, final Object value) {
     if (array == null) {
       return null;
     }
@@ -136,7 +114,7 @@ public final class ArrayUtils<T> {
     }
     if (i >= 0) {
       // Found it: remove value. i is guaranteed to be < array.length here.
-      T[] newArray = ObjectArrays.newArray(componentType, array.length - 1);
+      Object[] newArray = newArray(array.length - 1);
       if (i > 0) {
         System.arraycopy(array, 0, newArray, 0, i);
       }
@@ -157,7 +135,7 @@ public final class ArrayUtils<T> {
    *          to find; must not be {@code null}
    * @return the smallest index i; i >= 0 && i < array.length, such that value.equals(array[i]) == true, or -1 if there is no such value in the array.
    */
-  public int find(final T[] array, final T value) {
+  public static int find(final Object[] array, final Object value) {
     if (array == null) {
       return -1;
     }


### PR DESCRIPTION
Reduces the footprint of the QualifiedNameSegmentTreeLookup by making
the SegmentNode class static, which reduces the padded object size from
32 bytes to 24 bytes.

This required adding a ValueSharingSegmentNode subclass (in order to be
able to remove the reference to the "shareValues" field and also making
the methods in ArrayUtils static.