### PR TITLE
Make maximal cluster size and minimal memory value configurable

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/DefaultBuilderResourceLoadStrategy.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/DefaultBuilderResourceLoadStrategy.java
@@ -30,6 +30,9 @@ public class DefaultBuilderResourceLoadStrategy implements IBuilderResourceLoadS
   /** Default value for target free memory in megabytes. */
   private static final String TARGET_FREE_MEMORY_PROPERTY = "com.avaloq.tools.ddk.xtext.builder.targetFreeMemory"; //$NON-NLS-1$
 
+  /** Property for setting minimum free memory setting. */
+  private static final String MIN_FREE_MEMORY_PROPERTY = "com.avaloq.tools.ddk.xtext.builder.minFreeMemory"; //$NON-NLS-1$
+
   /** Property for setting the maximal cluster size. */
   private static final String MAX_CLUSTER_SIZE_PROPERTY = "com.avaloq.tools.ddk.xtext.builder.maxClusterSize"; //$NON-NLS-1$
 
@@ -45,8 +48,11 @@ public class DefaultBuilderResourceLoadStrategy implements IBuilderResourceLoadS
   /** Default target memory value. This is 10% of 2GB, which was historically used as the default memory settings. */
   private static final long DEFAULT_TARGET_FREE_MEMORY = 200 * ONE_MEGABYTE;
 
+  /** Default value for MINIMUM_FREE_MEMORY. */
+  private static final long DEFAULT_MIN_FREE_MEMORY = 100 * ONE_MEGABYTE;
+
   /** Cluster will always end if memory falls bellow this threshold. */
-  private static final long MINIMUM_FREE_MEMORY = 50 * ONE_MEGABYTE;
+  private static final long MINIMUM_FREE_MEMORY = getMinimumFreeMemory();
 
   /** Attempt to cap cluster when memory reaches this limit, as long as we processed more than the minimum cluster size. */
   private static final long TARGET_FREE_MEMORY = getTargetFreeMemory();
@@ -77,6 +83,16 @@ public class DefaultBuilderResourceLoadStrategy implements IBuilderResourceLoadS
   private static int getMaximalClusterSize() {
     String maxClusterSize = System.getProperty(MAX_CLUSTER_SIZE_PROPERTY);
     return maxClusterSize != null ? Integer.parseInt(maxClusterSize) : DEFAULT_MAX_CLUSTER_SIZE;
+  }
+
+  /**
+   * Returns the value for the minimum memory property..
+   *
+   * @return a value set by the corresponding system property, or a default value if the property is not set
+   */
+  private static long getMinimumFreeMemory() {
+    String minimumMemory = System.getProperty(MIN_FREE_MEMORY_PROPERTY);
+    return minimumMemory != null ? Long.parseLong(minimumMemory) : DEFAULT_MIN_FREE_MEMORY;
   }
 
   // note that this setter is required as otherwise the clusterSize field will be marked final


### PR DESCRIPTION
Default value is set to 50k to avoid strange memory effects on big
heaps.