### PR TITLE
Fix generation for Xtend isInstance() operation in Export DSL

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorSupport.java
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorSupport.java
@@ -15,10 +15,12 @@ import java.util.List;
 
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.internal.xtend.expression.parser.SyntaxConstants;
 import org.eclipse.xtend.expression.ExecutionContextImpl;
 import org.eclipse.xtend.expression.ResourceManagerDefaultImpl;
 import org.eclipse.xtend.expression.TypeSystemImpl;
 import org.eclipse.xtend.expression.Variable;
+import org.eclipse.xtend.typesystem.Type;
 import org.eclipse.xtend.typesystem.emf.EmfRegistryMetaModel;
 import org.eclipse.xtext.resource.IEObjectDescription;
 
@@ -84,6 +86,20 @@ public final class ExportGeneratorSupport extends GeneratorSupport {
         @Override
         public EPackage[] allPackages() {
           return ePackages;
+        }
+
+        @Override
+        public Type getTypeForName(final String name) {
+          final String[] frags = name.split(SyntaxConstants.NS_DELIM);
+          if (frags.length == 2) {
+            // convert references which use import alias
+            for (Import imp : model.getImports()) {
+              if (frags[0].equals(imp.getName()) && imp.getPackage() != null) {
+                return super.getTypeForName(imp.getPackage().getName() + SyntaxConstants.NS_DELIM + frags[1]);
+              }
+            }
+          }
+          return super.getTypeForName(name);
         }
       });
       // Finally, add the default meta models

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopingGeneratorUtil.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopingGeneratorUtil.java
@@ -15,13 +15,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.emf.ecore.ENamedElement;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.internal.xtend.expression.parser.SyntaxConstants;
 import org.eclipse.xtend.expression.ExecutionContextImpl;
 import org.eclipse.xtend.expression.ResourceManagerDefaultImpl;
 import org.eclipse.xtend.expression.TypeSystemImpl;
 import org.eclipse.xtend.expression.Variable;
+import org.eclipse.xtend.typesystem.Type;
 import org.eclipse.xtend.typesystem.emf.EmfRegistryMetaModel;
 
 import com.avaloq.tools.ddk.xtext.expression.generator.CompilationContext;
@@ -120,16 +121,17 @@ public final class ScopingGeneratorUtil {
         }
 
         @Override
-        protected String getElementName(final ENamedElement ele) {
-          if (ele instanceof EPackage) {
-            // use alias as name (if provided)
+        public Type getTypeForName(final String name) {
+          final String[] frags = name.split(SyntaxConstants.NS_DELIM);
+          if (frags.length == 2) {
+            // convert references which use import alias
             for (Import imp : model.getImports()) {
-              if (imp.getPackage() == ele) {
-                return imp.getName() != null ? imp.getName() : super.getElementName(ele);
+              if (frags[0].equals(imp.getName()) && imp.getPackage() != null) {
+                return super.getTypeForName(imp.getPackage().getName() + SyntaxConstants.NS_DELIM + frags[1]);
               }
             }
           }
-          return super.getElementName(ele);
+          return super.getTypeForName(name);
         }
       });
       // Finally, add the default meta models


### PR DESCRIPTION
Also fixes the generator in the Export DSL as already done in the Scope
DSL.

Note that this commit also implements the fix in a different way to
avoid problems with some more corner cases.