### PR TITLE
Fix bug in pattern matching of QualifiedNameSegmentTreeLookup

### DIFF
--- a/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookupTest.java
+++ b/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookupTest.java
@@ -20,13 +20,10 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.naming.QualifiedName;
 import org.junit.Test;
 
-import com.avaloq.tools.ddk.xtext.naming.QualifiedNamePattern;
-import com.avaloq.tools.ddk.xtext.naming.QualifiedNameSegmentTreeLookup;
-import com.avaloq.tools.ddk.xtext.naming.QualifiedNames;
 import com.google.common.collect.ImmutableSet;
 
 
-@SuppressWarnings("PMD.JUnitAssertionsShouldIncludeMessage")
+@SuppressWarnings({"nls", "unused", "PMD.JUnitAssertionsShouldIncludeMessage"})
 // CHECKSTYLE:CHECK-OFF MultipleStringLiteralsCheck
 public class QualifiedNameSegmentTreeLookupTest {
 
@@ -57,32 +54,20 @@ public class QualifiedNameSegmentTreeLookupTest {
 
   @Test
   public void testTopLevelPatternWithoutWildcard() {
-    QualifiedName name1 = name("foo");
-    URI value1 = uri(name1);
-    lookup.put(name1, value1);
-    QualifiedName name2 = name("bar");
-    URI value2 = uri(name2);
-    lookup.put(name2, value2);
-    QualifiedName name3 = name("foo2");
-    URI value3 = uri(name3);
-    lookup.put(name3, value3);
+    URI value1 = put("foo");
+    URI value2 = put("bar");
+    URI value3 = put("foo2");
 
-    assertContentEquals(ImmutableSet.of(value1), lookup.get(pattern(name1), false));
-    assertContentEquals(ImmutableSet.of(value2), lookup.get(pattern(name2), false));
-    assertContentEquals(ImmutableSet.of(value3), lookup.get(pattern(name3), false));
+    assertContentEquals(ImmutableSet.of(value1), lookup.get(pattern("foo"), false));
+    assertContentEquals(ImmutableSet.of(value2), lookup.get(pattern("bar"), false));
+    assertContentEquals(ImmutableSet.of(value3), lookup.get(pattern("foo2"), false));
   }
 
   @Test
   public void testTopLevelPatternWithWildcard() {
-    QualifiedName name1 = name("foo");
-    URI value1 = uri(name1);
-    lookup.put(name1, value1);
-    QualifiedName name2 = name("foo2");
-    URI value2 = uri(name2);
-    lookup.put(name2, value2);
-    QualifiedName name3 = name("bar");
-    URI value3 = uri(name3);
-    lookup.put(name3, value3);
+    URI value1 = put("foo");
+    URI value2 = put("foo2");
+    URI value3 = put("bar");
 
     assertContentEquals(ImmutableSet.of(value1, value2), lookup.get(pattern("f*"), true));
     assertContentEquals(ImmutableSet.of(value1, value2), lookup.get(pattern("foo*"), true));
@@ -91,38 +76,22 @@ public class QualifiedNameSegmentTreeLookupTest {
 
   @Test
   public void testNestedPatternMatchesWithoutWildcard() {
-    QualifiedName name1 = name("foo");
-    URI value1 = uri(name1);
-    lookup.put(name1, value1);
-    QualifiedName name2 = name("foo.bar");
-    URI value2 = uri(name2);
-    lookup.put(name2, value2);
-    QualifiedName name3 = name("foo2");
-    URI value3 = uri(name3);
-    lookup.put(name3, value3);
+    URI value1 = put("foo");
+    URI value2 = put("foo.bar");
+    URI value3 = put("foo2");
 
-    assertContentEquals(ImmutableSet.of(value1), lookup.get(pattern(name1), true));
-    assertContentEquals(ImmutableSet.of(value2), lookup.get(pattern(name2), true));
-    assertContentEquals(ImmutableSet.of(value3), lookup.get(pattern(name3), true));
+    assertContentEquals(ImmutableSet.of(value1), lookup.get(pattern("foo"), true));
+    assertContentEquals(ImmutableSet.of(value2), lookup.get(pattern("foo.bar"), true));
+    assertContentEquals(ImmutableSet.of(value3), lookup.get(pattern("foo2"), true));
   }
 
   @Test
   public void testNestedPatternMatchesWithWildcard() {
-    QualifiedName name1 = name("foo");
-    URI value1 = uri(name1);
-    lookup.put(name1, value1);
-    QualifiedName name2 = name("foo.bar");
-    URI value2 = uri(name2);
-    lookup.put(name2, value2);
-    QualifiedName name3 = name("foo.baz");
-    URI value3 = uri(name3);
-    lookup.put(name3, value3);
-    QualifiedName name4 = name("foo.baz.bazz");
-    URI value4 = uri(name4);
-    lookup.put(name4, value4);
-    QualifiedName name5 = name("foo2");
-    URI value5 = uri(name5);
-    lookup.put(name5, value5);
+    URI value1 = put("foo");
+    URI value2 = put("foo.bar");
+    URI value3 = put("foo.baz");
+    URI value4 = put("foo.baz.bazz");
+    URI value5 = put("foo2");
 
     assertContentEquals(ImmutableSet.of(value1, value5), lookup.get(pattern("f*"), true));
     assertContentEquals(ImmutableSet.of(value2, value3), lookup.get(pattern("foo.*"), true));
@@ -132,27 +101,34 @@ public class QualifiedNameSegmentTreeLookupTest {
 
   @Test
   public void testNestedPatternMatchesWithRecursiveWildcard() {
-    QualifiedName name1 = name("foo");
-    URI value1 = uri(name1);
-    lookup.put(name1, value1);
-    QualifiedName name2 = name("foo.bar");
-    URI value2 = uri(name2);
-    lookup.put(name2, value2);
-    QualifiedName name3 = name("foo.bar.baz");
-    URI value3 = uri(name3);
-    lookup.put(name3, value3);
-    QualifiedName name4 = name("foo.bar.baz.quux");
-    URI value4 = uri(name4);
-    lookup.put(name4, value4);
-    QualifiedName name5 = name("foo.foo");
-    URI value5 = uri(name5);
-    lookup.put(name5, value5);
-    QualifiedName name6 = name("foo2");
-    URI value6 = uri(name6);
-    lookup.put(name6, value6);
+    URI value1 = put("foo");
+    URI value2 = put("foo.bar");
+    URI value3 = put("foo.bar.baz");
+    URI value4 = put("foo.bar.baz.quux");
+    URI value5 = put("foo.foo");
+    URI value6 = put("foo2");
 
     assertContentEquals(ImmutableSet.of(value2, value3, value4, value5), lookup.get(pattern("foo.**"), true));
     assertContentEquals(ImmutableSet.of(value2, value3, value4), lookup.get(pattern("foo.b**"), true));
+  }
+
+  @Test
+  public void testUnmatchedNestedPattern() {
+    URI value1 = put("foo");
+    URI value2 = put("foo.bar");
+    URI value3 = put("foo.bar.baz");
+    URI value4 = put("foo.bar.baz.quux");
+    URI value5 = put("foo.foo");
+    URI value6 = put("foo2");
+
+    assertContentEquals(ImmutableSet.of(), lookup.get(pattern("e*"), true));
+    assertContentEquals(ImmutableSet.of(), lookup.get(pattern("g*"), true));
+    assertContentEquals(ImmutableSet.of(), lookup.get(pattern("foa.*"), true));
+    assertContentEquals(ImmutableSet.of(), lookup.get(pattern("fon.b*"), true));
+    assertContentEquals(ImmutableSet.of(), lookup.get(pattern("foo.c*"), true));
+    assertContentEquals(ImmutableSet.of(), lookup.get(pattern("foo.baq.b*"), true));
+    assertContentEquals(ImmutableSet.of(), lookup.get(pattern("foo.bar.a*"), true));
+    assertContentEquals(ImmutableSet.of(), lookup.get(pattern("foo.bar.bazz*"), true));
   }
 
   @Test
@@ -184,8 +160,14 @@ public class QualifiedNameSegmentTreeLookupTest {
     return URI.createURI("scheme:/" + name);
   }
 
+  private URI put(final String name) {
+    QualifiedName qname = name(name);
+    URI value = uri(qname);
+    lookup.put(qname, value);
+    return value;
+  }
+
   public void assertContentEquals(final Collection<?> expected, final Collection<?> actual) {
     assertEquals(ImmutableSet.copyOf(expected), ImmutableSet.copyOf(actual));
   }
 }
-

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookup.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookup.java
@@ -81,9 +81,10 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
         return null;
       }
       String seg = name.getSegment(segIdx++);
+      boolean lastSeg = name.getSegmentCount() == segIdx;
       int idx = binarySearch(children, seg);
       if (idx < 0) {
-        if (exactMatch) {
+        if (exactMatch || !lastSeg) {
           return null;
         }
         idx = -(idx + 1);
@@ -91,7 +92,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
       if (idx == children.size()) {
         return null;
       }
-      if (name.getSegmentCount() == segIdx) {
+      if (lastSeg) {
         return children.get(idx);
       }
       SegmentNode result = children.get(idx++).find(name, segIdx, exactMatch);
@@ -148,15 +149,17 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
      *          visitor to visit matching nodes with, must not be {@code null}
      * @return {@code false} if marker {@code upper} node was found and search should be stopped
      */
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    @SuppressWarnings({"PMD.CompareObjectsWithEquals", "PMD.NPathComplexity"})
     protected boolean collectMatches(final QualifiedName lower, int lowerIdx, final SegmentNode upper, final boolean recursive, final Visitor visitor) {
-      if (children == null || this == upper) {
+      if (children == null || this == upper || upper == null) {
         return false;
       }
       String seg = lower.getSegment(lowerIdx++);
       int idx = binarySearch(children, seg);
-      if (idx < 0) {
+      if (idx < 0 && lower.getSegmentCount() == lowerIdx) {
         idx = -(idx + 1);
+      } else if (idx < 0) {
+        return false;
       }
       if (idx == children.size()) {
         return true;


### PR DESCRIPTION
QualifiedNameSegmentTreeLookup#get(QualifiedNamePattern, boolean)
delivered unmatched results when given a name pattern where any of the
leading name segments (i.e. not the last segment with the prefix
pattern) didn't match any element in the lookup.

Internal issue: DSL-1964