### PR TITLE
Improve performance of fragment providers

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/FragmentProviderGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/FragmentProviderGenerator.xtend
@@ -41,7 +41,7 @@ class FragmentProviderGenerator {
       public class «getFragmentProvider().toSimpleName()» extends AbstractSelectorFragmentProvider {
 
         @Override
-        public CharSequence getFragmentSegment(final EObject object) {
+        public boolean appendFragmentSegment(final EObject object, StringBuilder builder) {
           EClass eClass = object.eClass();
           EPackage ePackage = eClass.getEPackage();
           «val typeMap = fingerprintedExports.typeMap(grammar)»
@@ -54,28 +54,28 @@ class FragmentProviderGenerator {
                 «val e = typeMap.get(c)»
                 «javaContributorComment(e.location())»
                 case «c.classifierIdLiteral()»: {
-                  return getFragmentSegment((«c.instanceClassName()») object);
+                  return appendFragmentSegment((«c.instanceClassName()») object, builder);
                 }
               «ENDFOR»
               default:
-                return super.getFragmentSegment(object);
+                return super.appendFragmentSegment(object, builder);
               }
             }
           «ENDFOR»
-          return super.getFragmentSegment(object);
+          return super.appendFragmentSegment(object, builder);
         }
 
         «IF it.extension»
           @Override
-          protected CharSequence getFragmentSegmentFallback(final EObject object) {
-            // For export extension we must return null, so the logic will try other extensions
-            return null;
+          protected boolean appendFragmentSegmentFallback(final EObject object, StringBuilder builder) {
+            // For export extension we must return false, so the logic will try other extensions
+            return false;
           }
 
         «ENDIF»
         «FOR e : fingerprintedExports»
-          protected CharSequence getFragmentSegment(final «e.type.instanceClassName()» obj) {
-            return computeSelectorFragmentSegment(obj, «e.fragmentAttribute.literalIdentifier()», «e.fragmentUnique»);
+          protected boolean appendFragmentSegment(final «e.type.instanceClassName()» obj, StringBuilder builder) {
+            return computeSelectorFragmentSegment(obj, «e.fragmentAttribute.literalIdentifier()», «e.fragmentUnique», builder);
           }
 
         «ENDFOR»

--- a/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/linking/AbstractFragmentProviderTest.java
+++ b/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/linking/AbstractFragmentProviderTest.java
@@ -14,8 +14,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.avaloq.tools.ddk.xtext.linking.AbstractFragmentProvider;
-
 
 /**
  * Tests for {@code AbstractFragmentProvider}.
@@ -27,8 +25,8 @@ public class AbstractFragmentProviderTest {
   private static class TestAbstractFragmentProvider extends AbstractFragmentProvider {
 
     @Override
-    public CharSequence getFragmentSegment(final EObject object) {
-      return null;
+    public boolean appendFragmentSegment(final EObject object, final StringBuilder builder) {
+      return false;
     }
 
     @Override
@@ -39,8 +37,8 @@ public class AbstractFragmentProviderTest {
     @Override
     // make method public for testing
     @SuppressWarnings("PMD.UselessOverridingMethod")
-    public String escape(final String text) {
-      return super.escape(text);
+    public void appendEscaped(final String text, final StringBuilder builder) {
+      super.appendEscaped(text, builder);
     }
 
     @Override
@@ -55,7 +53,9 @@ public class AbstractFragmentProviderTest {
 
   @Test
   public void testEscape() {
-    Assert.assertEquals("foo\\/bar#\\\\", fragmentProvider.escape("foo/bar#\\"));
+    StringBuilder builder = new StringBuilder();
+    fragmentProvider.appendEscaped("foo/bar#\\", builder);
+    Assert.assertEquals("foo\\/bar#\\\\", builder.toString());
   }
 
   @Test
@@ -66,9 +66,10 @@ public class AbstractFragmentProviderTest {
   @Test
   public void testUnescapeEscape() {
     for (String text : SPECIAL_ESCAPE_CASES) {
-      Assert.assertEquals(text, fragmentProvider.unescape(fragmentProvider.escape(text)));
+      StringBuilder builder = new StringBuilder();
+      fragmentProvider.appendEscaped(text, builder);
+      Assert.assertEquals(text, fragmentProvider.unescape(builder.toString()));
     }
   }
 
 }
-

--- a/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/resource/AbstractSelectorFragmentProviderTest.java
+++ b/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/resource/AbstractSelectorFragmentProviderTest.java
@@ -27,7 +27,6 @@ import org.eclipse.xtext.util.Modules2;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.avaloq.tools.ddk.xtext.resource.AbstractSelectorFragmentProvider;
 import com.google.inject.AbstractModule;
 
 
@@ -93,47 +92,46 @@ public class AbstractSelectorFragmentProviderTest extends AbstractXtextTests {
   private static class TestSelectorFragmentProvider extends AbstractSelectorFragmentProvider {
 
     @Override
-    public CharSequence getFragmentSegment(final EObject object) {
+    public boolean appendFragmentSegment(final EObject object, final StringBuilder builder) {
       EClass eClass = object.eClass();
       EPackage ePackage = eClass.getEPackage();
       if (ePackage == XtextPackage.eINSTANCE) {
         int classifierID = eClass.getClassifierID();
         switch (classifierID) {
         case XtextPackage.GRAMMAR:
-          return getFragmentSegment((Grammar) object);
+          return appendFragmentSegment((Grammar) object, builder);
         case XtextPackage.ENUM_RULE:
         case XtextPackage.PARSER_RULE:
         case XtextPackage.TERMINAL_RULE:
-          return getFragmentSegment((AbstractRule) object);
+          return appendFragmentSegment((AbstractRule) object, builder);
         case XtextPackage.KEYWORD:
           if (((Keyword) object).getValue().equals("selectCardinality")) {
-            return getFragmentSegment((AbstractElement) object);
+            return appendFragmentSegment((AbstractElement) object, builder);
           } else {
-            return getFragmentSegment((Keyword) object);
+            return appendFragmentSegment((Keyword) object, builder);
           }
         default:
-          return super.getFragmentSegment(object);
+          return super.appendFragmentSegment(object, builder);
         }
       }
-      return super.getFragmentSegment(object);
+      return super.appendFragmentSegment(object, builder);
     }
 
-    protected CharSequence getFragmentSegment(final Grammar obj) {
-      return computeSelectorFragmentSegment(obj, XtextPackage.Literals.GRAMMAR__NAME, true);
+    protected boolean appendFragmentSegment(final Grammar obj, final StringBuilder builder) {
+      return computeSelectorFragmentSegment(obj, XtextPackage.Literals.GRAMMAR__NAME, true, builder);
     }
 
-    protected CharSequence getFragmentSegment(final AbstractRule obj) {
-      return computeSelectorFragmentSegment(obj, XtextPackage.Literals.ABSTRACT_RULE__NAME, false);
+    protected boolean appendFragmentSegment(final AbstractRule obj, final StringBuilder builder) {
+      return computeSelectorFragmentSegment(obj, XtextPackage.Literals.ABSTRACT_RULE__NAME, false, builder);
     }
 
-    protected CharSequence getFragmentSegment(final AbstractElement obj) {
-      return computeSelectorFragmentSegment(obj, XtextPackage.Literals.ABSTRACT_ELEMENT__CARDINALITY, false);
+    protected boolean appendFragmentSegment(final AbstractElement obj, final StringBuilder builder) {
+      return computeSelectorFragmentSegment(obj, XtextPackage.Literals.ABSTRACT_ELEMENT__CARDINALITY, false, builder);
     }
 
-    protected CharSequence getFragmentSegment(final Keyword obj) {
-      return computeSelectorFragmentSegment(obj, XtextPackage.Literals.KEYWORD__VALUE, false);
+    protected boolean appendFragmentSegment(final Keyword obj, final StringBuilder builder) {
+      return computeSelectorFragmentSegment(obj, XtextPackage.Literals.KEYWORD__VALUE, false, builder);
     }
 
   }
 }
-

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/ShortFragmentProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/ShortFragmentProvider.java
@@ -25,20 +25,19 @@ public class ShortFragmentProvider extends AbstractFragmentProvider {
 
   /** {@inheritDoc} */
   @Override
-  public CharSequence getFragmentSegment(final EObject object) {
+  public boolean appendFragmentSegment(final EObject object, final StringBuilder builder) {
     final EReference containmentFeature = object.eContainmentFeature();
-    final StringBuilder result = new StringBuilder();
     if (containmentFeature == null) {
-      result.append(object.eResource().getContents().indexOf(object));
+      builder.append(object.eResource().getContents().indexOf(object));
     } else {
       final EObject container = object.eContainer();
-      result.append(container.eClass().getFeatureID(containmentFeature));
+      builder.append(container.eClass().getFeatureID(containmentFeature));
       if (containmentFeature.isMany()) {
         final List<?> list = (List<?>) container.eGet(containmentFeature, false);
-        result.append(LIST_SEPARATOR).append(list.indexOf(object));
+        builder.append(LIST_SEPARATOR).append(list.indexOf(object));
       }
     }
-    return result;
+    return true;
   }
 
   /** {@inheritDoc} */
@@ -47,9 +46,9 @@ public class ShortFragmentProvider extends AbstractFragmentProvider {
     final int listSeparatorIndex = segment.indexOf(LIST_SEPARATOR);
     int featureId;
     if (listSeparatorIndex == -1) {
-      featureId = Integer.parseInt(segment);
+      featureId = Integer.parseUnsignedInt(segment);
     } else {
-      featureId = Integer.parseInt(segment.substring(0, listSeparatorIndex));
+      featureId = Integer.parseUnsignedInt(segment.substring(0, listSeparatorIndex));
     }
     final EReference reference = (EReference) container.eClass().getEStructuralFeature(featureId);
     if (reference.isMany()) {
@@ -59,7 +58,7 @@ public class ShortFragmentProvider extends AbstractFragmentProvider {
         return null;
       }
       final List<?> list = (List<?>) container.eGet(reference, false);
-      final int listIndex = Integer.parseInt(segment.substring(listSeparatorIndex + 1));
+      final int listIndex = Integer.parseUnsignedInt(segment.substring(listSeparatorIndex + 1));
       // If the uri references an element outside of the list range return null (i.e. cannot find element)
       if (listIndex >= list.size()) {
         return null;

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractExportFeatureExtension.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractExportFeatureExtension.java
@@ -44,8 +44,8 @@ public abstract class AbstractExportFeatureExtension implements IExportFeatureEx
   }
 
   @Override
-  public CharSequence getFragmentSegment(final EObject object) {
-    return getFragmentProvider().getFragmentSegment(object);
+  public boolean appendFragmentSegment(final EObject object, final StringBuilder builder) {
+    return getFragmentProvider().appendFragmentSegment(object, builder);
   }
 
   @Override

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractSelectorFragmentProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractSelectorFragmentProvider.java
@@ -20,7 +20,7 @@ import com.google.inject.Inject;
 
 
 /**
- * Fragment provider which understands fragments with selector path segments. E.g. <code>0.1.3(0=='foo').0</code>.
+ * Fragment provider which understands fragments with selector path segments. E.g. <code>0/1/3(0=='foo')/0</code>.
  * <p>
  * Implementation classes should override {@link #getFragment(EObject, org.eclipse.xtext.resource.IFragmentProvider.Fallback)} and call
  * {@link #computeSelectorFragment(EObject, EStructuralFeature, boolean, org.eclipse.xtext.resource.IFragmentProvider.Fallback)} as appropriate.
@@ -39,42 +39,45 @@ public abstract class AbstractSelectorFragmentProvider extends AbstractFragmentP
   private ShortFragmentProvider shortFragmentProvider;
 
   /**
-   * Returns a segment of the fragment with a selector for the given object.
+   * Computes a segment of the fragment with a selector for the given object and appends it to the given {@link StringBuilder}.
    *
    * @param obj
    *          object to compute fragment for
    * @param selectorFeature
    *          selector feature
    * @param unique
-   *          <code>true</code> the values for selectorFeature are unique within the object's containment feature setting
-   * @return computed selector fragment
+   *          {@code true} the values for selectorFeature are unique within the object's containment feature setting
+   * @param builder
+   *          builder to append fragment segment to, must not be {@code null}
+   * @return {@code true} if a fragment segment was appended to {@code builder}
    */
   @SuppressWarnings("unchecked")
-  protected CharSequence computeSelectorFragmentSegment(final EObject obj, final EStructuralFeature selectorFeature, final boolean unique) {
+  protected boolean computeSelectorFragmentSegment(final EObject obj, final EStructuralFeature selectorFeature, final boolean unique, final StringBuilder builder) {
     final EObject container = obj.eContainer();
     if (container == null) {
-      return shortFragmentProvider.getFragmentSegment(obj);
+      return shortFragmentProvider.appendFragmentSegment(obj, builder);
     }
-    final StringBuilder result = new StringBuilder();
     // containment feature
     final EStructuralFeature containmentFeature = obj.eContainmentFeature();
-    result.append(container.eClass().getFeatureID(containmentFeature));
+    builder.append(container.eClass().getFeatureID(containmentFeature));
     // selector
     final Object selectorValue = obj.eGet(selectorFeature);
-    result.append(SELECTOR_START).append(obj.eClass().getFeatureID(selectorFeature)).append(EQ_OP);
+    builder.append(SELECTOR_START).append(obj.eClass().getFeatureID(selectorFeature)).append(EQ_OP);
     if (selectorValue != null) {
-      result.append(VALUE_SEP).append(escape(selectorValue.toString())).append(VALUE_SEP);
+      builder.append(VALUE_SEP);
+      appendEscaped(selectorValue.toString(), builder);
+      builder.append(VALUE_SEP);
     } else {
-      result.append(NULL_VALUE);
+      builder.append(NULL_VALUE);
     }
     if (unique) {
-      result.append(UNIQUE);
+      builder.append(UNIQUE);
     }
-    result.append(SELECTOR_END);
+    builder.append(SELECTOR_END);
 
     // selector index
     if (!unique && containmentFeature.isMany()) {
-      result.append(ShortFragmentProvider.LIST_SEPARATOR);
+      builder.append(ShortFragmentProvider.LIST_SEPARATOR);
       final EList<? extends EObject> containmentList = (EList<? extends EObject>) container.eGet(containmentFeature);
       int selectorIndex = 0;
       final int objectIndex = containmentList.indexOf(obj);
@@ -84,10 +87,9 @@ public abstract class AbstractSelectorFragmentProvider extends AbstractFragmentP
           selectorIndex++;
         }
       }
-      result.append(selectorIndex);
+      builder.append(selectorIndex);
     }
-
-    return result;
+    return true;
   }
 
   /**
@@ -95,23 +97,25 @@ public abstract class AbstractSelectorFragmentProvider extends AbstractFragmentP
    *
    * @param object
    *          object to compute fragment for
-   * @return fragment, never {@code null}
+   * @param builder
+   *          builder to append fragment segment to, must not be {@code null}
+   * @return {@code true} if a fragment segment was appended to {@code builder}
    */
-  protected CharSequence getFragmentSegmentFallback(final EObject object) {
-    return shortFragmentProvider.getFragmentSegment(object);
+  protected boolean appendFragmentSegmentFallback(final EObject object, final StringBuilder builder) {
+    return shortFragmentProvider.appendFragmentSegment(object, builder);
   }
 
   /**
    * {@inheritDoc}
    * <p>
-   * By default, this method delegates to {@link ShortFragmentProvider#getFragmentSegment(EObject)}. Sub classes have to override this method in order to
+   * By default, this method delegates to {@link #appendFragmentSegmentFallback(EObject, StringBuilder)}. Sub classes have to override this method in order to
    * customize which EObject generates a selector segment.
    * </p>
    */
   // TODO DSL-348: change generator for fragment providers to implement getFragmentSegment instead of getFragment
   @Override
-  public CharSequence getFragmentSegment(final EObject object) {
-    return getFragmentSegmentFallback(object);
+  public boolean appendFragmentSegment(final EObject object, final StringBuilder builder) {
+    return appendFragmentSegmentFallback(object, builder);
   }
 
   /** {@inheritDoc} */
@@ -121,7 +125,7 @@ public abstract class AbstractSelectorFragmentProvider extends AbstractFragmentP
     final int selectorEndOffset = segment.lastIndexOf(SELECTOR_END);
     if (selectorEndOffset != -1) {
       final int selectorOffset = segment.indexOf(SELECTOR_START);
-      final int containmentFeatureId = Integer.parseInt(segment.substring(0, selectorOffset));
+      final int containmentFeatureId = Integer.parseUnsignedInt(segment.substring(0, selectorOffset));
       final EStructuralFeature containmentFeature = container.eClass().getEStructuralFeature(containmentFeatureId);
       if (containmentFeature == null) {
         return null;
@@ -130,9 +134,9 @@ public abstract class AbstractSelectorFragmentProvider extends AbstractFragmentP
         return (EObject) container.eGet(containmentFeature);
       }
       final int eqOffset = segment.indexOf(EQ_OP, selectorOffset);
-      final int selectorFeatureId = Integer.parseInt(segment.substring(selectorOffset + 1, eqOffset));
+      final int selectorFeatureId = Integer.parseUnsignedInt(segment.substring(selectorOffset + 1, eqOffset));
       boolean uniqueMatch = segment.charAt(selectorEndOffset - 1) == UNIQUE;
-      int matchedIndex = uniqueMatch ? 0 : Integer.parseInt(segment.substring(selectorEndOffset + 2));
+      int matchedIndex = uniqueMatch ? 0 : Integer.parseUnsignedInt(segment.substring(selectorEndOffset + 2));
       boolean isNull = segment.startsWith(NULL_VALUE, eqOffset + EQ_OP_LENGTH);
       String matchedValue = isNull ? null
           : unescape(segment.substring(eqOffset + EQ_OP_LENGTH + 1, uniqueMatch ? selectorEndOffset - 2 : selectorEndOffset - 1));

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/DefaultExportFeatureExtensionService.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/DefaultExportFeatureExtensionService.java
@@ -24,8 +24,8 @@ import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.util.IAcceptor;
 
-import com.avaloq.tools.ddk.xtext.extension.ILanguageExtensionsService;
 import com.avaloq.tools.ddk.xtext.extension.ILanguageExtensions;
+import com.avaloq.tools.ddk.xtext.extension.ILanguageExtensionsService;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -61,8 +61,13 @@ public class DefaultExportFeatureExtensionService implements IExportFeatureExten
   }
 
   @Override
-  public CharSequence getFragmentSegment(final EObject object) {
-    return returnFirst(c -> c.getFragmentSegment(object));
+  public boolean appendFragmentSegment(final EObject object, final StringBuilder builder) {
+    for (IExportFeatureExtension ext : exportFeatureExtensions) {
+      if (ext.appendFragmentSegment(object, builder)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/IExportComputer.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/IExportComputer.java
@@ -50,14 +50,16 @@ public interface IExportComputer {
   /**
    * Extension for fragment computation.
    * <p>
-   * Implementations must return {@code null} if this extension is not meant to handle the EClass of the given object.
+   * Implementations must return {@code false} if this extension is not meant to handle the EClass of the given object.
    * </p>
    *
    * @param object
    *          the object, must not be {@code null}
-   * @return the fragment segment for the object or {@code null} if this extension is not handling these objects
+   * @param builder
+   *          builder to append fragment segment to, must not be {@code null}
+   * @return {@code true} if a fragment segment was appended to {@code builder}
    */
-  CharSequence getFragmentSegment(final EObject object);
+  boolean appendFragmentSegment(final EObject object, StringBuilder builder);
 
   /**
    * Returns additional exported classes by this extension.

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/PatternAwareEObjectDescriptionLookUp.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/PatternAwareEObjectDescriptionLookUp.java
@@ -16,10 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.RandomAccess;
 
-import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.resource.IEObjectDescription;
@@ -28,6 +26,7 @@ import org.eclipse.xtext.resource.impl.EObjectDescriptionLookUp;
 import com.avaloq.tools.ddk.caching.CacheManager;
 import com.avaloq.tools.ddk.xtext.naming.QualifiedNameLookup;
 import com.avaloq.tools.ddk.xtext.naming.QualifiedNamePattern;
+import com.avaloq.tools.ddk.xtext.util.EObjectUtil;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
@@ -83,8 +82,8 @@ public class PatternAwareEObjectDescriptionLookUp extends EObjectDescriptionLook
 
   @Override
   public Iterable<IEObjectDescription> getExportedObjectsByObject(final EObject object) {
-    final URI objectUri = EcoreUtil.getURI(object);
-    return Iterables.filter(getExportedObjects(), input -> objectUri.equals(input.getEObjectURI()));
+    final String fragment = EObjectUtil.getURIFragment(object);
+    return Iterables.filter(getExportedObjects(), input -> fragment.equals(input.getEObjectURI().fragment()));
   }
 
   @Override


### PR DESCRIPTION
Improves the URI fragment computation in AbstractFragmentProvider and
all AbstractSelectorFragmentProvider based implementations by allocating
less StringBuilders and Strings (and hence less char[] objects). This is
achieved by reusing the same three StringBuilder instances while
computing the URI fragment (see AbstractFragmentProvider#getFragment()).

To achieve this the abstract method getFragmentSegment(EObject) was
replaced with appendFragmentSegment(EObject, StringBuilder).

The Export DSL generator was adjusted accordingly.