### PR TITLE
Mr QA: Fix warnings in ddk-master-analysis job.

### DIFF
--- a/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/AbstractCheckGenerationTestCase.java
+++ b/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/AbstractCheckGenerationTestCase.java
@@ -44,6 +44,7 @@ import com.google.inject.Injector;
 /**
  * An abstract test class for tests on Check models. Allows creating a project, adding files, and generating and compiling the project.
  */
+@SuppressWarnings("deprecation")
 public class AbstractCheckGenerationTestCase extends AbstractCheckTestCase {
 
   @Inject

--- a/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/BugDsl27.java
+++ b/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/BugDsl27.java
@@ -26,6 +26,7 @@ import com.avaloq.tools.ddk.check.CheckInjectorProvider;
  */
 @InjectWith(CheckInjectorProvider.class)
 @RunWith(XtextRunner.class)
+@SuppressWarnings("deprecation")
 public class BugDsl27 extends AbstractCheckGenerationTestCase {
 
   /**

--- a/com.avaloq.tools.ddk.xtext.format.generator/src/com/avaloq/tools/ddk/xtext/format/generator/FormatFragmentUtil.java
+++ b/com.avaloq.tools.ddk.xtext.format.generator/src/com/avaloq/tools/ddk/xtext/format/generator/FormatFragmentUtil.java
@@ -38,6 +38,7 @@ import com.avaloq.tools.ddk.xtext.generator.util.ModelValidator;
 /**
  * Various utility functions for the format generator.
  */
+@SuppressWarnings("deprecation")
 public final class FormatFragmentUtil {
 
   /** Class-wide logger. */

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/ecore/CustomClassEMFGeneratorFragment2.xtend
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/ecore/CustomClassEMFGeneratorFragment2.xtend
@@ -35,8 +35,6 @@ import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.emf.ecore.resource.URIConverter
 import org.eclipse.emf.mwe.core.ConfigurationException
 import org.eclipse.emf.mwe.utils.GenModelHelper
-import org.eclipse.emf.mwe.utils.StandaloneSetup
-import org.eclipse.xtext.generator.GenModelAccess
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.xtext.generator.ecore.EMFGeneratorFragment2
 
@@ -98,7 +96,7 @@ class CustomClassEMFGeneratorFragment2 extends EMFGeneratorFragment2 {
   }
 
   /**
-   * Use {@link GenModelAccess#getGenPackage(EPackage)}
+   * Use {@link org.eclipse.xtext.generator.GenModelAccess#getGenPackage(EPackage, ResourceSet) GenModelAccess#getGenPackage(EPackage, ResourceSet)}
    */
   @Deprecated
   def protected List<GenPackage> loadReferencedGenModels(ResourceSet rs) {
@@ -123,7 +121,7 @@ class CustomClassEMFGeneratorFragment2 extends EMFGeneratorFragment2 {
   }
 
   /**
-   * use {@link StandaloneSetup#addRegisterGenModelFile(String)}
+   * use {@link org.eclipse.emf.mwe.utils.StandaloneSetup#addRegisterGenModelFile(String) StandaloneSetup#addRegisterGenModelFile(String)}
    */
   @Deprecated
   def void setReferencedGenModels(String referencedGenModel) {
@@ -157,7 +155,7 @@ class CustomClassEMFGeneratorFragment2 extends EMFGeneratorFragment2 {
 
   /**
    * Sets the URIs for the generated EMF generator models (aka genmodels).
-   * use {@link StandaloneSetup#addRegisterGenModelFile(String)}
+   * use {@link org.eclipse.emf.mwe.utils.StandaloneSetup#addRegisterGenModelFile(String) StandaloneSetup#addRegisterGenModelFile(String)}
    *
    * @param uris
    * @deprecated

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/ecore/GeneratorAdapterDescriptor.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/ecore/GeneratorAdapterDescriptor.java
@@ -22,17 +22,26 @@ import org.eclipse.emf.codegen.util.ImportManager;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.mwe2.ecore.CvsIdFilteringGeneratorAdapterFactoryDescriptor;
 
-import com.avaloq.tools.ddk.xtext.generator.ecore.CustomClassEcoreGeneratorFragment.TypeMapper;
 import com.google.common.base.Function;
 
 
 /**
- * Custom EMF GenModel generator adapter using the {@link TypeMapper} to make EMF properly generate import statements for the custom classes.
+ * Custom EMF GenModel generator adapter using one of
+ * <ul>
+ * <li>{@link com.avaloq.tools.ddk.xtext.generator.ecore.CustomClassEcoreGeneratorFragment.TypeMapper CustomClassEcoreGeneratorFragment.TypeMapper}</li>
+ * <li>{@link com.avaloq.tools.ddk.xtext.generator.ecore.CustomClassEMFGeneratorFragment2.TypeMapper CustomClassEMFGeneratorFragment2.TypeMapper}</li>
+ * </ul>
+ * to make EMF properly generate import statements for the custom classes.
  */
 class GeneratorAdapterDescriptor extends CvsIdFilteringGeneratorAdapterFactoryDescriptor {
 
   /**
-   * Custom EMF GenModel generator adapter factory using the {@link TypeMapper} to make EMF properly generate import statements for the custom classes.
+   * Custom EMF GenModel generator adapter using one of
+   * <ul>
+   * <li>{@link com.avaloq.tools.ddk.xtext.generator.ecore.CustomClassEcoreGeneratorFragment.TypeMapper CustomClassEcoreGeneratorFragment.TypeMapper}</li>
+   * <li>{@link com.avaloq.tools.ddk.xtext.generator.ecore.CustomClassEMFGeneratorFragment2.TypeMapper CustomClassEMFGeneratorFragment2.TypeMapper}</li>
+   * </ul>
+   * to make EMF properly generate import statements for the custom classes.
    */
   private final class CustomImplAwareGeneratorAdapterFactory extends IdFilteringGenModelGeneratorAdapterFactory {
     @Override
@@ -40,7 +49,7 @@ class GeneratorAdapterDescriptor extends CvsIdFilteringGeneratorAdapterFactoryDe
       return new IdFilteringGenClassAdapter(this) {
         @Override
         protected void createImportManager(final String packageName, final String className) {
-          importManager = new ImportManagerHack(packageName, typeMapper);
+          importManager = new CustomImportManager(packageName, typeMapper);
           importManager.addMasterImport(packageName, className);
           if (generatingObject != null) {
             ((GenBase) generatingObject).getGenModel().setImportManager(importManager);
@@ -54,7 +63,7 @@ class GeneratorAdapterDescriptor extends CvsIdFilteringGeneratorAdapterFactoryDe
       return new IdFilteringGenEnumAdapter(this) {
         @Override
         protected void createImportManager(final String packageName, final String className) {
-          importManager = new ImportManagerHack(packageName, typeMapper);
+          importManager = new CustomImportManager(packageName, typeMapper);
           importManager.addMasterImport(packageName, className);
           if (generatingObject != null) {
             ((GenBase) generatingObject).getGenModel().setImportManager(importManager);
@@ -69,7 +78,7 @@ class GeneratorAdapterDescriptor extends CvsIdFilteringGeneratorAdapterFactoryDe
         genModelGeneratorAdapter = new GenModelGeneratorAdapter(this) {
           @Override
           protected void createImportManager(final String packageName, final String className) {
-            importManager = new ImportManagerHack(packageName, typeMapper);
+            importManager = new CustomImportManager(packageName, typeMapper);
             importManager.addMasterImport(packageName, className);
             if (generatingObject != null) {
               ((GenBase) generatingObject).getGenModel().setImportManager(importManager);
@@ -95,7 +104,7 @@ class GeneratorAdapterDescriptor extends CvsIdFilteringGeneratorAdapterFactoryDe
       return new IdFilteringGenPackageAdapter(this) {
         @Override
         protected void createImportManager(final String packageName, final String className) {
-          importManager = new ImportManagerHack(packageName, typeMapper);
+          importManager = new CustomImportManager(packageName, typeMapper);
           importManager.addMasterImport(packageName, className);
           if (generatingObject != null) {
             ((GenBase) generatingObject).getGenModel().setImportManager(importManager);
@@ -120,13 +129,13 @@ class GeneratorAdapterDescriptor extends CvsIdFilteringGeneratorAdapterFactoryDe
   }
 
   /**
-   * Hacked EMF ImportManager which returns the name of the custom classes as returned by the {@link TypeMapper}.
+   * Adapted EMF ImportManager which returns the name of the custom classes as returned by the given type mapping function.
    */
-  protected class ImportManagerHack extends ImportManager {
+  protected class CustomImportManager extends ImportManager {
 
     private final Function<String, String> typeMapper;
 
-    public ImportManagerHack(final String compilationUnitPackage, final Function<String, String> typeMapper) {
+    public CustomImportManager(final String compilationUnitPackage, final Function<String, String> typeMapper) {
       super(compilationUnitPackage);
       this.typeMapper = typeMapper;
     }


### PR DESCRIPTION
Suppress 'deprecated' warnings until cleanup job can be done.
Fixed comments to use fully qualified class names for otherwise unused
classes so that the import can be removed.
Changed name of custom ImportManager.