### PR TITLE
Fix bug in ProxyCompositeNode#equals()

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
@@ -161,9 +161,10 @@ class ProxyCompositeNode implements ICompositeNode, BidiTreeIterable<INode>, Ada
   }
 
   @Override
+  // @SuppressFBWarnings("EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS")
   public boolean equals(final Object obj) {
     // this override is required for NodeTreeIterator (returned by iterator()) to work correctly in the context of NodeModelUtils
-    return this == obj || !(obj instanceof ProxyCompositeNode) && delegate() == obj;
+    return this == obj || obj instanceof CompositeNode && delegate() == obj;
   }
 
   @Override


### PR DESCRIPTION
This is a follow-up to PR #162 which fixes a bug in
ProxyCompositeNode#equals(), which would cause the node model to get
demand-loaded too eagerly. This could happen any time an installed
ProxyCompositeNode adapter gets compared to som other adapter (e.g.
CacheAdapter) using equals(). This is now fixed by restricting equals()
to only accept CompositeNode instances as potential matches.