### PR TITLE
Report warning on failed attempt to link in indexing phase

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/Messages.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/Messages.java
@@ -23,7 +23,6 @@ public class Messages extends NLS {
   public static String MonitoredClusteringBuilderState_WRITE_DESCRIPTIONS;
   public static String MonitoredClusteringBuilderState_WRITE_ONE_DESCRIPTION;
   public static String MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR;
-  public static String MonitoredClusteringBuilderState_FAILED_REFERENCE_RESOLUTION_IN_INDEXING;
 
   static {
     // initialize resource bundle
@@ -34,4 +33,3 @@ public class Messages extends NLS {
     super();
   }
 }
-

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -828,14 +828,9 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
           if (manager != null) {
             final IResourceDescription description = manager.getResourceDescription(resource);
             // We don't care here about links, we really just want the exported objects so that we can link in the next phase.
-            // Set flag to make unresolvable cross-references raise an error
+            // Set flag to tell linker to log warnings on unresolvable cross-references
             resourceSet.getLoadOptions().put(ILazyLinkingResource2.MARK_UNRESOLVABLE_XREFS, Boolean.FALSE);
             final IResourceDescription copiedDescription = new FixedCopiedResourceDescription(description);
-            final boolean hasUnresolvedLinks = resourceSet.getLoadOptions().get(ILazyLinkingResource2.MARK_UNRESOLVABLE_XREFS) == Boolean.TRUE;
-            if (hasUnresolvedLinks) {
-              LOGGER.warn(NLS.bind(Messages.MonitoredClusteringBuilderState_FAILED_REFERENCE_RESOLUTION_IN_INDEXING, uri));
-            }
-            // In any case process the resource. We expect no DSL to depend on linking in indexing phase
             final Delta intermediateDelta = manager.createDelta(oldState.getResourceDescription(uri), copiedDescription);
             newState.register(intermediateDelta);
             toBuild.add(uri);

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/messages.properties
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/messages.properties
@@ -5,4 +5,3 @@ MonitoredClusteringBuilderState_UPDATE_DESCRIPTIONS=Updating resource descriptio
 MonitoredClusteringBuilderState_WRITE_DESCRIPTIONS=Write new resource descriptions
 MonitoredClusteringBuilderState_WRITE_ONE_DESCRIPTION=Writing new resource description {0} of {1} {2} sources: {3}
 MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR=Could not process {0} due to StackOverflowError
-MonitoredClusteringBuilderState_FAILED_REFERENCE_RESOLUTION_IN_INDEXING=Failed attempt to resolve reference during indexing of {0}

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.diagnostics.ExceptionDiagnostic;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.nodemodel.serialization.SerializationUtil;
@@ -120,6 +121,11 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
       if (result == null && getEncoder().isCrossLinkFragment(this, uriFragment)) {
         final ResourceSet rs = getResourceSet();
         if (rs.getLoadOptions().get(MARK_UNRESOLVABLE_XREFS) == Boolean.FALSE) {
+          Triple<EObject, EReference, INode> refInfo = getEncoder().decode(this, uriFragment);
+          EReference reference = refInfo.getSecond();
+          EObject context = refInfo.getFirst();
+          LOGGER.warn("Failed unexpected attempt to resolve reference during indexing " + context.eClass().getName() + "#" //$NON-NLS-1$ //$NON-NLS-2$
+              + reference.getName() + " for object " + EcoreUtil.getURI(context), new RuntimeException()); //$NON-NLS-1$
           rs.getLoadOptions().put(MARK_UNRESOLVABLE_XREFS, Boolean.TRUE);
         }
       }


### PR DESCRIPTION
If MARK_UNRESOLVABLE_XREFS is set to FALSE then not just set the flag in
the resource, but report a warning with details of the problem.

Places where such linking is allowed need to remove the FALSE flag.