### PR TITLE
Cleanup: Throw IOException in DirectLinkingResourceStorageLoadable

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
@@ -96,6 +96,11 @@ public class DirectLinkingResourceStorageFacade extends ResourceStorageFacade {
     return uri.deresolve(srcContainerURI, false, false, true).path();
   }
 
+  @Override
+  protected URI getSourceContainerURI(final StorageAwareResource resource) {
+    return getSourceContainerURI(resource.getURI());
+  }
+
   /**
    * URI-based alternative to {@link #getSourceContainerURI(StorageAwareResource)}.
    *


### PR DESCRIPTION
With the Xtext upgrade it is now possible to throw IOExceptions from
DirectLinkingResourceStorageLoadable. As a result the exception handling
can be simplified.

Additionally also removed the "Skipping loading node model for synthetic
resource" log message which is no longer required, as the source text is
stored as part of the binary storage.

Lastly, fixes a bug in the builder which could result in invalidated sources getting loaded from binary storage rather than from source.