### PR TITLE
Catch the StackOverflowError

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/DelegatingScope.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/DelegatingScope.java
@@ -235,14 +235,19 @@ public class DelegatingScope extends AbstractRecursiveScope {
     if (name == null) {
       throw new IllegalArgumentException("Null name in getContentByName"); //$NON-NLS-1$
     }
-    for (final IScope scope : getDelegates()) {
-      final IEObjectDescription elem = scope.getSingleElement(name);
-      if (elem != null) {
-        // ScopeTrace.addTrace(elem, getId());
-        return elem;
+
+    try {
+      for (final IScope scope : getDelegates()) {
+        final IEObjectDescription elem = scope.getSingleElement(name);
+        if (elem != null) {
+          // ScopeTrace.addTrace(elem, getId());
+          return elem;
+        }
       }
+      return getParent().getSingleElement(name);
+    } catch (StackOverflowError e) {
+      return STACK_OVERFLOW_EOBJECT_DESCRIPTION;
     }
-    return getParent().getSingleElement(name);
   }
 
   @Override


### PR DESCRIPTION
Under some rare circumstances scopes may delegate to each other.
Normally this is either an error in the DSL implementation or in the
implementation of some concrete source(s). This should be handled
gracefully though.