### PR TITLE
Fix JDT compiler version

### DIFF
--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -215,6 +215,22 @@
             <artifactId>org.eclipse.equinox.common</artifactId>
             <version>3.10.0</version>
           </dependency>
+          <!-- workaround for issue https://github.com/eclipse/xtext-xtend/issues/493  -->
+          <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.core</artifactId>
+            <version>3.15.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+            <version>1.3.300</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.compiler.tool</artifactId>
+            <version>1.2.300</version>
+          </dependency>
         </dependencies>
         <executions>
           <execution>


### PR DESCRIPTION
Our builds take latest Xtend compiler. JDT API changed, Xtend compiler
fails. So we need to fix the JDT compiler version.

See https://github.com/eclipse/xtext-xtend/issues/493 for details