### PR TITLE
Do not replace uriResouceMap in ResourceSet in RebuildingXtextBuilder

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/RebuildingXtextBuilder.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/RebuildingXtextBuilder.java
@@ -168,7 +168,7 @@ public class RebuildingXtextBuilder extends XtextBuilder {
 
       ResourceSet resourceSet = getResourceSetProvider().get(getProject());
       resourceSet.getLoadOptions().put(ResourceDescriptionsProvider.NAMED_BUILDER_SCOPE, Boolean.TRUE);
-      if (resourceSet instanceof ResourceSetImpl) {
+      if (resourceSet instanceof ResourceSetImpl && ((ResourceSetImpl) resourceSet).getURIResourceMap() == null) {
         ((ResourceSetImpl) resourceSet).setURIResourceMap(Maps.<URI, Resource> newHashMap());
       }
       BuildData buildData = new BuildData(getProject().getName(), resourceSet, toBeBuilt, queuedBuildData);
@@ -200,4 +200,3 @@ public class RebuildingXtextBuilder extends XtextBuilder {
     }
   }
 }
-


### PR DESCRIPTION
Before this change, the RebuildingXtextBuilder set the uriResourceMap in
the resource set it uses unconditionally. This can cause problems if
this map was already initialised elsewhere (e.g. to use soft or weak
references). This change adds a check to avoid replacing the
uriResourceMap.