### PR TITLE
Wrap load exceptions for resources not enabled for parallel loading 

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
@@ -240,7 +240,15 @@ public class ParallelResourceLoader extends AbstractResourceLoader {
         Resource resource = result.getSecond();
         if (resource == null) {
           // null when parallel loading is not supported
-          resource = parent.getResource(uri, true);
+          try {
+            resource = parent.getResource(uri, true);
+          } catch (WrappedException e) {
+            throw new LoadOperationException(uri, e.exception());
+            // CHECKSTYLE:OFF
+          } catch (Exception e) {
+            // CHECKSTYLE:ON
+            throw new LoadOperationException(uri, e);
+          }
         }
         return new LoadResult(resource, uri);
       } finally {


### PR DESCRIPTION
If parallel loading is not supported for a resource type, then errors
loading such resources are propagated to consumers without being wrapped
in a LoadOperationException. This change makes the behavior more
consistent.