### PR TITLE
Check memory when performing resource demand loads

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/DefaultBuilderResourceLoadStrategy.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/DefaultBuilderResourceLoadStrategy.java
@@ -27,10 +27,10 @@ public class DefaultBuilderResourceLoadStrategy implements IBuilderResourceLoadS
   /** Class-wide logger. */
   private static final Logger LOGGER = Logger.getLogger(DefaultBuilderResourceLoadStrategy.class);
 
-  /** Property for setting target free memory value. (in megabyte). */
+  /** Property for setting target free memory value. (in megabytes). */
   private static final String TARGET_FREE_MEMORY_PROPERTY = "com.avaloq.tools.ddk.xtext.builder.targetFreeMemory"; //$NON-NLS-1$
 
-  /** Property for setting minimum free memory value. (in megabyte) */
+  /** Property for setting minimum free memory value. (in megabytes) */
   private static final String MIN_FREE_MEMORY_PROPERTY = "com.avaloq.tools.ddk.xtext.builder.minFreeMemory"; //$NON-NLS-1$
 
   /** Property for setting the maximal cluster size. */

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/DefaultBuilderResourceLoadStrategy.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/DefaultBuilderResourceLoadStrategy.java
@@ -18,7 +18,7 @@ import com.google.inject.name.Named;
 
 
 /**
- * Determine when to stop loading resources during build.
+ * Determine when to stop loading resources during the build.
  */
 @SuppressWarnings("nls")
 // CHECKSTYLE:CONSTANTS-OFF
@@ -27,10 +27,10 @@ public class DefaultBuilderResourceLoadStrategy implements IBuilderResourceLoadS
   /** Class-wide logger. */
   private static final Logger LOGGER = Logger.getLogger(DefaultBuilderResourceLoadStrategy.class);
 
-  /** Default value for target free memory in megabytes. */
+  /** Property for setting target free memory value. (in megabyte). */
   private static final String TARGET_FREE_MEMORY_PROPERTY = "com.avaloq.tools.ddk.xtext.builder.targetFreeMemory"; //$NON-NLS-1$
 
-  /** Property for setting minimum free memory setting. */
+  /** Property for setting minimum free memory value. (in megabyte) */
   private static final String MIN_FREE_MEMORY_PROPERTY = "com.avaloq.tools.ddk.xtext.builder.minFreeMemory"; //$NON-NLS-1$
 
   /** Property for setting the maximal cluster size. */
@@ -51,16 +51,16 @@ public class DefaultBuilderResourceLoadStrategy implements IBuilderResourceLoadS
   /** Default value for MINIMUM_FREE_MEMORY. */
   private static final long DEFAULT_MIN_FREE_MEMORY = 100 * ONE_MEGABYTE;
 
-  /** Cluster will always end if memory falls bellow this threshold. */
+  /** Cluster will always end if memory falls below this threshold. */
   private static final long MINIMUM_FREE_MEMORY = getMinimumFreeMemory();
 
-  /** Attempt to cap cluster when memory reaches this limit, as long as we processed more than the minimum cluster size. */
+  /** Attempt to cap a cluster when memory reaches this limit, as long as we processed more than the minimum cluster size. */
   private static final long TARGET_FREE_MEMORY = getTargetFreeMemory();
 
   /** Cluster size. */
   @Inject(optional = true)
   @Named("org.eclipse.xtext.builder.clustering.ClusteringBuilderState.clusterSize")
-  private int clusterSize = 20; // NOPMD Cannot be static because of the way Guice injection works.
+  private int clusterSize = 50; // NOPMD Cannot be static because of the way Guice injection works.
 
   /** The Java runtime; needed to get access to memory usage data. */
   private static final Runtime RUNTIME = Runtime.getRuntime();
@@ -100,7 +100,6 @@ public class DefaultBuilderResourceLoadStrategy implements IBuilderResourceLoadS
     this.clusterSize = clusterSize;
   }
 
