### PR TITLE
Revert "Performance: Optimize PatternAwareEObjectDescriptionLookUp"

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/PatternAwareEObjectDescriptionLookUp.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/PatternAwareEObjectDescriptionLookUp.java
@@ -82,9 +82,9 @@ public class PatternAwareEObjectDescriptionLookUp extends EObjectDescriptionLook
 
   @Override
   public Iterable<IEObjectDescription> getExportedObjectsByObject(final EObject object) {
-    final EClass eClass = object.eClass();
+    // cannot really filter by EClass, as "object" may be a dummy proxy of arbitrary type
     final String fragment = EObjectUtil.getURIFragment(object);
-    return Iterables.filter(getExportedObjects(), input -> eClass == input.getEClass() && fragment.equals(input.getEObjectURI().fragment()));
+    return Iterables.filter(getExportedObjects(), input -> fragment.equals(input.getEObjectURI().fragment()));
   }
 
   @Override


### PR DESCRIPTION
The ISelectable#getExportedObjectsByObject(EObject) API is sometimes
being used by clients which pass in a dummy proxy object of arbitrary
type, so the filtering by EClass doesn't work for these use cases.
Therefore reverting commit 38d3f30295731da61956ee619da44e4f129b8644.
Having the API as ISelectable#getExportedObjectsByObject(URI) would
probably have been cleaner anyway.