### PR TITLE
#165: Improve performance of InferenceContainer

### DIFF
--- a/com.avaloq.tools.ddk.xtext/model/ModelInference.ecore
+++ b/com.avaloq.tools.ddk.xtext/model/ModelInference.ecore
@@ -11,5 +11,7 @@
     </eOperations>
     <eStructuralFeatures xsi:type="ecore:EReference" name="contents" upperBound="-1"
         eType="ecore:EClass http://www.eclipse.org/emf/2002/Ecore#//EObject" containment="true"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="fragments" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/com.avaloq.tools.ddk.xtext/model/ModelInference.genmodel
+++ b/com.avaloq.tools.ddk.xtext/model/ModelInference.genmodel
@@ -9,6 +9,7 @@
       ecorePackage="ModelInference.ecore#/">
     <genClasses ecoreClass="ModelInference.ecore#//InferenceContainer">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference ModelInference.ecore#//InferenceContainer/contents"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ModelInference.ecore#//InferenceContainer/fragments"/>
       <genOperations ecoreOperation="ModelInference.ecore#//InferenceContainer/getFragmentSegment">
         <genParameters ecoreParameter="ModelInference.ecore#//InferenceContainer/getFragmentSegment/object"/>
       </genOperations>

--- a/com.avaloq.tools.ddk.xtext/src-gen/com/avaloq/tools/ddk/xtext/modelinference/InferenceContainer.java
+++ b/com.avaloq.tools.ddk.xtext/src-gen/com/avaloq/tools/ddk/xtext/modelinference/InferenceContainer.java
@@ -16,6 +16,7 @@ import org.eclipse.emf.ecore.EObject;
  * </p>
  * <ul>
  *   <li>{@link com.avaloq.tools.ddk.xtext.modelinference.InferenceContainer#getContents <em>Contents</em>}</li>
+ *   <li>{@link com.avaloq.tools.ddk.xtext.modelinference.InferenceContainer#getFragments <em>Fragments</em>}</li>
  * </ul>
  *
  * @see com.avaloq.tools.ddk.xtext.modelinference.ModelInferencePackage#getInferenceContainer()
@@ -39,6 +40,22 @@ public interface InferenceContainer extends EObject
 	 * @generated
 	 */
 	EList<EObject> getContents();
+
+	/**
+	 * Returns the value of the '<em><b>Fragments</b></em>' attribute list.
+	 * The list contents are of type {@link java.lang.String}.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Fragments</em>' attribute list isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Fragments</em>' attribute list.
+	 * @see com.avaloq.tools.ddk.xtext.modelinference.ModelInferencePackage#getInferenceContainer_Fragments()
+	 * @model
+	 * @generated
+	 */
+	EList<String> getFragments();
 
 	/**
 	 * <!-- begin-user-doc -->

--- a/com.avaloq.tools.ddk.xtext/src-gen/com/avaloq/tools/ddk/xtext/modelinference/ModelInferencePackage.java
+++ b/com.avaloq.tools.ddk.xtext/src-gen/com/avaloq/tools/ddk/xtext/modelinference/ModelInferencePackage.java
@@ -2,6 +2,7 @@
  */
 package com.avaloq.tools.ddk.xtext.modelinference;
 
+import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EPackage;
@@ -77,13 +78,22 @@ public interface ModelInferencePackage extends EPackage
 	int INFERENCE_CONTAINER__CONTENTS = 0;
 
 	/**
+	 * The feature id for the '<em><b>Fragments</b></em>' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INFERENCE_CONTAINER__FRAGMENTS = 1;
+
+	/**
 	 * The number of structural features of the '<em>Inference Container</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int INFERENCE_CONTAINER_FEATURE_COUNT = 1;
+	int INFERENCE_CONTAINER_FEATURE_COUNT = 2;
 
 	/**
 	 * The operation id for the '<em>Get Fragment Segment</em>' operation.
@@ -133,6 +143,17 @@ public interface ModelInferencePackage extends EPackage
 	 * @generated
 	 */
 	EReference getInferenceContainer_Contents();
+
+	/**
+	 * Returns the meta object for the attribute list '{@link com.avaloq.tools.ddk.xtext.modelinference.InferenceContainer#getFragments <em>Fragments</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute list '<em>Fragments</em>'.
+	 * @see com.avaloq.tools.ddk.xtext.modelinference.InferenceContainer#getFragments()
+	 * @see #getInferenceContainer()
+	 * @generated
+	 */
+	EAttribute getInferenceContainer_Fragments();
 
 	/**
 	 * Returns the meta object for the '{@link com.avaloq.tools.ddk.xtext.modelinference.InferenceContainer#getFragmentSegment(org.eclipse.emf.ecore.EObject) <em>Get Fragment Segment</em>}' operation.
@@ -195,6 +216,14 @@ public interface ModelInferencePackage extends EPackage
 		 * @generated
 		 */
 		EReference INFERENCE_CONTAINER__CONTENTS = eINSTANCE.getInferenceContainer_Contents();
+
+		/**
+		 * The meta object literal for the '<em><b>Fragments</b></em>' attribute list feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute INFERENCE_CONTAINER__FRAGMENTS = eINSTANCE.getInferenceContainer_Fragments();
 
 		/**
 		 * The meta object literal for the '<em><b>Get Fragment Segment</b></em>' operation.

--- a/com.avaloq.tools.ddk.xtext/src-gen/com/avaloq/tools/ddk/xtext/modelinference/impl/InferenceContainerImpl.java
+++ b/com.avaloq.tools.ddk.xtext/src-gen/com/avaloq/tools/ddk/xtext/modelinference/impl/InferenceContainerImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.MinimalEObjectImpl;
 
+import org.eclipse.emf.ecore.util.EDataTypeUniqueEList;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.emf.ecore.util.InternalEList;
 
@@ -31,6 +32,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
  * </p>
  * <ul>
  *   <li>{@link com.avaloq.tools.ddk.xtext.modelinference.impl.InferenceContainerImpl#getContents <em>Contents</em>}</li>
+ *   <li>{@link com.avaloq.tools.ddk.xtext.modelinference.impl.InferenceContainerImpl#getFragments <em>Fragments</em>}</li>
  * </ul>
  *
  * @generated
@@ -46,6 +48,16 @@ public class InferenceContainerImpl extends MinimalEObjectImpl.Container impleme
 	 * @ordered
 	 */
 	protected EList<EObject> contents;
+
+	/**
+	 * The cached value of the '{@link #getFragments() <em>Fragments</em>}' attribute list.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getFragments()
+	 * @generated
+	 * @ordered
+	 */
+	protected EList<String> fragments;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -80,6 +92,20 @@ public class InferenceContainerImpl extends MinimalEObjectImpl.Container impleme
 			contents = new EObjectContainmentEList<EObject>(EObject.class, this, ModelInferencePackage.INFERENCE_CONTAINER__CONTENTS);
 		}
 		return contents;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EList<String> getFragments()
+	{
+		if (fragments == null)
+		{
+			fragments = new EDataTypeUniqueEList<String>(String.class, this, ModelInferencePackage.INFERENCE_CONTAINER__FRAGMENTS);
+		}
+		return fragments;
 	}
 
 	/**
@@ -134,6 +160,8 @@ public class InferenceContainerImpl extends MinimalEObjectImpl.Container impleme
 		{
 			case ModelInferencePackage.INFERENCE_CONTAINER__CONTENTS:
 				return getContents();
+			case ModelInferencePackage.INFERENCE_CONTAINER__FRAGMENTS:
+				return getFragments();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -153,6 +181,10 @@ public class InferenceContainerImpl extends MinimalEObjectImpl.Container impleme
 				getContents().clear();
 				getContents().addAll((Collection<? extends EObject>)newValue);
 				return;
+			case ModelInferencePackage.INFERENCE_CONTAINER__FRAGMENTS:
+				getFragments().clear();
+				getFragments().addAll((Collection<? extends String>)newValue);
+				return;
 		}
 		super.eSet(featureID, newValue);
 	}
@@ -170,6 +202,9 @@ public class InferenceContainerImpl extends MinimalEObjectImpl.Container impleme
 			case ModelInferencePackage.INFERENCE_CONTAINER__CONTENTS:
 				getContents().clear();
 				return;
+			case ModelInferencePackage.INFERENCE_CONTAINER__FRAGMENTS:
+				getFragments().clear();
+				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -186,6 +221,8 @@ public class InferenceContainerImpl extends MinimalEObjectImpl.Container impleme
 		{
 			case ModelInferencePackage.INFERENCE_CONTAINER__CONTENTS:
 				return contents != null && !contents.isEmpty();
+			case ModelInferencePackage.INFERENCE_CONTAINER__FRAGMENTS:
+				return fragments != null && !fragments.isEmpty();
 		}
 		return super.eIsSet(featureID);
 	}
@@ -206,6 +243,23 @@ public class InferenceContainerImpl extends MinimalEObjectImpl.Container impleme
 				return getEObject((String)arguments.get(0));
 		}
 		return super.eInvoke(operationID, arguments);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString()
+	{
+		if (eIsProxy()) return super.toString();
+
+		StringBuffer result = new StringBuffer(super.toString());
+		result.append(" (fragments: ");
+		result.append(fragments);
+		result.append(')');
+		return result.toString();
 	}
 
 } //InferenceContainerImpl

--- a/com.avaloq.tools.ddk.xtext/src-gen/com/avaloq/tools/ddk/xtext/modelinference/impl/ModelInferencePackageImpl.java
+++ b/com.avaloq.tools.ddk.xtext/src-gen/com/avaloq/tools/ddk/xtext/modelinference/impl/ModelInferencePackageImpl.java
@@ -6,6 +6,7 @@ import com.avaloq.tools.ddk.xtext.modelinference.InferenceContainer;
 import com.avaloq.tools.ddk.xtext.modelinference.ModelInferenceFactory;
 import com.avaloq.tools.ddk.xtext.modelinference.ModelInferencePackage;
 
+import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EPackage;
@@ -116,6 +117,16 @@ public class ModelInferencePackageImpl extends EPackageImpl implements ModelInfe
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EAttribute getInferenceContainer_Fragments()
+	{
+		return (EAttribute)inferenceContainerEClass.getEStructuralFeatures().get(1);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EOperation getInferenceContainer__GetFragmentSegment__EObject()
 	{
 		return inferenceContainerEClass.getEOperations().get(0);
@@ -163,6 +174,7 @@ public class ModelInferencePackageImpl extends EPackageImpl implements ModelInfe
 		// Create classes and their features
 		inferenceContainerEClass = createEClass(INFERENCE_CONTAINER);
 		createEReference(inferenceContainerEClass, INFERENCE_CONTAINER__CONTENTS);
+		createEAttribute(inferenceContainerEClass, INFERENCE_CONTAINER__FRAGMENTS);
 		createEOperation(inferenceContainerEClass, INFERENCE_CONTAINER___GET_FRAGMENT_SEGMENT__EOBJECT);
 		createEOperation(inferenceContainerEClass, INFERENCE_CONTAINER___GET_EOBJECT__STRING);
 	}
@@ -200,6 +212,7 @@ public class ModelInferencePackageImpl extends EPackageImpl implements ModelInfe
 		// Initialize classes, features, and operations; add parameters
 		initEClass(inferenceContainerEClass, InferenceContainer.class, "InferenceContainer", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getInferenceContainer_Contents(), ecorePackage.getEObject(), null, "contents", null, 0, -1, InferenceContainer.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getInferenceContainer_Fragments(), ecorePackage.getEString(), "fragments", null, 0, -1, InferenceContainer.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		EOperation op = initEOperation(getInferenceContainer__GetFragmentSegment__EObject(), ecorePackage.getEString(), "getFragmentSegment", 0, 1, IS_UNIQUE, IS_ORDERED);
 		addEParameter(op, ecorePackage.getEObject(), "object", 0, 1, IS_UNIQUE, IS_ORDERED);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/impl/InferenceContainerImplCustom.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/impl/InferenceContainerImplCustom.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
 
@@ -68,6 +67,9 @@ public class InferenceContainerImplCustom extends InferenceContainerImpl {
             objectToFragmentMap.remove(oldObject);
           }
           break;
+        case Notification.MOVE:
+        case Notification.SET:
+          throw new UnsupportedOperationException("Operations move() and set() are not supported."); //$NON-NLS-1$
         default:
           break;
         }
@@ -93,6 +95,7 @@ public class InferenceContainerImplCustom extends InferenceContainerImpl {
       // append sequence number suffix in case fragment is already assigned (collision)
       key = fragmentSegment + '.' + i++;
     }
+    getFragments().add(key);
   }
 
   /**
@@ -126,11 +129,19 @@ public class InferenceContainerImplCustom extends InferenceContainerImpl {
     if (fragmentToObjectMap.isEmpty()) {
       if (eResource() == null) {
         LOG.warn("InferenceContainer must be contained in a resource to compute URI fragments."); //$NON-NLS-1$
-        return;
-      }
-      EList<EObject> contents = getContents();
-      for (int i = 0; i < contents.size(); i++) {
-        addFragmentMapping(contents.get(i));
+      } else {
+        int size = getContents().size();
+        if (getFragments().size() != size) {
+          LOG.warn("Fragments need to be recomputed for the InferenceContainer in " + eResource().getURI()); //$NON-NLS-1$
+          getFragments().clear();
+          for (int i = 0; i < getContents().size(); i++) {
+            addFragmentMapping(getContents().get(i));
+          }
+        } else {
+          for (int i = 0; i < size; i++) {
+            fragmentToObjectMap.put(getFragments().get(i), getContents().get(i));
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
In the context of resources loaded from binary storage the overhead of
InferenceContainer is minimized by storing the object URI fragments. As
a consequence these don't need to be recomputed after loading the
resource from binary storage. This was particularly expensive because
this relied on an EMF EContentAdapter which was added to every EObject
of the resource. Thus this commit also slightly lowers the memory
footprint.