-  /** {@inheritDoc} */
   @Override
   public boolean mayProcessAnotherResource(final ResourceSet resourceSet, final int alreadyProcessed) {
     if (alreadyProcessed == 0) {
@@ -115,13 +114,13 @@ public class DefaultBuilderResourceLoadStrategy implements IBuilderResourceLoadS
       return false;
     }
 
-    final long freeMemory = RUNTIME.freeMemory();
-    if (freeMemory < MINIMUM_FREE_MEMORY) {
+    if (isMemoryLimitReached()) {
       return false;
     } else if (alreadyProcessed < clusterSize) {
       return true; // Process at least up to cluster size
     }
 
+    final long freeMemory = RUNTIME.freeMemory();
     if (freeMemory < TARGET_FREE_MEMORY) {
       // Running GC here might free memory, but would not significantly speed up processing.
       // We may use slightly smaller clusters than strictly necessary without GC, though.
@@ -134,4 +133,10 @@ public class DefaultBuilderResourceLoadStrategy implements IBuilderResourceLoadS
     }
     return true; // Keep on loading resources into this resource set
   }
+
+  @Override
+  public boolean isMemoryLimitReached() {
+    return RUNTIME.freeMemory() < MINIMUM_FREE_MEMORY;
+  }
+
 }

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/DemandLoadFailedException.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/DemandLoadFailedException.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.builder;
+
+/**
+ * Exception thrown when a resource set fails to demand-load a resource because of not having enough memory.
+ */
+public class DemandLoadFailedException extends RuntimeException {
+
+  private static final long serialVersionUID = 8162994321500072190L;
+
+}

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/IBuilderResourceLoadStrategy.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/IBuilderResourceLoadStrategy.java
@@ -22,7 +22,7 @@ import com.google.inject.ImplementedBy;
 public interface IBuilderResourceLoadStrategy {
 
   /**
-   * Determine whether the builder may, in its second phase, process yet another resource.
+   * Determine whether the builder may process yet another resource.
    *
    * @param resourceSet
    *          The builder's resource set, containing all currently loaded resources.
@@ -31,5 +31,12 @@ public interface IBuilderResourceLoadStrategy {
    * @return true, if the builder shall continue; false if it shall start a new cluster.
    */
   boolean mayProcessAnotherResource(ResourceSet resourceSet, int alreadyProcessed);
+
+  /**
+   * Checks whether the builder has reached the minimal amount of free memory, which prevents further progress without clearing the resource set.
+   *
+   * @return {@code true} if the described condition is met, {@code false} otherwise
+   */
+  boolean isMemoryLimitReached();
 
 }

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/Messages.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/Messages.java
@@ -15,7 +15,9 @@ import org.eclipse.osgi.util.NLS;
 
 //CHECKSTYLE:OFF
 public class Messages extends NLS {
+
   private static final String BUNDLE_NAME = "com.avaloq.tools.ddk.xtext.builder.messages"; //$NON-NLS-1$
+
   public static String MonitoredClusteringBuilderState_CANNOT_LOAD_RESOURCE;
   public static String MonitoredClusteringBuilderState_NO_MORE_RESOURCES;
   public static String MonitoredClusteringBuilderState_PHASE_ONE_DONE;
@@ -23,6 +25,8 @@ public class Messages extends NLS {
   public static String MonitoredClusteringBuilderState_WRITE_DESCRIPTIONS;
   public static String MonitoredClusteringBuilderState_WRITE_ONE_DESCRIPTION;
   public static String MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR;
+  public static String MonitoredClusteringBuilderState_TRY_AGAIN;
+  public static String MonitoredClusteringBuilderState_TRY_AGAIN_FAILED;
 
   static {
     // initialize resource bundle

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/Messages.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/Messages.java
@@ -25,8 +25,6 @@ public class Messages extends NLS {
   public static String MonitoredClusteringBuilderState_WRITE_DESCRIPTIONS;
   public static String MonitoredClusteringBuilderState_WRITE_ONE_DESCRIPTION;
   public static String MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR;
-  public static String MonitoredClusteringBuilderState_TRY_AGAIN;
-  public static String MonitoredClusteringBuilderState_TRY_AGAIN_FAILED;
 
   static {
     // initialize resource bundle

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -940,7 +940,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
           monitor.worked(1);
         }
 
-        if (!loadingStrategy.mayProcessAnotherResource(resourceSet, resourceSet.getResources().size()) || resourceToRetry == null) {
+        if (!loadingStrategy.mayProcessAnotherResource(resourceSet, resourceSet.getResources().size()) || resourceToRetry != null) {
           clearResourceSet(resourceSet);
         }
 

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -905,6 +905,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
           // Demand load failed because of memory shortage, save the uri to process again in the next cluster
           // Resource set will be cleared at the end of this loop iteration
           resourceToRetry = uri;
+          LOGGER.info("Demand load failed during resource indexing: " + resourceToRetry); //$NON-NLS-1$
         } catch (final WrappedException ex) {
           pollForCancellation(monitor);
           if (uri == null && ex instanceof LoadOperationException) { // NOPMD
@@ -939,7 +940,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
           monitor.worked(1);
         }
 
-        if (!loadingStrategy.mayProcessAnotherResource(resourceSet, resourceSet.getResources().size())) {
+        if (!loadingStrategy.mayProcessAnotherResource(resourceSet, resourceSet.getResources().size()) || resourceToRetry == null) {
           clearResourceSet(resourceSet);
         }
 

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -852,7 +852,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
    *          The progress monitor used for user feedback
    * @return the list of {@link URI}s of loaded resources to be processed in the second phase
    */
-  private List<URI> writeResources(final Collection<URI> toWrite, final BuildData buildData, final IResourceDescriptions oldState, final CurrentDescriptions newState, final IProgressMonitor monitor) {
+  private List<URI> writeResources(final Collection<URI> toWrite, final BuildData buildData, final IResourceDescriptions oldState, final CurrentDescriptions newState, final IProgressMonitor monitor) { // NOPMD
     ResourceSet resourceSet = buildData.getResourceSet();
     IProject currentProject = getBuiltProject(buildData);
     List<URI> toBuild = Lists.newArrayList();

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/messages.properties
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/messages.properties
@@ -5,3 +5,5 @@ MonitoredClusteringBuilderState_UPDATE_DESCRIPTIONS=Updating resource descriptio
 MonitoredClusteringBuilderState_WRITE_DESCRIPTIONS=Write new resource descriptions
 MonitoredClusteringBuilderState_WRITE_ONE_DESCRIPTION=Writing new resource description {0} of {1} {2} sources: {3}
 MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR=Could not process {0} due to StackOverflowError
+MonitoredClusteringBuilderState_TRY_AGAIN=Processing {0} resources again: {1}
+MonitoredClusteringBuilderState_TRY_AGAIN_FAILED=Failed to write {0} resources to index after multiple attempts: {1}

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/messages.properties
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/messages.properties
@@ -5,5 +5,3 @@ MonitoredClusteringBuilderState_UPDATE_DESCRIPTIONS=Updating resource descriptio
 MonitoredClusteringBuilderState_WRITE_DESCRIPTIONS=Write new resource descriptions
 MonitoredClusteringBuilderState_WRITE_ONE_DESCRIPTION=Writing new resource description {0} of {1} {2} sources: {3}
 MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR=Could not process {0} due to StackOverflowError
-MonitoredClusteringBuilderState_TRY_AGAIN=Processing {0} resources again: {1}
-MonitoredClusteringBuilderState_TRY_AGAIN_FAILED=Failed to write {0} resources to index after multiple attempts: {1}


### PR DESCRIPTION
If there is not enough memory to load a needed resource -> abort
processing the current one, clear the resource set and try again later.

The new 'isMemoryLimitReached' method has been introduced in
IBuilderResourceLoadStrategy. It returns 'true' when there is not enough
memory.

The retry logic is essentially a revert of a part of
https://github.com/dsldevkit/dsl-devkit/pull/148