### PR TITLE
Fix FindBugs warnings

### DIFF
--- a/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
@@ -13,8 +13,7 @@ Require-Bundle: com.google.guava,
  org.eclipse.emf.ecore,
  org.eclipse.xtext,
  org.eclipse.xtext.builder,
- org.eclipse.xtext.util,
- edu.umd.cs.findbugs.annotations;resolution:=optional
+ org.eclipse.xtext.util
 Export-Package: com.avaloq.tools.ddk.caching,
  com.avaloq.tools.ddk.xtext.build,
  com.avaloq.tools.ddk.xtext.documentation,

--- a/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: com.google.guava,
  org.eclipse.emf.ecore,
  org.eclipse.xtext,
  org.eclipse.xtext.builder,
- org.eclipse.xtext.util
+ org.eclipse.xtext.util,
+ edu.umd.cs.findbugs.annotations;resolution:=optional
 Export-Package: com.avaloq.tools.ddk.caching,
  com.avaloq.tools.ddk.xtext.build,
  com.avaloq.tools.ddk.xtext.documentation,

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/annotations/SuppressFBWarnings.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/annotations/SuppressFBWarnings.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+
+/**
+ * Used to suppress FindBugs warnings.
+ */
+@Retention(RetentionPolicy.CLASS)
+public @interface SuppressFBWarnings {
+  /**
+   * The set of FindBugs warnings that are to be suppressed in
+   * annotated element. The value can be a bug category, kind or pattern.
+   */
+  String[] value() default {};
+
+  /**
+   * Optional documentation of the reason why the warning is suppressed.
+   */
+  String justification() default "";
+}

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/documentation/SingleLineCommentDocumentationProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/documentation/SingleLineCommentDocumentationProvider.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.documentation;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -23,7 +24,6 @@ import org.eclipse.xtext.nodemodel.ILeafNode;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -87,7 +87,7 @@ public class SingleLineCommentDocumentationProvider implements IEObjectDocumenta
   public List<INode> getDocumentationNodes(final EObject object) {
     ICompositeNode node = NodeModelUtils.getNode(object);
     if (node == null) {
-      return ImmutableList.of();
+      return Collections.emptyList();
     }
 
     // get all single line comments before a non hidden leaf node
@@ -130,8 +130,8 @@ public class SingleLineCommentDocumentationProvider implements IEObjectDocumenta
   protected String findTrailingComment(final EObject context) {
     StringBuilder returnValue = new StringBuilder();
     ICompositeNode node = NodeModelUtils.getNode(context);
-    final int contextEndLine = node.getEndLine();
     if (node != null) {
+      final int contextEndLine = node.getEndLine();
       // process all leaf nodes first
       for (ILeafNode leave : node.getLeafNodes()) {
         addComment(returnValue, leave, contextEndLine);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescription2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescription2.java
@@ -43,7 +43,6 @@ import com.avaloq.tools.ddk.xtext.linking.ImportedNamesTypesAdapter;
 import com.avaloq.tools.ddk.xtext.resource.extensions.IResourceDescription2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
 
 /**
@@ -63,7 +62,7 @@ public class ResourceDescription2 extends DefaultResourceDescription implements 
   @Override
   protected EObjectDescriptionLookUp getLookUp() {
     if (lookup == null) {
-      lookup = new PatternAwareEObjectDescriptionLookUp(ImmutableList.<IEObjectDescription> of());
+      lookup = new PatternAwareEObjectDescriptionLookUp(Collections.emptyList());
       lookup.setExportedObjects(computeExportedObjects());
     }
     return lookup;
@@ -76,7 +75,7 @@ public class ResourceDescription2 extends DefaultResourceDescription implements 
         getResource().load(null);
       } catch (IOException e) {
         LOG.error(e.getMessage(), e);
-        return ImmutableList.of();
+        return Collections.emptyList();
       }
     }
     // Maybe we need to install the derived state first. Installing/discarding the derived state will clear the resource cache, so we must
@@ -212,6 +211,6 @@ public class ResourceDescription2 extends DefaultResourceDescription implements 
     if (adapter instanceof ImportedNamesTypesAdapter) {
       return ImmutableMap.copyOf(((ImportedNamesTypesAdapter) adapter).getImportedNamesTypes());
     }
-    return Maps.newHashMap();
+    return Collections.emptyMap();
   }
 }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescriptionDelta.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescriptionDelta.java
@@ -169,7 +169,7 @@ public class ResourceDescriptionDelta extends AbstractResourceDescriptionDelta {
     }
 
     // At least one has no fingerprint. If both have none, try the default method, otherwise, there is a change.
-    if (oldHash != newHash) {
+    if (oldHash != null || newHash != null) {
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug(getNew().getURI().toString() + ": fingerprint has changed from: " + oldHash + " to " + newHash); //$NON-NLS-1$ //$NON-NLS-2$
       }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
@@ -43,6 +43,7 @@ import org.eclipse.xtext.util.ITextRegionWithLineInformation;
 
 import com.avaloq.tools.ddk.xtext.util.EObjectUtil;
 import com.google.common.collect.Lists;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 
 /**
@@ -161,7 +162,7 @@ class ProxyCompositeNode implements ICompositeNode, BidiTreeIterable<INode>, Ada
   }
 
   @Override
-  // @SuppressFBWarnings("EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS")
+  @SuppressFBWarnings("EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS")
   public boolean equals(final Object obj) {
     // this override is required for NodeTreeIterator (returned by iterator()) to work correctly in the context of NodeModelUtils
     return this == obj || obj instanceof CompositeNode && delegate() == obj;

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
@@ -41,9 +41,9 @@ import org.eclipse.xtext.resource.persistence.StorageAwareResource;
 import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.ITextRegionWithLineInformation;
 
+import com.avaloq.tools.ddk.annotations.SuppressFBWarnings;
 import com.avaloq.tools.ddk.xtext.util.EObjectUtil;
 import com.google.common.collect.Lists;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 
 /**

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/TraceSet.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/TraceSet.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
+import com.avaloq.tools.ddk.annotations.SuppressFBWarnings;
 import com.avaloq.tools.ddk.xtext.tracing.TraceEvent.Trigger;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -160,6 +161,7 @@ public class TraceSet implements ITraceSet {
    * @return new event instance
    */
   @SuppressWarnings("unchecked")
+  @SuppressFBWarnings("RV_RETURN_VALUE_OF_PUTIFABSENT_IGNORED")
   protected <T extends TraceEvent> T newEvent(final Class<T> eventClass, final Trigger trigger, final Object... data) {
     try {
       Constructor<T> constructor = (Constructor<T>) constructors.get(eventClass);


### PR DESCRIPTION
SingleLineCommentDocumentationProvider: Refer 'node' variable after checking for non-nullness.

ResourceDescriptionDelta: checking that one of the hashes isn't null in a more explicit way.

ProxyCompositeNode: uncommented the warning suppression.

Plus some minor clean ups.