### PR TITLE
Clean up ResourceDescriptionDelta

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/FingerprintResourceDescription.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/FingerprintResourceDescription.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.builder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.naming.QualifiedName;
+import org.eclipse.xtext.resource.EObjectDescription;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import org.eclipse.xtext.resource.IReferenceDescription;
+import org.eclipse.xtext.resource.IResourceDescription;
+import org.eclipse.xtext.resource.impl.AbstractResourceDescription;
+import org.eclipse.xtext.resource.impl.EObjectDescriptionLookUp;
+
+import com.avaloq.tools.ddk.xtext.resource.IFingerprintComputer;
+import com.avaloq.tools.ddk.xtext.resource.PatternAwareEObjectDescriptionLookUp;
+import com.avaloq.tools.ddk.xtext.resource.extensions.IResourceDescription2;
+import com.google.common.collect.ImmutableList;
+
+
+/**
+ * Lightweight resource description that contains only the data necessary for the invalidations.
+ * That is, the resource URI and a list of exported objects' descriptions with their fingerprints.
+ */
+public class FingerprintResourceDescription extends AbstractResourceDescription implements IResourceDescription2 {
+
+  private final URI uri;
+  private final List<IEObjectDescription> exportedObjects;
+
+  public FingerprintResourceDescription(final IResourceDescription original) {
+    this.uri = original.getURI();
+    ImmutableList.Builder<IEObjectDescription> builer = ImmutableList.builder();
+    for (IEObjectDescription description : original.getExportedObjects()) {
+      builer.add(createLightDescription(description));
+    }
+    this.exportedObjects = builer.build();
+  }
+
+  private static IEObjectDescription createLightDescription(final IEObjectDescription original) {
+    InternalEObject result = (InternalEObject) EcoreUtil.create(original.getEClass());
+    result.eSetProxyURI(original.getEObjectURI());
+    String fingerprint = original.getUserData(IFingerprintComputer.OBJECT_FINGERPRINT);
+    Map<String, String> data = fingerprint != null ? Collections.singletonMap(IFingerprintComputer.OBJECT_FINGERPRINT, fingerprint) : Collections.emptyMap();
+    return EObjectDescription.create(original.getName(), result, data);
+  }
+
+  @Override
+  public URI getURI() {
+    return uri;
+  }
+
+  @Override
+  protected List<IEObjectDescription> computeExportedObjects() {
+    return exportedObjects;
+  }
+
+  @Override
+  protected EObjectDescriptionLookUp getLookUp() {
+    if (lookup == null) {
+      lookup = new PatternAwareEObjectDescriptionLookUp(computeExportedObjects());
+    }
+    return lookup;
+  }
+
+  @Override
+  public Iterable<QualifiedName> getImportedNames() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Iterable<IReferenceDescription> getReferenceDescriptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Map<QualifiedName, Set<EClass>> getImportedNamesTypes() {
+    return Collections.emptyMap();
+  }
+
+}

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/FixedCopiedResourceDescription.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/FixedCopiedResourceDescription.java
@@ -28,18 +28,18 @@ import org.eclipse.xtext.resource.impl.AbstractResourceDescription;
 import org.eclipse.xtext.resource.impl.EObjectDescriptionLookUp;
 
 import com.avaloq.tools.ddk.xtext.resource.IDetachableDescription;
-import com.avaloq.tools.ddk.xtext.resource.IFingerprintComputer;
 import com.avaloq.tools.ddk.xtext.resource.PatternAwareEObjectDescriptionLookUp;
 import com.avaloq.tools.ddk.xtext.resource.extensions.IResourceDescription2;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 
 
 /**
  * Fix a contract-breaking default implementation in Xtext 2.0.1. Further use LinkedHashMap instead of HashMap to preserve order of user data entries.
  * Also the {@link IDetachableDescription} is respected in order to reuse descriptions and computed data where possible.
- * This implementation keeps only the object fingerprint out of all the user data items, as this is the only one relevant for computing invalidation.
  */
 public class FixedCopiedResourceDescription extends AbstractResourceDescription implements IResourceDescription2 {
 
@@ -60,10 +60,11 @@ public class FixedCopiedResourceDescription extends AbstractResourceDescription 
         }
         InternalEObject result = (InternalEObject) EcoreUtil.create(from.getEClass());
         result.eSetProxyURI(from.getEObjectURI());
-        String fingerprint = from.getUserData(IFingerprintComputer.OBJECT_FINGERPRINT);
-        Map<String, String> userData = fingerprint != null ? Collections.singletonMap(IFingerprintComputer.OBJECT_FINGERPRINT, fingerprint)
-            : Collections.emptyMap();
-        return EObjectDescription.create(from.getName(), result, userData);
+        ImmutableMap.Builder<String, String> userData = ImmutableMap.builder();
+        for (final String key : from.getUserDataKeys()) {
+          userData.put(key, from.getUserData(key));
+        }
+        return EObjectDescription.create(from.getName(), result, userData.build());
       }
     }));
   }
@@ -119,6 +120,7 @@ public class FixedCopiedResourceDescription extends AbstractResourceDescription 
    */
   @Override
   public Map<QualifiedName, Set<EClass>> getImportedNamesTypes() {
-    return Collections.emptyMap();
+    return Maps.newHashMap();
   }
 }
