### PR TITLE
Disable Check and Format inferrers in pre-linking phase

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/jvmmodel/CheckJvmModelInferrer.xtend
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/jvmmodel/CheckJvmModelInferrer.xtend
@@ -84,6 +84,7 @@ class CheckJvmModelInferrer extends AbstractModelInferrer {
     // JVM validator class before the resource gets indexed, so the JVM catalog class cannot be found yet when we
     // create the injection in the validator. Therefore, remember the class here directly, and set it directly
     // in the validator, completely bypassing any scoping.
+    if (preIndexingPhase) return;
     val catalogClass = catalog.toClass(catalog.qualifiedCatalogClassName);
     val issueCodeToLabelMapTypeRef = typeRef(ImmutableMap, typeRef(String), typeRef(String))
     acceptor.accept(catalogClass, [

--- a/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/jvmmodel/FormatJvmModelInferrer.xtend
+++ b/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/jvmmodel/FormatJvmModelInferrer.xtend
@@ -120,6 +120,7 @@ class FormatJvmModelInferrer extends AbstractModelInferrer {
    *      rely on linking using the index if isPreIndexingPhase is {@code true}.
    */
   def dispatch void infer(FormatConfiguration format, IJvmDeclaredTypeAcceptor acceptor, boolean isPreIndexingPhase) {
+   if (isPreIndexingPhase) return
    val context = format.targetGrammar
     if (EcoreUtil.getAdapter(context.eAdapters(), typeof(RuleNames)) === null) {
     	val allRules = GrammarUtil.allRules(context);


### PR DESCRIPTION
The check and format inferrers don't add anything we need to the xtext
index during the pre-linking phase (so don't need to be run), but
attempt to resolve references that are not yet in the index. Disabling
them removes the errors.