### PR TITLE
com.avaloq.tools.ddk.test.core now re-exports org.eclipse.xtext.junit4

### DIFF
--- a/com.avaloq.tools.ddk.test.core/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.test.core/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
  com.google.guava,
  org.apache.commons.lang,
  org.eclipse.emf.common,
- org.eclipse.xtext.junit4
+ org.eclipse.xtext.junit4;visibility:=reexport
 Export-Package: com.avaloq.tools.ddk.test.core,
  com.avaloq.tools.ddk.test.core.data,
  com.avaloq.tools.ddk.test.core.junit.runners,

--- a/com.avaloq.tools.ddk.test.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.test.ui/META-INF/MANIFEST.MF
@@ -23,8 +23,7 @@ Require-Bundle: com.avaloq.tools.ddk.test.core,
  org.mockito,
  com.google.guava,
  org.apache.commons.lang,
- org.eclipse.emf.common,
- org.eclipse.xtext.junit4
+ org.eclipse.emf.common
 Export-Package: com.avaloq.tools.ddk.test.ui,
  com.avaloq.tools.ddk.test.ui.junit.runners,
  com.avaloq.tools.ddk.test.ui.swtbot,

--- a/com.avaloq.tools.ddk.xtext.ui.test/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.ui.test/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: com.avaloq.tools.ddk.xtext.ui.test;singleton:=true
 Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: Avaloq Evolution AG
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.xtext.junit4,
- org.eclipse.xtext.ui,
+Require-Bundle: org.eclipse.xtext.ui,
  org.eclipse.xtext.xbase.lib,
  org.junit,
  org.mockito,


### PR DESCRIPTION
com.avaloq.tools.ddk.test.core now re-exports org.eclipse.xtext.junit4
so dependent projects do not have to require it directly.