### PR TITLE
Derelease retry in indexing if reference resolution fails

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/Messages.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/Messages.java
@@ -19,12 +19,11 @@ public class Messages extends NLS {
   public static String MonitoredClusteringBuilderState_CANNOT_LOAD_RESOURCE;
   public static String MonitoredClusteringBuilderState_NO_MORE_RESOURCES;
   public static String MonitoredClusteringBuilderState_PHASE_ONE_DONE;
-  public static String MonitoredClusteringBuilderState_TRY_AGAIN;
-  public static String MonitoredClusteringBuilderState_TRY_AGAIN_FAILED;
   public static String MonitoredClusteringBuilderState_UPDATE_DESCRIPTIONS;
   public static String MonitoredClusteringBuilderState_WRITE_DESCRIPTIONS;
   public static String MonitoredClusteringBuilderState_WRITE_ONE_DESCRIPTION;
   public static String MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR;
+  public static String MonitoredClusteringBuilderState_FAILED_REFERENCE_RESOLUTION_IN_INDEXING;
 
   static {
     // initialize resource bundle

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -794,15 +794,12 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
    *          The new index
    * @param monitor
    *          The progress monitor used for user feedback
-   * @return a List with the list of loaded resources {@link URI} in the first position and a list of {@link URI}s of resources that could not be loaded in the
-   *         second position.
+   * @return a List with the list of loaded resources {@link URI}
    */
-  @SuppressWarnings("unchecked")
-  private List<List<URI>> writeResources(final Collection<URI> toWrite, final BuildData buildData, final IResourceDescriptions oldState, final CurrentDescriptions newState, final IProgressMonitor monitor) {
+  private List<URI> writeResources(final Collection<URI> toWrite, final BuildData buildData, final IResourceDescriptions oldState, final CurrentDescriptions newState, final IProgressMonitor monitor) {
     ResourceSet resourceSet = buildData.getResourceSet();
     IProject currentProject = getBuiltProject(buildData);
     List<URI> toBuild = Lists.newLinkedList();
-    List<URI> toRetry = Lists.newLinkedList();
     IResourceLoader.LoadOperation loadOperation = null;
     try {
       int resourcesToWriteSize = toWrite.size();
@@ -834,16 +831,14 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
             // Set flag to make unresolvable cross-references raise an error
             resourceSet.getLoadOptions().put(ILazyLinkingResource2.MARK_UNRESOLVABLE_XREFS, Boolean.FALSE);
             final IResourceDescription copiedDescription = new FixedCopiedResourceDescription(description);
-
             final boolean hasUnresolvedLinks = resourceSet.getLoadOptions().get(ILazyLinkingResource2.MARK_UNRESOLVABLE_XREFS) == Boolean.TRUE;
             if (hasUnresolvedLinks) {
-              toRetry.add(uri);
-              resourceSet.getResources().remove(resource);
-            } else {
-              final Delta intermediateDelta = manager.createDelta(oldState.getResourceDescription(uri), copiedDescription);
-              newState.register(intermediateDelta);
-              toBuild.add(uri);
+              LOGGER.warn(NLS.bind(Messages.MonitoredClusteringBuilderState_FAILED_REFERENCE_RESOLUTION_IN_INDEXING, uri));
             }
+            // In any case process the resource. We expect no DSL to depend on linking in indexing phase
+            final Delta intermediateDelta = manager.createDelta(oldState.getResourceDescription(uri), copiedDescription);
+            newState.register(intermediateDelta);
+            toBuild.add(uri);
           }
         } catch (final WrappedException ex) {
           pollForCancellation(monitor);
@@ -889,7 +884,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
         loadOperation.cancel();
       }
     }
-    return Lists.newArrayList(toBuild, toRetry);
+    return toBuild;
   }
 
   /** {@inheritDoc} */
@@ -898,13 +893,11 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
     final List<URI> toBuild = Lists.newLinkedList();
     ResourceSet resourceSet = buildData.getResourceSet();
     BuildPhases.setIndexing(resourceSet, true);
-    List<URI> tryAgain = Lists.newLinkedList();
     int totalSize = 0;
     for (List<URI> group : toWriteGroups) {
       totalSize = totalSize + group.size();
     }
     final SubMonitor subMonitor = SubMonitor.convert(monitor, Messages.MonitoredClusteringBuilderState_WRITE_DESCRIPTIONS, totalSize);
-    int nofRetries = 0;
 
     try {
       traceSet.started(BuildIndexingEvent.class);
@@ -916,23 +909,9 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
        * In fact, in this case we might start processing sources before the ones they depend on are still being handled.
        */
       for (Collection<URI> fileExtensionBuildGroup : toWriteGroups) {
-        List<List<URI>> result = writeResources(fileExtensionBuildGroup, buildData, oldState, newState, subMonitor);
-        toBuild.addAll(result.get(0));
-        tryAgain.addAll(result.get(1));
+        toBuild.addAll(writeResources(fileExtensionBuildGroup, buildData, oldState, newState, subMonitor));
       }
       flushChanges(newData);
-
-      while (!tryAgain.isEmpty() && (tryAgain.size() != nofRetries)) {
-        // We made some progress.
-        nofRetries = tryAgain.size();
-        LOGGER.info(NLS.bind(Messages.MonitoredClusteringBuilderState_TRY_AGAIN, nofRetries, tryAgain));
-        List<List<URI>> result = writeResources(tryAgain, buildData, oldState, newState, subMonitor);
-        toBuild.addAll(result.get(0));
-        tryAgain = result.get(1);
-      }
-      if (!tryAgain.isEmpty()) {
-        LOGGER.warn(NLS.bind(Messages.MonitoredClusteringBuilderState_TRY_AGAIN_FAILED, nofRetries, tryAgain));
-      }
     } finally {
       // Clear the flags
       BuildPhases.setIndexing(resourceSet, false);

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -794,7 +794,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
    *          The new index
    * @param monitor
    *          The progress monitor used for user feedback
-   * @return a List with the list of loaded resources {@link URI}
+   * @return the list of {@link URI}s of loaded resources to be processed in the second phase
    */
   private List<URI> writeResources(final Collection<URI> toWrite, final BuildData buildData, final IResourceDescriptions oldState, final CurrentDescriptions newState, final IProgressMonitor monitor) {
     ResourceSet resourceSet = buildData.getResourceSet();

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/messages.properties
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/messages.properties
@@ -1,9 +1,8 @@
 MonitoredClusteringBuilderState_CANNOT_LOAD_RESOURCE=Error loading resource from: {0}
 MonitoredClusteringBuilderState_NO_MORE_RESOURCES=No more resources left to load.
 MonitoredClusteringBuilderState_PHASE_ONE_DONE=FINISHED WRITING GLOBAL INDEX
-MonitoredClusteringBuilderState_TRY_AGAIN=Processing {0} resources again: {1}
-MonitoredClusteringBuilderState_TRY_AGAIN_FAILED=Failed to write {0} resources to index after multiple attempts: {1}
 MonitoredClusteringBuilderState_UPDATE_DESCRIPTIONS=Updating resource description {0} of {1}: {2}
 MonitoredClusteringBuilderState_WRITE_DESCRIPTIONS=Write new resource descriptions
 MonitoredClusteringBuilderState_WRITE_ONE_DESCRIPTION=Writing new resource description {0} of {1} {2} sources: {3}
 MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR=Could not process {0} due to StackOverflowError
+MonitoredClusteringBuilderState_FAILED_REFERENCE_RESOLUTION_IN_INDEXING=Failed attempt to resolve reference during indexing of {0}


### PR DESCRIPTION
DSLs should not rely on indexing order and if needed use other means to
resolve within indexing phase (i.e. include-like concepts over file
system directly).

So we are replacing an old mechanism that retries indexing of a source
if it attempts to resolve a reference in an indexing phase and fails
with a warning.

Now resource descriptions will be written AS IS in case of a failed
linking attempt. A warning log message will be reported, meaning that
DSL-implementers need to do something.