### PR TITLE
In UI tests close only shells with names

### DIFF
--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/FixedDefaultWorkbench.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/FixedDefaultWorkbench.java
@@ -11,6 +11,7 @@
 package com.avaloq.tools.ddk.test.ui.swtbot;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.eclipse.swt.widgets.Widget;
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
@@ -77,9 +78,18 @@ class FixedDefaultWorkbench {
    * @return the fixed default workbench
    */
   FixedDefaultWorkbench closeAllShells() {
+    return closeShellsMatchingName(v -> true);
+  }
+
+  /**
+   * Close all shells matching given name predicate.
+   *
+   * @return the fixed default workbench
+   */
+  FixedDefaultWorkbench closeShellsMatchingName(final Predicate<String> predicate) {
     SWTBotShell[] shells = bot.shells();
     for (SWTBotShell shell : shells) {
-      if (!isEclipseShell(shell) && !isLimboShell(shell) && !isQuickAccess(shell)) {
+      if (!isEclipseShell(shell) && !isLimboShell(shell) && !isQuickAccess(shell) && predicate.test(shell.getText())) {
         shell.close();
       }
     }

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/FixedDefaultWorkbench.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/FixedDefaultWorkbench.java
@@ -84,6 +84,8 @@ class FixedDefaultWorkbench {
   /**
    * Close all shells matching given name predicate.
    *
+   * @param predicate
+   *          condition on name of shells
    * @return the fixed default workbench
    */
   FixedDefaultWorkbench closeShellsMatchingName(final Predicate<String> predicate) {

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/SwtWorkbenchBot.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/SwtWorkbenchBot.java
@@ -21,7 +21,6 @@ import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.withSt
 import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.withTooltip;
 
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.eclipse.emf.common.util.WrappedException;
@@ -64,23 +63,6 @@ public class SwtWorkbenchBot extends SWTWorkbenchBot {
 
   @Override
   public void closeAllShells() {
-    closeShellsNonEmptyName();
-  }
-
-  /**
-   * Close shells matching given name predicate, excluding Eclipse system shells though.
-   *
-   * @param predicate
-   *          name predicate
-   */
-  public void closeShellsMatchingName(final Predicate<String> predicate) {
-    new FixedDefaultWorkbench(this).closeShellsMatchingName(predicate);
-  }
-
-  /**
-   * Closes shells that have some name, but are not Eclipse system shells.
-   */
-  public void closeShellsNonEmptyName() {
     new FixedDefaultWorkbench(this).closeShellsMatchingName(s -> !s.isEmpty());
   }
 

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/SwtWorkbenchBot.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/SwtWorkbenchBot.java
@@ -21,6 +21,7 @@ import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.withSt
 import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.withTooltip;
 
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import org.eclipse.emf.common.util.WrappedException;
@@ -63,7 +64,24 @@ public class SwtWorkbenchBot extends SWTWorkbenchBot {
 
   @Override
   public void closeAllShells() {
-    new FixedDefaultWorkbench(this).closeAllShells();
+    closeShellsNonEmptyName();
+  }
+
+  /**
+   * Close shells matching given name predicate, excluding Eclipse system shells though.
+   *
+   * @param predicate
+   *          name predicate
+   */
+  public void closeShellsMatchingName(final Predicate<String> predicate) {
+    new FixedDefaultWorkbench(this).closeShellsMatchingName(predicate);
+  }
+
+  /**
+   * Closes shells that have some name, but are not Eclipse system shells.
+   */
+  public void closeShellsNonEmptyName() {
+    new FixedDefaultWorkbench(this).closeShellsMatchingName(s -> !s.isEmpty());
   }
 
   /**


### PR DESCRIPTION
This is to avoid closing shells that might still be relevant for the
framework.