### PR TITLE
#125: Don't install derived state for resources loaded from storage

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
@@ -319,7 +319,7 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
 
   @Override
   public void installDerivedState(final boolean isPrelinkingPhase) {
-    if (derivedStateComputer != null && !fullyInitialized && !isInitializing) {
+    if (derivedStateComputer != null && !fullyInitialized && !isInitializing && !isLoadedFromStorage()) {
       try {
         traceSet.started(ResourceInferenceEvent.class, getURI());
         isInitializing = true;
@@ -350,7 +350,7 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
 
   @Override
   public boolean isInitialized() {
-    return fullyInitialized || isInitializing;
+    return fullyInitialized || isInitializing || isLoadedFromStorage();
   }
 
   @Override


### PR DESCRIPTION
Resources loaded from binary storage already have derived state
installed and thus there is no need to invoke the derived state computer
again.