### PR TITLE
Cleanup: Remove downstream project dependency

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
@@ -32,8 +32,6 @@ import com.google.inject.Inject;
  */
 public class DirectLinkingResourceStorageFacade extends ResourceStorageFacade {
 
-  private static final URI SOURCE_CONTAINER_URI = URI.createURI("ctx:/src/"); //$NON-NLS-1$
-
   @Inject
   private ITraceSet traceSet;
 
@@ -80,13 +78,32 @@ public class DirectLinkingResourceStorageFacade extends ResourceStorageFacade {
     fsa.deleteFile(computeOutputPath(resourceUri));
   }
 
-  private String computeOutputPath(final URI resourceUri) {
+  @Override
+  protected final String computeOutputPath(final StorageAwareResource resource) {
+    return computeOutputPath(resource.getURI());
+  }
+
+  /**
+   * URI-based alternative to {@link #computeOutputPath(StorageAwareResource)}.
+   *
+   * @param resourceUri
+   *          resource URI, must not be {@code null}
+   * @return output path for given URI, never {@code null}
+   */
+  protected String computeOutputPath(final URI resourceUri) {
     URI srcContainerURI = getSourceContainerURI(resourceUri);
     URI uri = getBinaryStorageURI(resourceUri);
     return uri.deresolve(srcContainerURI, false, false, true).path();
   }
 
-  private URI getSourceContainerURI(final URI resourceUri) {
+  /**
+   * URI-based alternative to {@link #getSourceContainerURI(StorageAwareResource)}.
+   *
+   * @param resourceUri
+   *          resource URI, must not be {@code null}
+   * @return source container URI for given URI, never {@code null}
+   */
+  protected URI getSourceContainerURI(final URI resourceUri) {
     return resourceUri.trimSegments(1).appendSegment(""); //$NON-NLS-1$
   }
 
@@ -98,11 +115,6 @@ public class DirectLinkingResourceStorageFacade extends ResourceStorageFacade {
   @Override
   public ResourceStorageWritable createResourceStorageWritable(final OutputStream out) {
     return new DirectLinkingResourceStorageWritable(out, isStoreNodeModel());
-  }
-
-  @Override
-  protected URI getSourceContainerURI(final StorageAwareResource resource) {
-    return SOURCE_CONTAINER_URI;
   }
 
 }


### PR DESCRIPTION
Removes reference to "ctx:/src/" URI from
DirectLinkingResourceStorageFacade and declared a two of its private
methods as protected, to make it easier to extend.