### PR TITLE
Add utility for combining trace configurations.

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/TraceConfiguration.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/TraceConfiguration.java
@@ -80,4 +80,24 @@ public interface TraceConfiguration {
     }
     return includedTraceClassMap::containsKey;
   }
+
+  /**
+   * Creates a new trace configuration that is the combination of a list of other configurations.
+   * Tracing is enabled for event types that are enabled in any of the given configurations.
+   *
+   * @param configurations
+   *          the configurations to combine.
+   * @return trace configuration, never {@code null}
+   */
+  @SafeVarargs
+  static TraceConfiguration combine(final TraceConfiguration... configurations) {
+    return c -> {
+      for (TraceConfiguration config : configurations) {
+        if (config.isEnabled(c)) {
+          return true;
+        }
+      }
+      return false;
+    };
+  }
 }


### PR DESCRIPTION
Utility method for combining trace configurations enables tracing for
trace events if the event type is enabled in any of the contributing
configurations.