### PR TITLE
Expose the delegate of ForwardingMap used in ResourceDescriptionStrategy

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ResourceDescriptionStrategyGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ResourceDescriptionStrategyGenerator.xtend
@@ -49,7 +49,7 @@ class ResourceDescriptionStrategyGenerator {
       «IF exports.exists(e|e.lookup)»
         import com.avaloq.tools.ddk.xtext.resource.DetachableEObjectDescription;
       «ENDIF»
-      import com.google.common.collect.ForwardingMap;
+      import com.avaloq.tools.ddk.xtext.resource.extensions.AbstractForwardingResourceDescriptionStrategyMap;
       import com.google.common.collect.ImmutableMap;
       import com.google.common.collect.ImmutableSet;
       «val types = exports»
@@ -131,13 +131,10 @@ class ResourceDescriptionStrategyGenerator {
     '''
       «IF !a.isEmpty || !d.isEmpty || c.fingerprint || c.resourceFingerprint || c.lookup »
         // Use a forwarding map to delay calculation as much as possible; otherwise we may get recursive EObject resolution attempts
-        Map<String, String> data = new ForwardingMap<String, String>() {
-          private Map<String, String> delegate;
+        Map<String, String> data = new AbstractForwardingResourceDescriptionStrategyMap() {
 
           @Override
-          protected Map<String, String> delegate() {
-            if (delegate == null) {
-              ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+          protected void fill(final ImmutableMap.Builder<String, String> builder) {
               Object value = null;
               «IF c.fingerprint»
                 // Fingerprint
@@ -181,9 +178,7 @@ class ResourceDescriptionStrategyGenerator {
                   }
                 «ENDFOR»
               «ENDIF»
-              delegate = builder.build();
             }
-            return delegate;
           }
         };
         acceptEObjectDescription(obj, data, acceptor.get());

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/caching/CacheConfiguration.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/caching/CacheConfiguration.java
@@ -14,10 +14,14 @@ package com.avaloq.tools.ddk.caching;
  * Allows the behaviour of a cache to be configured.
  */
 public class CacheConfiguration {
+  static final int UNSET_INT = -1;
+
   private boolean arraySize;
   private boolean softValues;
   private boolean statistics;
-  private long cacheSize = -1;
+
+  private long cacheSize = UNSET_INT;
+  private int initialCapacity = UNSET_INT;
 
   /**
    * All values stored in the cache are wrapped as {@link java.lang.ref.SoftReference SoftReference}, allowing them to be garbage collected as necessary.
@@ -76,5 +80,20 @@ public class CacheConfiguration {
   public boolean isArraySizeEnabled() {
     return arraySize;
   }
-}
 
+  /**
+   * Sets the initial size for the cache.
+   *
+   * @param capacity
+   *          the initial capacity
+   * @return the cache configuration
+   */
+  public CacheConfiguration setInitialCapacity(final int capacity) {
+    initialCapacity = capacity;
+    return this;
+  }
+
+  public int getInitialCapacity() {
+    return initialCapacity;
+  }
+}

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/caching/MapCache.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/caching/MapCache.java
@@ -46,6 +46,9 @@ public class MapCache<K, V> implements ICache<K, V>, Map<K, V> {
     if (config.isSoftValuesEnabled()) {
       cacheBuilder.softValues();
     }
+    if (config.getInitialCapacity() >= 0) {
+      cacheBuilder.initialCapacity(config.getInitialCapacity());
+    }
     if (config.getMaximumSize() >= 0) {
       if (config.isArraySizeEnabled()) {
         cacheBuilder.maximumWeight(config.getMaximumSize());

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/extensions/AbstractForwardingResourceDescriptionStrategyMap.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/extensions/AbstractForwardingResourceDescriptionStrategyMap.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.resource.extensions;
+
+import java.util.Map;
+
+import com.google.common.collect.ForwardingMap;
+import com.google.common.collect.ImmutableMap;
+
+
+/**
+ * The Class AbstractForwardingResourceDescriptionStrategyMap.
+ */
+public abstract class AbstractForwardingResourceDescriptionStrategyMap extends ForwardingMap<String, String> {
+
+  private Map<String, String> delegateMap;
+
+  /**
+   * Implementations must use this method to associates keys with value by using the method {@code put} of the {@link ImmutableMap.Builder}.
+   *
+   * @param builder
+   *          the builder
+   */
+  protected abstract void fill(final ImmutableMap.Builder<String, String> builder);
+
+  @Override
+  public Map<String, String> delegate() {
+    if (delegateMap == null) {
+      ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+      fill(builder);
+      delegateMap = builder.build();
+    }
+
+    return delegateMap;
+  }
+
+}

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/TraceSet.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/TraceSet.java
@@ -15,7 +15,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.function.Supplier;
 
 import com.avaloq.tools.ddk.annotations.SuppressFBWarnings;


### PR DESCRIPTION
Expose the delegate of ForwardingMap used in the generated code of the
ResourceDescriptionStrategy. This allows consumers of this map to get a
reference to the ImmutableMap. Until now consumers who needed such an
immutable map where creating a new immutable map which was a copy of the
original one. This overhead can be eliminated by exposing the delegate.