### PR TITLE
Prevent generation of empty toc.xml and contents.xml files for DSL internal checks

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/compiler/CheckGeneratorConfigProvider.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/compiler/CheckGeneratorConfigProvider.java
@@ -11,7 +11,7 @@
 
 package com.avaloq.tools.ddk.check.compiler;
 
-import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.common.util.URI;
 
 
 /**
@@ -22,7 +22,7 @@ public class CheckGeneratorConfigProvider implements ICheckGeneratorConfigProvid
   private static final CheckGeneratorConfig CONFIG_INSTANCE = new CheckGeneratorConfig();
 
   @Override
-  public CheckGeneratorConfig get(final Resource context) {
+  public CheckGeneratorConfig get(final URI uri) {
     return CONFIG_INSTANCE;
   }
 

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/compiler/ICheckGeneratorConfigProvider.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/compiler/ICheckGeneratorConfigProvider.java
@@ -11,7 +11,7 @@
 
 package com.avaloq.tools.ddk.check.compiler;
 
-import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.common.util.URI;
 
 import com.google.inject.ImplementedBy;
 
@@ -25,10 +25,10 @@ public interface ICheckGeneratorConfigProvider {
   /**
    * Gets the generator configuration.
    *
-   * @param resource
-   *          the context resource to detect generator preferences, must not be {@code null}
+   * @param uri
+   *          the uri to detect generator preferences, must not be {@code null}
    * @return the check generator configuration
    */
-  CheckGeneratorConfig get(Resource resource);
+  CheckGeneratorConfig get(URI uri);
 
 }

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGenerator.xtend
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGenerator.xtend
@@ -37,7 +37,7 @@ class CheckGenerator extends JvmModelGenerator {
 
   override void doGenerate(Resource resource, IFileSystemAccess fsa) {
     super.doGenerate(resource, fsa); // Generate validator, catalog, and preference initializer from inferred Jvm models.
-    val config = generatorConfigProvider.get(resource);
+    val config = generatorConfigProvider.get(resource?.URI);
     for (catalog : toIterable(resource.allContents).filter(typeof(CheckCatalog))) {
 
       fsa.generateFile(catalog.issueCodesFilePath, catalog.compileIssueCodes)

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckBuilderParticipant.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckBuilderParticipant.java
@@ -14,7 +14,6 @@ import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.builder.EclipseResourceFileSystemAccess2;
 import org.eclipse.xtext.resource.IResourceDescription.Delta;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
@@ -82,8 +81,7 @@ public class CheckBuilderParticipant extends ConditionalBuilderParticipant {
       } catch (CoreException e) {
         LOGGER.error(e.getMessage(), e);
       }
-      Resource resource = context.getResourceSet().getResource(delta.getUri(), true);
-      CheckGeneratorConfig config = generatorConfigProvider.get(resource);
+      CheckGeneratorConfig config = generatorConfigProvider.get(delta.getUri());
       // Generate docu-related files for SCA checks only
       if (!config.isGenerateLanguageInternalChecks()) {
         try {
@@ -115,15 +113,19 @@ public class CheckBuilderParticipant extends ConditionalBuilderParticipant {
       } catch (CoreException e) {
         LOGGER.error(e.getMessage(), e);
       }
-      try {
-        tocGenerator.removeTopicFromTocFile(delta.getUri());
-      } catch (CoreException e) {
-        LOGGER.error(e.getMessage(), e);
-      }
-      try {
-        contextsGenerator.removeContexts(delta);
-      } catch (CoreException e) {
-        LOGGER.error(e.getMessage(), e);
+      CheckGeneratorConfig config = generatorConfigProvider.get(delta.getUri());
+
+      if (!config.isGenerateLanguageInternalChecks()) {
+        try {
+          tocGenerator.removeTopicFromTocFile(delta.getUri());
+        } catch (CoreException e) {
+          LOGGER.error(e.getMessage(), e);
+        }
+        try {
+          contextsGenerator.removeContexts(delta);
+        } catch (CoreException e) {
+          LOGGER.error(e.getMessage(), e);
+        }
       }
     }
   }

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckEclipseGeneratorConfigProvider.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckEclipseGeneratorConfigProvider.java
@@ -13,7 +13,7 @@ package com.avaloq.tools.ddk.check.ui.builder;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IStorage;
-import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.ui.resource.IStorage2UriMapper;
 import org.eclipse.xtext.util.Pair;
 
@@ -35,11 +35,11 @@ public class CheckEclipseGeneratorConfigProvider implements ICheckGeneratorConfi
   private CheckBuilderPreferenceAccess xbaseBuilderPreferenceAccess;
 
   @Override
-  public CheckGeneratorConfig get(final Resource resource) {
+  public CheckGeneratorConfig get(final URI uri) {
     CheckGeneratorConfig result = new CheckGeneratorConfig();
     IProject project = null;
-    if (resource != null) {
-      Pair<IStorage, IProject> pair = Iterables.getFirst(storage2UriMapper.getStorages(resource.getURI()), null);
+    if (uri != null) {
+      Pair<IStorage, IProject> pair = Iterables.getFirst(storage2UriMapper.getStorages(uri), null);
       if (pair != null) {
         project = pair.getSecond();
       }

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/AbstractCheckDocumentationExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/AbstractCheckDocumentationExtensionHelper.java
@@ -40,7 +40,7 @@ public abstract class AbstractCheckDocumentationExtensionHelper extends Abstract
       return false;
     }
     // Do not generate plugin.xml extensions for docu in a non SCA-plguin
-    CheckGeneratorConfig config = generatorConfigProvider.get(catalog.eResource());
+    CheckGeneratorConfig config = generatorConfigProvider.get(catalog.eResource().getURI());
     return !config.isGenerateLanguageInternalChecks();
   }
 


### PR DESCRIPTION
Prevent generation of empty toc.xml and contents.xml files when the Check compiler is configured for DSL internal checks.