### PR TITLE
Add explicit source dependencies in MonitoredClusteringBuilderState

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractResourceDescriptionStrategy.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractResourceDescriptionStrategy.java
@@ -31,7 +31,7 @@ import org.eclipse.xtext.util.IAcceptor;
 
 import com.avaloq.tools.ddk.xtext.build.BuildPhases;
 import com.avaloq.tools.ddk.xtext.linking.ICrossReferenceHelper;
-import com.avaloq.tools.ddk.xtext.scoping.ImplicitReferencesAdapter;
+import com.avaloq.tools.ddk.xtext.scoping.InferredImplicitReferencesAdapter;
 import com.avaloq.tools.ddk.xtext.util.EObjectUtil;
 import com.google.inject.Inject;
 
@@ -162,17 +162,17 @@ public abstract class AbstractResourceDescriptionStrategy extends DefaultResourc
   }
 
   /**
-   * Creates all implicit reference descriptions and adds them to the acceptor.
+   * Creates all inferred and implicit reference descriptions and adds them to the acceptor.
    *
    * @param resource
    *          resource to create implicit references for
    * @param acceptor
    *          acceptor
    */
-  public void createImplicitReferenceDescriptions(final Resource resource, final IAcceptor<IReferenceDescription> acceptor) {
-    ImplicitReferencesAdapter adapter = ImplicitReferencesAdapter.find(resource);
+  public void createInferredImplicitReferenceDescriptions(final Resource resource, final IAcceptor<IReferenceDescription> acceptor) {
+    InferredImplicitReferencesAdapter adapter = InferredImplicitReferencesAdapter.find(resource);
     if (adapter != null) {
-      for (IReferenceDescription ref : adapter.getImplicitReferences()) {
+      for (IReferenceDescription ref : adapter.getInferredImplicitReferences()) {
         acceptor.accept(ref);
       }
     }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescription2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescription2.java
@@ -151,7 +151,7 @@ public class ResourceDescription2 extends DefaultResourceDescription implements 
       }
     }
     if (strategy instanceof AbstractResourceDescriptionStrategy) {
-      ((AbstractResourceDescriptionStrategy) strategy).createImplicitReferenceDescriptions(getResource(), referenceDescriptions::add);
+      ((AbstractResourceDescriptionStrategy) strategy).createInferredImplicitReferenceDescriptions(getResource(), referenceDescriptions::add);
     }
     return referenceDescriptions.build();
   }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AbstractPolymorphicScopeProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AbstractPolymorphicScopeProvider.java
@@ -111,24 +111,7 @@ public abstract class AbstractPolymorphicScopeProvider extends AbstractScopeProv
    *          Our resource
    */
   protected void registerForeignObject(final EObject context, final XtextResource contextResource, final Resource originalResource) {
-    getImplicitReferencesAdapter(originalResource).addImplicitReference(contextResource.getURI());
-  }
-
-  /**
-   * Returns the implicit references adapter for the given resource. It will be added first if it doesn't already exist.
-   *
-   * @param context
-   *          resource
-   * @return adapter
-   */
-  protected ImplicitReferencesAdapter getImplicitReferencesAdapter(final Resource context) {
-    ImplicitReferencesAdapter adapter = ImplicitReferencesAdapter.find(context);
-    if (adapter != null) {
-      return adapter;
-    }
-    ImplicitReferencesAdapter implicitReferencesAdapter = new ImplicitReferencesAdapter();
-    context.eAdapters().add(implicitReferencesAdapter);
-    return implicitReferencesAdapter;
+    InferredImplicitReferencesAdapter.findOrCreate(originalResource).addImplicitReference(contextResource.getURI());
   }
 
   // "Exported" operation (from IScopeProvider). As this is the only operation known from the interface, this is


### PR DESCRIPTION
It is possible to specify explicit dependencies between source files
which will be evaluated before the indexing phase.