### PR TITLE
#139: "Slow loading of source" timeout is too strict

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
@@ -58,7 +58,7 @@ import com.google.inject.name.Names;
 public class ParallelResourceLoader extends AbstractResourceLoader {
 
   private static final long MAX_WAIT_TIME = TimeUnit.SECONDS.toMillis(300);
-  private static final long SLOW_LOADING_TIME_DEFAULT = TimeUnit.SECONDS.toMillis(30);
+  private static final long SLOW_LOADING_TIME_DEFAULT = TimeUnit.SECONDS.toMillis(60);
   private static final String SLOW_LOADING_TIME_PROPERTY = "resourceloader.slowloadingtime"; //$NON-NLS-1$
 
   private static final Logger LOGGER = Logger.getLogger(ParallelResourceLoader.class);


### PR DESCRIPTION
Instead of just reporting a warning when loading a resource takes longer
than a fixed amount of time we know report a warning if parsing and/or
inference takes longer than expected.

Internal Issue: DSL-1967