### PR TITLE
Expose the delegate of ForwardingMap used in ResourceDescriptionStrategy

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ResourceDescriptionStrategyGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ResourceDescriptionStrategyGenerator.xtend
@@ -49,7 +49,7 @@ class ResourceDescriptionStrategyGenerator {
       «IF exports.exists(e|e.lookup)»
         import com.avaloq.tools.ddk.xtext.resource.DetachableEObjectDescription;
       «ENDIF»
-      import com.google.common.collect.ForwardingMap;
+      import com.avaloq.tools.ddk.xtext.resource.extensions.ForwardingResourceDescriptionStrategyMap;
       import com.google.common.collect.ImmutableMap;
       import com.google.common.collect.ImmutableSet;
       «val types = exports»
@@ -131,13 +131,10 @@ class ResourceDescriptionStrategyGenerator {
     '''
       «IF !a.isEmpty || !d.isEmpty || c.fingerprint || c.resourceFingerprint || c.lookup »
         // Use a forwarding map to delay calculation as much as possible; otherwise we may get recursive EObject resolution attempts
-        Map<String, String> data = new ForwardingMap<String, String>() {
-          private Map<String, String> delegate;
+        Map<String, String> data = new ForwardingResourceDescriptionStrategyMap() {
 
           @Override
-          protected Map<String, String> delegate() {
-            if (delegate == null) {
-              ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+          protected void build(final ImmutableMap.Builder<String, String> builder) {
               Object value = null;
               «IF c.fingerprint»
                 // Fingerprint
@@ -181,9 +178,7 @@ class ResourceDescriptionStrategyGenerator {
                   }
                 «ENDFOR»
               «ENDIF»
-              delegate = builder.build();
             }
-            return delegate;
           }
         };
         acceptEObjectDescription(obj, data, acceptor.get());

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/extensions/ForwardingResourceDescriptionStrategyMap.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/extensions/ForwardingResourceDescriptionStrategyMap.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.resource.extensions;
+
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+
+
+public class ForwardingResourceDescriptionStrategyMap extends ForwardingMap<String, String> {
+
+  private Map<String, String> delegate;
+
+  protected void build(final ImmutableMap.Builder<String, String> builder) {
+    // must be overridden by implementation
+  }
+
+  @Override
+  public Map<String, String> delegate() {
+    if (delegate == null) {
+      ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+      build(builder);
+      delegate = builder.build();
+    }
+
+    return delegate;
+  }
+
+}


### PR DESCRIPTION
Expose the delegate of ForwardingMap used in the generated code of the
ResourceDescriptionStrategy. This allows consumers of this map to get a
reference to the ImmutableMap. Until now consumers who needed such an
immutable map where creating a new immutable map which was a copy of the
original one. This overhead can be eliminated by exposing the delegate.