### PR TITLE
Give the executor thread of TraceSet a name related to the class

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
@@ -23,6 +23,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.ThreadFactory;
 
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IProject;
@@ -45,6 +46,7 @@ import com.avaloq.tools.ddk.xtext.util.EmfResourceSetUtil;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Binding;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -168,7 +170,7 @@ public class ParallelResourceLoader extends AbstractResourceLoader {
           return resourceSet;
         }
       };
-      this.executor = Executors.newFixedThreadPool(nThreads);
+      this.executor = Executors.newFixedThreadPool(nThreads, new ThreadFactoryBuilder().setNameFormat("parallel-load-operation").build()); //$NON-NLS-1$
       this.waitTime = getTimeout();
     }
 

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/TraceSet.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/TraceSet.java
@@ -15,6 +15,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.function.Supplier;
 
 import com.avaloq.tools.ddk.annotations.SuppressFBWarnings;
@@ -23,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.AsyncEventBus;
 import com.google.common.eventbus.EventBus;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Singleton;
 
 
@@ -36,7 +38,7 @@ import com.google.inject.Singleton;
 public class TraceSet implements ITraceSet {
 
   private final EventBus syncBus = new EventBus();
-  private final EventBus asyncBus = new AsyncEventBus(Executors.newSingleThreadExecutor());
+  private final EventBus asyncBus = new AsyncEventBus(Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("trace-set-async-bus").build())); //$NON-NLS-1$
 
   private final ConcurrentMap<Class<?>, Constructor<?>> constructors = Maps.newConcurrentMap();
 


### PR DESCRIPTION
Give the executor thread of TraceSet a name related to the class to aid
monitoring of the threads.