+

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -409,6 +409,8 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
 
     propagateDependencyChains(buildData.getToBeUpdated(), newState);
 
+    // These descriptions are mainly used to compute the set of invalidated resources
+    // Therefore, contain only the objects fingerprint, other user data items are not saved
     final Map<URI, IResourceDescription> oldDescriptions = saveOldDescriptions(buildData);
 
     final Map<URI, DerivedObjectAssociations> oldDerivedObjectAssociations = saveOldDerivedObjectAssociations(buildData);

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -83,7 +84,6 @@ import com.avaloq.tools.ddk.xtext.scoping.ImplicitReferencesAdapter;
 import com.avaloq.tools.ddk.xtext.tracing.ITraceSet;
 import com.avaloq.tools.ddk.xtext.tracing.ResourceValidationRuleSummaryEvent;
 import com.avaloq.tools.ddk.xtext.util.EmfResourceSetUtil;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Iterables;
@@ -757,7 +757,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
     if (saved == null) {
       // TODO DSL-828: this may end up using a lot of memory; we should instead consider creating old copies of the resources in the db
       IResourceDescription old = getResourceDescription(uri);
-      saved = old != null ? new FixedCopiedResourceDescription(old) : null;
+      saved = old != null ? new FingerprintResourceDescription(old) : null;
     } else if (saved == NULL_DESCRIPTION) { // NOPMD
       saved = null; // NOPMD
     }
@@ -774,9 +774,8 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
   protected Map<URI, IResourceDescription> saveOldDescriptions(final BuildData buildData) {
     Map<URI, IResourceDescription> cache = Maps.newHashMapWithExpectedSize(buildData.getToBeUpdated().size());
     for (URI uri : Iterables.concat(buildData.getToBeUpdated(), buildData.getToBeDeleted())) {
-      cache.computeIfAbsent(uri, u -> Optional.fromNullable(getResourceDescription(u))
-          // Do *not* use descriptionCopier here, we just want the EObjectDescriptions!
-          .<IResourceDescription> transform(FixedCopiedResourceDescription::new).or(NULL_DESCRIPTION));
+      // Do *not* use descriptionCopier here, we just want the EObjectDescriptions!
+      cache.computeIfAbsent(uri, u -> Optional.ofNullable(getResourceDescription(u)).<IResourceDescription> map(FixedCopiedResourceDescription::new).orElse(NULL_DESCRIPTION));
     }
     return cache;
   }
@@ -887,7 +886,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
             // We don't care here about links, we really just want the exported objects so that we can link in the next phase.
             // Set flag to tell linker to log warnings on unresolvable cross-references
             resourceSet.getLoadOptions().put(ILazyLinkingResource2.MARK_UNRESOLVABLE_XREFS, Boolean.FALSE);
-            final IResourceDescription copiedDescription = new FixedCopiedResourceDescription(description);
+            final IResourceDescription copiedDescription = new FingerprintResourceDescription(description);
             final Delta intermediateDelta = manager.createDelta(oldState.getResourceDescription(uri), copiedDescription);
             newState.register(intermediateDelta);
             toBuild.add(uri);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescriptionDelta.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescriptionDelta.java
@@ -11,7 +11,6 @@
 package com.avaloq.tools.ddk.xtext.resource;
 
 import java.lang.ref.SoftReference;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -199,33 +198,12 @@ public class ResourceDescriptionDelta extends AbstractResourceDescriptionDelta {
    * @return true if both are equal
    */
   protected boolean equals(final IEObjectDescription oldObj, final IEObjectDescription newObj) {
-    if (oldObj == newObj) {
-      return true;
-    }
-    String newFingerprint = newObj.getUserData(IFingerprintComputer.OBJECT_FINGERPRINT);
-    if (newFingerprint != null && !newFingerprint.equals(oldObj.getUserData(IFingerprintComputer.OBJECT_FINGERPRINT))) {
-      return false;
-    }
-    if (oldObj.getEClass() != newObj.getEClass()) {
-      return false;
-    }
-    if (oldObj.getName() != null && !oldObj.getName().equals(newObj.getName())) {
-      return false;
-    }
-    if (!oldObj.getEObjectURI().equals(newObj.getEObjectURI())) {
-      return false;
-    }
-    if (!Arrays.equals(oldObj.getUserDataKeys(), newObj.getUserDataKeys())) {
-      return false;
-    }
-    for (String key : oldObj.getUserDataKeys()) {
-      String userData = oldObj.getUserData(key);
-      String userData2 = newObj.getUserData(key);
-      if (userData == null) {
-        if (userData2 != null) {
-          return false;
-        }
-      } else if (!userData.equals(userData2)) {
+    if (oldObj != newObj) {
+      String newFingerprint = newObj.getUserData(IFingerprintComputer.OBJECT_FINGERPRINT);
+      if (newFingerprint != null && !newFingerprint.equals(oldObj.getUserData(IFingerprintComputer.OBJECT_FINGERPRINT))) {
+        return false;
+      }
+      if (!oldObj.getEObjectURI().equals(newObj.getEObjectURI())) {
         return false;
       }
     }


### PR DESCRIPTION
DetailedDiff introduced to avoid long method signatures. Factory method
is used instead of exception-throwing constructor.