### PR TITLE
Add a generic Resource Set Cache Adapter which uses Strong References

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/CacheAdapter.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/CacheAdapter.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.resource;
 
+import java.util.function.Function;
+
 import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
 
@@ -25,34 +27,43 @@ import com.avaloq.tools.ddk.caching.MapCache;
  *          the type of the stored values
  */
 public class CacheAdapter<V> extends AdapterImpl implements IResourceSetCache<V> {
-  private final MapCache<Object, V> cache = CacheManager.getInstance().createMapCache("CacheAdapter#cache", new CacheConfiguration().useSoftValues()); //$NON-NLS-1$
+  private final MapCache<Object, V> cache;
 
-  /** {@inheritDoc} */
+  public CacheAdapter(final CacheConfiguration configuration) {
+    cache = CacheManager.getInstance().createMapCache("CacheAdapter#cache", configuration); //$NON-NLS-1$ ;
+  }
+
   @Override
   public V get(final Object key) {
     return cache.get(key);
   }
 
-  /** {@inheritDoc} */
   @Override
   public void put(final Object key, final V scope) {
     cache.put(key, scope);
   }
 
-  /** {@inheritDoc} */
+  @Override
+  public V putIfAbsent(final Object key, final V scope) {
+    return cache.putIfAbsent(key, scope);
+  }
+
+  @Override
+  public V computeIfAbsent(final Object key, final Function<? super Object, ? extends V> mappingFunction) {
+    return cache.computeIfAbsent(key, mappingFunction);
+  }
+
   @Override
   public void clear() {
     cache.clear();
   }
 
-  /** {@inheritDoc} */
   @Override
   public void setTarget(final Notifier newTarget) {
     clear();
     super.setTarget(newTarget);
   }
 
-  /** {@inheritDoc} */
   @Override
   public boolean isAdapterForType(final Object type) {
     if (type instanceof Class<?>) {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/IResourceSetCache.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/IResourceSetCache.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.resource;
 
+import java.util.function.Function;
+
+
 /**
  * A cache for generic objects that is intended to be used in adapters for resource sets.
  *
@@ -36,6 +39,41 @@ public interface IResourceSetCache<V> {
    *          the value, may be {@code null}
    */
   void put(Object key, V value);
+
+  /**
+   * If the specified key is not already associated with a value (or is mapped
+   * to {@code null}) associates it with the given value and returns
+   * {@code null}, else returns the current value.
+   *
+   * @param key
+   *          key with which the specified value is to be associated
+   * @param value
+   *          value to be associated with the specified key
+   * @return the previous value associated with the specified key, or
+   *         {@code null} if there was no mapping for the key.
+   *         (A {@code null} return can also indicate that the map
+   *         previously associated {@code null} with the key,
+   *         if the implementation supports null values.)
+   */
+  V putIfAbsent(final Object key, final V value);
+
+  /**
+   * If the specified key is not already associated with a value (or is mapped
+   * to {@code null}), attempts to compute its value using the given mapping
+   * function and enters it into this map unless {@code null}.
+   * <p>
+   * If the function returns {@code null} no mapping is recorded. If
+   * the function itself throws an (unchecked) exception, the
+   * exception is rethrown, and no mapping is recorded.
+   *
+   * @param key
+   *          key with which the specified value is to be associated
+   * @param mappingFunction
+   *          the function to compute a value
+   * @return the current (existing or computed) value associated with
+   *         the specified key, or null if the computed value is null
+   */
+  V computeIfAbsent(Object key, Function<? super Object, ? extends V> mappingFunction);
 
   /**
    * Clears the cache.

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/ScopeCacheAdapter.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/ScopeCacheAdapter.java
@@ -12,10 +12,16 @@ package com.avaloq.tools.ddk.xtext.scoping;
 
 import org.eclipse.xtext.scoping.IScope;
 
+import com.avaloq.tools.ddk.caching.CacheConfiguration;
 import com.avaloq.tools.ddk.xtext.resource.CacheAdapter;
 
 
 /**
  * A cache adapter for {@link IScope}s.
  */
-public class ScopeCacheAdapter extends CacheAdapter<IScope> implements IResourceSetScopeCache {}
+public class ScopeCacheAdapter extends CacheAdapter<IScope> implements IResourceSetScopeCache {
+
+  public ScopeCacheAdapter(final CacheConfiguration configuration) {
+    super(configuration);
+  }
+}


### PR DESCRIPTION
Introduce a generic resource set cache adapter which uses strong
references.

In addition a method putIfAbsent and computeIfAbsent have been added to
the CacheAdapter, to offer this new Java API of the Map class also to
the users of the CacheAdapter.