### PR TITLE
Minor performance improvements

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/impl/InferenceContainerImplCustom.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/impl/InferenceContainerImplCustom.java
@@ -20,6 +20,7 @@ import org.apache.log4j.Logger;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
 
 import com.avaloq.tools.ddk.xtext.modelinference.IInferredElementFragmentProvider;
@@ -95,7 +96,7 @@ public class InferenceContainerImplCustom extends InferenceContainerImpl {
       // append sequence number suffix in case fragment is already assigned (collision)
       key = fragmentSegment + '.' + i++;
     }
-    getFragments().add(key);
+    ((InternalEList<String>) getFragments()).addUnique(key);
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/PatternAwareEObjectDescriptionLookUp.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/PatternAwareEObjectDescriptionLookUp.java
@@ -47,9 +47,6 @@ public class PatternAwareEObjectDescriptionLookUp extends EObjectDescriptionLook
 
   @Override
   public Iterable<IEObjectDescription> getExportedObjects(final EClass type, final QualifiedName name, final boolean ignoreCase) {
-    if (Iterables.isEmpty(getExportedObjects())) {
-      return Collections.emptyList();
-    }
     QualifiedName lowerCase = name.toLowerCase(); // NOPMD UseLocaleWithCaseConversions not a String!
     QualifiedNameLookup<IEObjectDescription> lookup = getNameToObjectsLookup();
     Collection<IEObjectDescription> values;
@@ -62,21 +59,9 @@ public class PatternAwareEObjectDescriptionLookUp extends EObjectDescriptionLook
     if (values == null) {
       return Collections.emptyList();
     }
-    Predicate<IEObjectDescription> predicate = ignoreCase ? new Predicate<IEObjectDescription>() {
-      @Override
-      public boolean apply(final IEObjectDescription input) {
-        return EcoreUtil2.isAssignableFrom(type, input.getEClass());
-      }
-    } : new Predicate<IEObjectDescription>() {
-      @Override
-      public boolean apply(final IEObjectDescription input) {
-        if (isPattern) {
-          return EcoreUtil2.isAssignableFrom(type, input.getEClass()) && ((QualifiedNamePattern) name).matches(name);
-        } else {
-          return name.equals(input.getName()) && EcoreUtil2.isAssignableFrom(type, input.getEClass());
-        }
-      }
-    };
+    Predicate<IEObjectDescription> predicate = ignoreCase ? input -> EcoreUtil2.isAssignableFrom(type, input.getEClass())
+        : input -> isPattern ? EcoreUtil2.isAssignableFrom(type, input.getEClass()) && ((QualifiedNamePattern) name).matches(name)
+            : name.equals(input.getName()) && EcoreUtil2.isAssignableFrom(type, input.getEClass());
     return Collections2.filter(values, predicate);
   }
 


### PR DESCRIPTION
Improves the performance of
InferenceContainerImplCustom#addFragmentMapping() by using
InternalEList#addUnique() rather than EList#add(). This is fine because
we already know that the fragment is unique.

PatternAwareEObjectDescriptionLookUp#getExportedObjects() is also
slightly improved by removing the Iterables#isEmpty() check at the
beginning. There is no reason to optimize this case, as it should
typically not occur anyway.