### PR TITLE
Move binary-model related functionality to DDK

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/IBinaryModelStore.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/IBinaryModelStore.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Avaloq Licence AG
+ * Schwerzistrasse 6, 8807 Freienbach, Switzerland, http://www.avaloq.com
+ * All Rights Reserved.
+ *
+ * This software is the confidential and proprietary information of Avaloq Licence AG.
+ * You shall not disclose whole or parts of it and shall use it only in accordance with the terms of the
+ * licence agreement you entered into with Avaloq Licence AG.
+ */
+
+package com.avaloq.tools.ddk.xtext.builder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.URI;
+
+import com.avaloq.tools.ddk.xtext.builder.IBinaryModelStore.NullBinaryModelStore;
+import com.google.inject.ImplementedBy;
+
+
+/**
+ * Manages the binary resources.
+ */
+@ImplementedBy(NullBinaryModelStore.class)
+public interface IBinaryModelStore {
+
+  String SIZE_OPTION = "SIZE"; //$NON-NLS-1$
+
+  /**
+   * Creates an input stream from which a binary model can be read.
+   *
+   * @param uri
+   *          binary model URI, must not be {@code null}
+   * @param options
+   *          a map of options to influence the kind of stream that is returned; can be {@code null} and unrecognized options are ignored
+   * @return input stream which can be used to read binary model
+   * @throws IOException
+   *           in case of an I/O error
+   */
+  InputStream createInputStream(URI uri, Map<?, ?> options) throws IOException;
+
+  /**
+   * Creates an output stream to which a binary model can be written.
+   *
+   * @param uri
+   *          binary model URI, must not be {@code null}
+   * @param options
+   *          a map of options to influence the kind of stream that is returned; can be {@code null} and unrecognized options are ignored
+   * @return output stream which can be used to write binary model
+   * @throws IOException
+   *           if a database error occurred
+   */
+  OutputStream createOutputStream(URI uri, Map<?, ?> options) throws IOException;
+
+  /**
+   * Checks whether a binary model exists with the given URI.
+   *
+   * @param uri
+   *          binary model URI, must not be {@code null}
+   * @return {@code true} if binary model with given URI exists
+   * @throws IOException
+   *           if a database error occurred
+   */
+  boolean exists(URI uri) throws IOException;
+
+  /**
+   * Deletes the binary model for the given URI.
+   *
+   * @param uri
+   *          binary model URI, must not be {@code null}
+   * @throws IOException
+   *           if I/O exception occurred
+   */
+  void delete(URI uri) throws IOException;
+
+  /**
+   * Default no-op implementation throwing runtime exceptions when calling {@link #createInputStream(URI)} or {@link #createOutputStream(URI)} as that means
+   * the application has not been configured correctly.
+   */
+  class NullBinaryModelStore implements IBinaryModelStore {
+
+    @Override
+    public InputStream createInputStream(final URI uri, final Map<?, ?> options) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OutputStream createOutputStream(final URI uri, final Map<?, ?> options) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean exists(final URI uri) throws IOException {
+      return false;
+    }
+
+    @Override
+    public void delete(final URI uri) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+  }
+}
+
+/* Copyright (c) Avaloq Licence AG */

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/layered/DefaultXtextTargetPlatform.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/layered/DefaultXtextTargetPlatform.java
@@ -12,16 +12,17 @@ package com.avaloq.tools.ddk.xtext.builder.layered;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.xtext.builder.builderState.PersistedStateProvider;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsData;
 
+import com.avaloq.tools.ddk.xtext.builder.IBinaryModelStore;
 import com.avaloq.tools.ddk.xtext.builder.IDerivedObjectAssociationsStore;
 import com.avaloq.tools.ddk.xtext.extensions.DelegatingResourceDescriptionsData;
 import com.avaloq.tools.ddk.xtext.extensions.IResourceDescriptionsData;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 
 
@@ -73,12 +74,17 @@ public class DefaultXtextTargetPlatform implements IXtextTargetPlatform {
   /** {@inheritDoc} */
   @Override
   public Map<String, String> getMetadata(final Collection<String> keys, final IProgressMonitor monitor) {
-    return ImmutableMap.of();
+    return Collections.emptyMap();
   }
 
   /** {@inheritDoc} */
   @Override
   public void setMetadata(final Map<String, String> options) {
     // nothing to do
+  }
+
+  @Override
+  public IBinaryModelStore getBinaryModelStore() {
+    return null;
   }
 }

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/layered/IXtextTargetPlatform.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/layered/IXtextTargetPlatform.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 
+import com.avaloq.tools.ddk.xtext.builder.IBinaryModelStore;
 import com.avaloq.tools.ddk.xtext.builder.IDerivedObjectAssociationsStore;
 import com.avaloq.tools.ddk.xtext.extensions.IResourceDescriptionsData;
 import com.google.inject.ImplementedBy;
@@ -108,6 +109,13 @@ public interface IXtextTargetPlatform {
    * @return the association store, or {@code null} if not supported
    */
   IDerivedObjectAssociationsStore getAssociationsStore();
+
+  /**
+   * Returns the store of binary resources.
+   *
+   * @return the platform's store, can be {@code null} if not supported
+   */
+  IBinaryModelStore getBinaryModelStore();
 
   /**
    * Platforms are supposed to be closed when no longer in use. At any time, there must be only one open platform.

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/layered/NullXtextTargetPlatform.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/layered/NullXtextTargetPlatform.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 
+import com.avaloq.tools.ddk.xtext.builder.IBinaryModelStore;
 import com.avaloq.tools.ddk.xtext.builder.IDerivedObjectAssociationsStore;
 import com.avaloq.tools.ddk.xtext.extensions.IResourceDescriptionsData;
 
@@ -53,6 +54,11 @@ public class NullXtextTargetPlatform implements IXtextTargetPlatform {
     return null;
   }
 
+  @Override
+  public IBinaryModelStore getBinaryModelStore() {
+    return null;
+  }
+
   /** {@inheritDoc} */
   @Override
   public Map<String, String> getMetadata(final Collection<String> keys, final IProgressMonitor monitor) {
@@ -64,4 +70,5 @@ public class NullXtextTargetPlatform implements IXtextTargetPlatform {
   public void setMetadata(final Map<String, String> options) {
     // Nothing to do.
   }
+
 }


### PR DESCRIPTION
The corresponding methods from StandaloneBuilderState moved to
MonitoredClusteringBuilderState.

IBinaryModelStore is now made a part of xtext target platform and
therefore moved to DDK.