### PR TITLE
Fix actual/expected order of assertThat call in AbstractQuickFixTest

### DIFF
--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/ui/quickfix/AbstractQuickFixTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/ui/quickfix/AbstractQuickFixTest.java
@@ -387,7 +387,7 @@ public abstract class AbstractQuickFixTest extends AbstractXtextEditorTest {
     String expected = expectedContent.replaceAll(CR_LF, LF);
     String actual = actualContent.replaceAll(CR_LF, LF);
     if (ignoreFormatting) {
-      assertThat(message, expected, equalToIgnoringWhiteSpace(actual));
+      assertThat(message, actual, equalToIgnoringWhiteSpace(expected));
     } else {
       assertEquals(message, expected, actual);
     }


### PR DESCRIPTION
for assertThat the assertion is always done on the 'actual' (because it
is not necessarily compared against something). with the inversed order
the output was wrong (and thus confusing) but the check was still right.

this has no functional impact, just makes the validation message
clearer.