### PR TITLE
Specify ParameterListMatchStatus.INVALID_FORMAL

### DIFF
--- a/com.avaloq.tools.ddk.typesystem.test/src/com/avaloq/tools/ddk/typesystem/ParameterListMatcherTest.java
+++ b/com.avaloq.tools.ddk.typesystem.test/src/com/avaloq/tools/ddk/typesystem/ParameterListMatcherTest.java
@@ -661,7 +661,7 @@ public class ParameterListMatcherTest {
     actuals.add(new NamedActualParameter(NAME_2, intType));
     actuals.add(new NamedActualParameter(NAME_3, textType));
     ParameterListMatchResult matchResult = parameterListMatcher.match(actuals, formals, parameterMatcher, CASE_INSENSITIVE);
-    checkParameterListResult(ParameterListMatchStatus.INVALID_FORMAL, 2, 3, matchResult);
+    checkParameterListResult(ParameterListMatchStatus.INVALID_FORMAL_NAME, 2, 3, matchResult);
     List<ParameterMatch> matches = matchResult.getMatches();
     checkParameterMatch(IParameterMatchChecker.MatchStatus.MATCH, actuals.get(0), formals.get(0), matches.get(0));
     checkParameterMatch(IParameterMatchChecker.MatchStatus.NO_MATCH_FOR_NAMED_ACTUAL, actuals.get(1), null, matches.get(1));
@@ -679,7 +679,7 @@ public class ParameterListMatcherTest {
     actuals.add(new ActualParameter(intType));
     actuals.add(new NamedActualParameter(null, textType));
     ParameterListMatchResult matchResult = parameterListMatcher.match(actuals, formals, parameterMatcher, CASE_INSENSITIVE);
-    checkParameterListResult(ParameterListMatchStatus.INVALID_FORMAL, 2, 3, matchResult); // position matches against null
+    checkParameterListResult(ParameterListMatchStatus.INVALID_FORMAL_NAME, 2, 3, matchResult); // position matches against null
     List<ParameterMatch> matches = matchResult.getMatches();
     checkParameterMatch(IParameterMatchChecker.MatchStatus.MATCH, actuals.get(0), formals.get(0), matches.get(0));
     checkParameterMatch(IParameterMatchChecker.MatchStatus.MATCH, actuals.get(1), formals.get(1), matches.get(1));
@@ -696,7 +696,7 @@ public class ParameterListMatcherTest {
     actuals.add(new ActualParameter(intType));
     actuals.add(new NamedActualParameter(NAME_3, textType));
     ParameterListMatchResult matchResult = parameterListMatcher.match(actuals, formals, parameterMatcher, CASE_INSENSITIVE);
-    checkParameterListResult(ParameterListMatchStatus.INVALID_FORMAL, 2, 2, matchResult);
+    checkParameterListResult(ParameterListMatchStatus.DUPLICATE_PARAMETER, 2, 2, matchResult);
     assertSame("have one duplicate formal", 1, matchResult.getDuplicateNamedFormals().size());
     List<ParameterMatch> matches = matchResult.getMatches();
     checkParameterMatch(IParameterMatchChecker.MatchStatus.MATCH, actuals.get(0), formals.get(0), matches.get(0));
@@ -821,7 +821,7 @@ public class ParameterListMatcherTest {
 
   private void verifyOneUnnamedFormalAfterNamed(final List<FormalParameter> formals, final FormalParameter unnamedFormal, final List<ActualParameter> actuals) {
     ParameterListMatchResult matchResult = parameterListMatcher.match(actuals, formals, parameterMatcher, CASE_INSENSITIVE);
-    checkParameterListResult(ParameterListMatchStatus.INVALID_FORMAL, 1, 1, matchResult);
+    checkParameterListResult(ParameterListMatchStatus.UNNAMED_FORMAL_AFTER_NAMED, 1, 1, matchResult);
     List<ParameterMatch> matches = matchResult.getMatches();
     checkParameterMatch(IParameterMatchChecker.MatchStatus.MATCH, actuals.get(0), formals.get(0), matches.get(0));
     assertSame(WRONG_NUMBER_OF_UNNAMED_FORMALS_AFTER_NAMED_FORMALS, 1, matchResult.getUnnamedFormalsAfterNamed().size());
@@ -841,7 +841,7 @@ public class ParameterListMatcherTest {
     actuals.add(new ActualParameter(intType));
     actuals.add(new ActualParameter(intType));
     ParameterListMatchResult matchResult = parameterListMatcher.match(actuals, formals, parameterMatcher, CASE_INSENSITIVE);
-    checkParameterListResult(ParameterListMatchStatus.INVALID_FORMAL, 2, 2, matchResult);
+    checkParameterListResult(ParameterListMatchStatus.UNNAMED_FORMAL_AFTER_NAMED, 2, 2, matchResult);
     List<ParameterMatch> matches = matchResult.getMatches();
     checkParameterMatch(IParameterMatchChecker.MatchStatus.MATCH, actuals.get(0), formals.get(0), matches.get(0));
     checkParameterMatch(IParameterMatchChecker.MatchStatus.MATCH, actuals.get(1), formals.get(1), matches.get(1));
@@ -886,7 +886,7 @@ public class ParameterListMatcherTest {
     List<ActualParameter> actuals = new ArrayList<ActualParameter>();
     actuals.add(new ActualParameter(intType));
     ParameterListMatchResult matchResult = parameterListMatcher.match(actuals, formals, parameterMatcher, CASE_INSENSITIVE);
-    checkParameterListResult(ParameterListMatchStatus.INVALID_FORMAL, 1, 1, matchResult);
+    checkParameterListResult(ParameterListMatchStatus.UNNAMED_FORMAL_AFTER_NAMED, 1, 1, matchResult);
     List<ParameterMatch> matches = matchResult.getMatches();
     checkParameterMatch(IParameterMatchChecker.MatchStatus.MATCH, actuals.get(0), formals.get(0), matches.get(0));
     assertSame(WRONG_NUMBER_OF_UNNAMED_FORMALS_AFTER_NAMED_FORMALS, 2, matchResult.getUnnamedFormalsAfterNamed().size());

--- a/com.avaloq.tools.ddk.typesystem/src/com/avaloq/tools/ddk/typesystem/ParameterListMatcher.java
+++ b/com.avaloq.tools.ddk.typesystem/src/com/avaloq/tools/ddk/typesystem/ParameterListMatcher.java
@@ -98,11 +98,14 @@ public class ParameterListMatcher {
     TOO_MANY_ACTUALS,
     /** An actual parameter is invalid, e.g., is null or has a name that is null or the empty string. */
     INVALID_ACTUAL,
-    /**
-     * A formal parameter is invalid, e.g., is null, has a name that is null or the empty string, is a duplicate named parameter or is an unnamed parameter that
-     * occurred after a named parameter.
-     */
+    /** A formal parameter is null. */
     INVALID_FORMAL,
+    /** A formal parameter is a duplicate named parameter. */
+    DUPLICATE_PARAMETER,
+    /** A formal parameter has a name that is null or the empty string. */
+    INVALID_FORMAL_NAME,
+    /** A formal parameter is an unnamed parameter that occurred after a named parameter. */
+    UNNAMED_FORMAL_AFTER_NAMED
   }
 
   /**
@@ -266,16 +269,21 @@ public class ParameterListMatcher {
           if (!Strings.isEmpty(name)) {
             if (getConsumedNamedFormals().containsKey(name) && !formal.isMulti()) {
               addDuplicateNamedFormal(namedFormal);
+              setStatus(ParameterListMatchStatus.DUPLICATE_PARAMETER);
+              return;
             } else {
               getConsumedNamedFormals().put(name, namedFormal);
               return;
             }
+          } else {
+            setStatus(ParameterListMatchStatus.INVALID_FORMAL_NAME);
+            return;
           }
         } else {
           return; // is an unnamed formal
         }
       }
-      setStatus(ParameterListMatchStatus.INVALID_FORMAL);
+      setStatus(ParameterListMatchStatus.INVALID_FORMAL); // Cannot match
     }
 
     /**
@@ -362,7 +370,7 @@ public class ParameterListMatcher {
           unnamedFormalsAfterNamedFormal = new ArrayList<IFormalParameter>(1);
         }
         unnamedFormalsAfterNamedFormal.add(formal);
-        setStatus(ParameterListMatchStatus.INVALID_FORMAL);
+        setStatus(ParameterListMatchStatus.UNNAMED_FORMAL_AFTER_NAMED);
       }
     }
 
@@ -498,7 +506,7 @@ public class ParameterListMatcher {
         if (validName && !listMatchResult.getConsumedNamedFormals().containsKey(formalName) && !resultMap.containsKey(formalName)) {
           resultMap.put(formalName, formal);
         } else if (!validName) {
-          listMatchResult.setStatus(ParameterListMatchStatus.INVALID_FORMAL);
+          listMatchResult.setStatus(ParameterListMatchStatus.INVALID_FORMAL_NAME);
         }
       } else { // it is either null or an unnamed parameter
         if (formal == null) {


### PR DESCRIPTION
Separate some ParameterListMatchStatus.INVALID_FORMAL errors in:
- DUPLICATE_PARAMETER
- INVALID_FORMAL_NAME
- UNNAMED_FORMAL_AFTER_NAMED