### PR TITLE
Performance: Demand load model associations

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
@@ -72,7 +72,9 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
   @Inject
   private Injector injector;
 
-  /** Default load mode to use when loading resources of this type. If not specified it defaults to {@link ResourceLoadMode#PROXIED_NODE_MODEL}. */
+  /**
+   * Default load mode to use when loading resources of this type. If not specified it defaults to {@link ResourceLoadMode#PROXIED_NODE_MODEL_AND_ASSOCIATIONS}.
+   */
   @Inject(optional = true)
   @Named(ResourceLoadMode.DEFAULT_LOAD_MODE)
   private ResourceLoadMode defaultLoadMode;
@@ -368,6 +370,6 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
   }
 
   public ResourceLoadMode getDefaultLoadMode() {
-    return defaultLoadMode != null ? defaultLoadMode : ResourceLoadMode.PROXIED_NODE_MODEL;
+    return defaultLoadMode != null ? defaultLoadMode : ResourceLoadMode.PROXIED_NODE_MODEL_AND_ASSOCIATIONS;
   }
 }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyModelAssociationsAdapter.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyModelAssociationsAdapter.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.resource.persistence;
+
+import java.io.IOException;
+import java.util.Deque;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.WrappedException;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.resource.persistence.StorageAwareResource;
+
+import com.avaloq.tools.ddk.xtext.modelinference.InferredModelAssociator;
+
+
+/**
+ * Proxy implementation of {@link InferredModelAssociator.Adapter}.
+ */
+final class ProxyModelAssociationsAdapter extends InferredModelAssociator.Adapter {
+
+  private final StorageAwareResource resource;
+
+  private ProxyModelAssociationsAdapter(final StorageAwareResource resource) {
+    this.resource = resource;
+  }
+
+  /**
+   * Installs a {@link ProxyModelAssociationsAdapter} unless the given resource already has an {@link InferredModelAssociator.Adapter}.
+   * 
+   * @param resource
+   *          resource to add adapter to, must not be {@code null}
+   */
+  static void install(final StorageAwareResource resource) {
+    InferredModelAssociator.Adapter adapter = (InferredModelAssociator.Adapter) EcoreUtil.getAdapter(resource.eAdapters(), InferredModelAssociator.Adapter.class);
+    if (adapter == null) {
+      adapter = new ProxyModelAssociationsAdapter(resource);
+      resource.eAdapters().add(adapter);
+    }
+  }
+
+  @Override
+  public Map<EObject, Deque<EObject>> getSourceToInferredModelMap() {
+    DirectLinkingResourceStorageLoadable loadable = (DirectLinkingResourceStorageLoadable) ((DirectLinkingResourceStorageFacade) resource.getResourceStorageFacade()).getOrCreateResourceStorageLoadable(resource);
+    try {
+      uninstall();
+      loadable.loadIntoResource(resource, ResourceLoadMode.ONLY_ASSOCIATIONS);
+    } catch (IOException e) {
+      throw new WrappedException(e);
+    }
+    return ((InferredModelAssociator.Adapter) EcoreUtil.getAdapter(resource.eAdapters(), InferredModelAssociator.Adapter.class)).getSourceToInferredModelMap();
+  }
+
+  @Override
+  public Map<EObject, Deque<EObject>> getInferredModelToSourceMap() {
+    DirectLinkingResourceStorageLoadable loadable = (DirectLinkingResourceStorageLoadable) ((DirectLinkingResourceStorageFacade) resource.getResourceStorageFacade()).getOrCreateResourceStorageLoadable(resource);
+    try {
+      uninstall();
+      loadable.loadIntoResource(resource, ResourceLoadMode.ONLY_ASSOCIATIONS);
+    } catch (IOException e) {
+      throw new WrappedException(e);
+    }
+    return ((InferredModelAssociator.Adapter) EcoreUtil.getAdapter(resource.eAdapters(), InferredModelAssociator.Adapter.class)).getInferredModelToSourceMap();
+  }
+
+  private void uninstall() {
+    resource.eAdapters().remove(this);
+  }
+
+}

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ResourceLoadMode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ResourceLoadMode.java
@@ -35,6 +35,8 @@ public interface ResourceLoadMode {
 
   /**
    * Constituent to load from binary storage.
+   * <p>
+   * Note: It is important that the order of these literals reflect the order of the entries in the zip archives.
    */
   enum Constituent {
     /**
@@ -50,6 +52,10 @@ public interface ResourceLoadMode {
      * elements in the resource contents.
      */
     ASSOCIATIONS,
+    /**
+     * This represents the source text behind the node model.
+     */
+    SOURCE,
     /**
      * This represents the {@link org.eclipse.xtext.parser.IParseResult#getRootNode() node model}.
      */
@@ -119,21 +125,42 @@ public interface ResourceLoadMode {
   ResourceLoadMode FULL = of(c -> Instruction.LOAD, "FULL");
 
   /**
-   * Load mode for loading a resource fully from binary storage except for the {@link Constituent#NODE_MODEL}, which will be {@link Instruction#PROXY proxied}.
+   * Load mode for loading a resource fully from binary storage except for the {@link Constituent#NODE_MODEL} and {@link Constituent#SOURCE}, which will be
+   * {@link Instruction#PROXY proxied}.
    */
-  ResourceLoadMode PROXIED_NODE_MODEL = of(c -> c == Constituent.NODE_MODEL ? Instruction.PROXY : Instruction.LOAD, "PROXIED_NODE_MODEL");
+  ResourceLoadMode PROXIED_NODE_MODEL = of(c -> c == Constituent.NODE_MODEL || c == Constituent.SOURCE ? Instruction.PROXY
+      : Instruction.LOAD, "PROXIED_NODE_MODEL");
+
+  /**
+   * Load mode for loading a resource fully from binary storage except for the {@link Constituent#ASSOCIATIONS}, {@link Constituent#NODE_MODEL}, and
+   * {@link Constituent#SOURCE}, which will all be {@link Instruction#PROXY proxied}.
+   */
+  ResourceLoadMode PROXIED_NODE_MODEL_AND_ASSOCIATIONS = of(c -> c == Constituent.NODE_MODEL || c == Constituent.SOURCE || c == Constituent.ASSOCIATIONS
+      ? Instruction.PROXY
+      : Instruction.LOAD, "PROXIED_NODE_MODEL_AND_ASSOCIATIONS");
 
   /**
    * Load mode for loading a resource from binary storage without any node model.
    */
-  ResourceLoadMode NO_NODE_MODEL = of(c -> c == Constituent.NODE_MODEL ? Instruction.SKIP : Instruction.LOAD, "NO_NODE_MODEL");
+  ResourceLoadMode NO_NODE_MODEL = of(c -> c == Constituent.NODE_MODEL || c == Constituent.SOURCE ? Instruction.SKIP : Instruction.LOAD, "NO_NODE_MODEL");
 
   /**
-   * Load mode for demand-loading a resource's node model from binary storage. This is intended to be used in conjunction with {@link #PROXIED_NODE_MODEL}.
+   * Load mode for demand-loading a resource's node model from binary storage. This is intended to be used in conjunction with {@link #PROXIED_NODE_MODEL} and
+   * {@link #PROXIED_NODE_MODEL_AND_ASSOCIATIONS}.
    *
    * @return load mode for demand-loading a resource's node model, never {@code null}
    */
-  ResourceLoadMode ONLY_NODE_MODEL = of(c -> c == Constituent.RESOURCE || c == Constituent.NODE_MODEL ? Instruction.LOAD : Instruction.SKIP, "ONLY_NODE_MODEL");
+  ResourceLoadMode ONLY_NODE_MODEL = of(c -> c == Constituent.RESOURCE || c == Constituent.NODE_MODEL || c == Constituent.SOURCE ? Instruction.LOAD
+      : Instruction.SKIP, "ONLY_NODE_MODEL");
+
+  /**
+   * Load mode for demand-loading a resource's associations from binary storage. This is intended to be used in conjunction with
+   * {@link #PROXIED_NODE_MODEL_AND_ASSOCIATIONS}.
+   *
+   * @return load mode for demand-loading a resource's associations, never {@code null}
+   */
+  ResourceLoadMode ONLY_ASSOCIATIONS = of(c -> c == Constituent.RESOURCE || c == Constituent.ASSOCIATIONS ? Instruction.LOAD
+      : Instruction.SKIP, "ONLY_ASSOCIATIONS");
 
   /**
    * Helper method to create a load mode using a function. The additional name will be returned by the load mode's {@link #toString()} method to assist while


### PR DESCRIPTION
Adds support for demand-loading the model associations from binary
storage. The new default mode is PROXIED_NODE_MODEL_AND_ASSOCIATIONS
which will both demand-load the node model and the model associations.