### PR TITLE
Avoid triggering inference when executing container queries

### DIFF
--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopeProviderGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopeProviderGenerator.xtend
@@ -268,7 +268,7 @@ class ScopeProviderGenerator {
     ENDIF»«
     ELSE»
       scope = newExternalDelegateScope("«it.locatorString()»", scope, «
-    query(external, model, typeOrRef, scope)».execute(ctx, originalResource)«
+    query(external, model, typeOrRef, scope)».execute(originalResource)«
     ENDIF», «
     IF it.scope !== null && it.scope.typeOrRef() != getScope(it).typeOrRef()»«it.scope.typeOrRef().literalIdentifier()»«ELSE»«typeOrRef»«ENDIF», "«if (it.scope !== null && it.scope.name !== null) it.scope.name else "scope"»", originalResource);
   '''

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/ContainerQuery.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/ContainerQuery.java
@@ -187,7 +187,7 @@ public class ContainerQuery {
    * @return The query results
    */
   public Iterable<IEObjectDescription> execute(final EObject context) {
-    return execute(context, context.eResource());
+    return execute(context.eResource());
   }
 
   /**
@@ -195,14 +195,18 @@ public class ContainerQuery {
    * {@link IContainer.Manager#getVisibleContainers(org.eclipse.xtext.resource.IResourceDescription, org.eclipse.xtext.resource.IResourceDescriptions)}. The
    * result does <em>not</em> apply any name shadowing.
    *
+   * @deprecated
+   *             <p>
+   *             use {@link ContainerQuery#execute(Resource)} instead (context is always ignored)
    * @param context
    *          The context resource.
    * @param originalResource
    *          The original resource.
    * @return The query results
    */
+  @Deprecated
   public Iterable<IEObjectDescription> execute(final Resource context, final Resource originalResource) {
-    return execute(context.getContents().get(0), originalResource);
+    return execute(originalResource);
   }
 
   /**
@@ -212,22 +216,41 @@ public class ContainerQuery {
    * result does <em>not</em> apply
    * any name shadowing.
    *
+   * @deprecated
+   *             <p>
+   *             use {@link ContainerQuery#execute(Resource)} instead (context is always ignored)
    * @param context
    *          An object in the context resource.
    * @param originalResource
    *          The original resource.
    * @return The query results
    */
-  @SuppressWarnings("nls")
+  @Deprecated
   public Iterable<IEObjectDescription> execute(final EObject context, final Resource originalResource) {
-    if (!(originalResource instanceof LazyLinkingResource)) {
-      throw new IllegalStateException("Resource is not a LazyLinkingResource " + (originalResource != null ? originalResource.getURI() : ""));
+    return execute(originalResource);
+  }
+
+  /**
+   * Execute the query on containers visible from a certain resource, and caches the results on that resource. The results will grouped by
+   * container and in the order of
+   * {@link IContainer.Manager#getVisibleContainers(org.eclipse.xtext.resource.IResourceDescription, org.eclipse.xtext.resource.IResourceDescriptions)}. The
+   * result does <em>not</em> apply
+   * any name shadowing.
+   *
+   * @param resource
+   *          The resource.
+   * @return The query results
+   */
+  @SuppressWarnings("nls")
+  public Iterable<IEObjectDescription> execute(final Resource resource) {
+    if (!(resource instanceof LazyLinkingResource)) {
+      throw new IllegalStateException("Resource is not a LazyLinkingResource " + (resource != null ? resource.getURI() : ""));
     }
-    final IScopeProvider scopeProvider = EObjectUtil.getScopeProviderByResource((LazyLinkingResource) originalResource);
+    final IScopeProvider scopeProvider = EObjectUtil.getScopeProviderByResource((LazyLinkingResource) resource);
     if (!(scopeProvider instanceof AbstractPolymorphicScopeProvider)) {
       throw new IllegalStateException("Scope provider is not an AbstractPolymorphicScopeProvider scope provider.");
     }
-    return execute(((AbstractPolymorphicScopeProvider) scopeProvider).getVisibleContainers(originalResource.getContents().get(0), originalResource));
+    return execute(((AbstractPolymorphicScopeProvider) scopeProvider).getVisibleContainers((LazyLinkingResource) resource));
   }
 
   /**


### PR DESCRIPTION
Calls to resource.getContents.get(0) accidentally trigger inference if
the resource was loaded without inference. Even in cases where the
context.eResource() and originalResource are different, we do not need
to get the an EObject from originalResource to find its visible
containers.

- Deprecate the first parameter in
ContainerQuery#execute(EObject/Resource context, Resource
originalResource) as it is never used
- Add AbstractPolymorphicScopeProvider#getVisibleContainers(XtextResource)
as alternative to
AbstractPolymorphicScopeProvider#getVisibleContainers(EObject, Resource)
as the EObject is only relevant if the resource is null.
- Refactor all methods to avoid useless calls to getContents()