### PR TITLE
Propagate the Source Level URIs to the child ResourceSet

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
@@ -41,6 +41,7 @@ import com.avaloq.tools.ddk.xtext.build.BuildPhases;
 import com.avaloq.tools.ddk.xtext.builder.tracing.LoaderDequeueEvent;
 import com.avaloq.tools.ddk.xtext.builder.tracing.ResourceLoadEvent;
 import com.avaloq.tools.ddk.xtext.linking.ILazyLinkingResource2;
+import com.avaloq.tools.ddk.xtext.resource.persistence.DirectLinkingSourceLevelURIsAdapter;
 import com.avaloq.tools.ddk.xtext.tracing.ITraceSet;
 import com.avaloq.tools.ddk.xtext.util.EmfResourceSetUtil;
 import com.google.common.base.Joiner;
@@ -164,6 +165,7 @@ public class ParallelResourceLoader extends AbstractResourceLoader {
         protected ResourceSet initialValue() {
           ResourceSet resourceSet = getResourceSetProvider().get(project);
           BuildPhases.setIndexing(resourceSet, BuildPhases.isIndexing(parent));
+          DirectLinkingSourceLevelURIsAdapter.setSourceLevelUris(resourceSet, DirectLinkingSourceLevelURIsAdapter.findInstalledAdapter(parent).getSourceLevelURIs());
           resourceSet.getLoadOptions().putAll(parent.getLoadOptions());
           // we are not loading as part of a build
           resourceSet.getLoadOptions().remove(ResourceDescriptionsProvider.NAMED_BUILDER_SCOPE);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingSourceLevelURIsAdapter.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingSourceLevelURIsAdapter.java
@@ -11,7 +11,6 @@
 
 package com.avaloq.tools.ddk.xtext.resource.persistence;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
@@ -35,7 +34,7 @@ public class DirectLinkingSourceLevelURIsAdapter extends AdapterImpl {
     return type == DirectLinkingSourceLevelURIsAdapter.class;
   }
 
-  public Collection<URI> getSourceLevelURIs() {
+  public Set<URI> getSourceLevelURIs() {
     return sourceLevelURIs;
   }
 
@@ -59,7 +58,7 @@ public class DirectLinkingSourceLevelURIsAdapter extends AdapterImpl {
 
   /**
    * Finds an installed {@link DirectLinkingSourceLevelURIsAdapter} adapter for a given resource set.
-   * 
+   *
    * @param resourceSet
    *          resource set, must not be {@code null}
    * @return installed adapter or {@code null} if none


### PR DESCRIPTION
Propagate the Source Level URIs to the child ResourceSet, this allows
code which runs inside the ParallelResourceLoader (mainly inference) to
use the binary models.