### PR TITLE
Rename ResourcePostProcessingEvent

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/tracing/ResourceMarkersPostProcessingEvent.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/tracing/ResourceMarkersPostProcessingEvent.java
@@ -14,19 +14,19 @@ import com.avaloq.tools.ddk.xtext.tracing.ResourceEvent;
 
 
 /**
- * An event representing the post-processing of a resource during the build. This event will have a {@link ResourceLinkingEvent} as its parent.
+ * An event representing the post-processing of a resource's markers during the build. This event will have a {@link ResourceValidationEvent} as its parent.
  */
-public class ResourcePostProcessingEvent extends ResourceEvent {
+public class ResourceMarkersPostProcessingEvent extends ResourceEvent {
 
   /**
-   * Creates a new instance of {@link ResourcePostProcessingEvent}.
+   * Creates a new instance of {@link ResourceMarkersPostProcessingEvent}.
    *
    * @param trigger
    *          event trigger
    * @param data
    *          event data, where the first data object is expected to be the resource's {@link org.eclipse.emf.common.util.URI} this event pertains to
    */
-  public ResourcePostProcessingEvent(final Trigger trigger, final Object... data) {
+  public ResourceMarkersPostProcessingEvent(final Trigger trigger, final Object... data) {
     super(trigger, data);
   }
 

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/tracing/ResourceProcessingEvent.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/tracing/ResourceProcessingEvent.java
@@ -19,7 +19,7 @@ import com.avaloq.tools.ddk.xtext.tracing.ResourceEvent;
 public class ResourceProcessingEvent extends ResourceEvent {
 
   /**
-   * Creates a new instance of {@link ResourcePostProcessingEvent}.
+   * Creates a new instance of {@link ResourceProcessingEvent}.
    *
    * @param trigger
    *          event trigger


### PR DESCRIPTION
It wasn't used anymore, therefore renamed to
ResourceMarkersPostProcessingEvent, which will correspond to
post-processing of the validation results. For example - filtering out
the suppressed markers and adding TODO ones.