### PR TITLE
Introduce interface IDynamicDefaultPackageSetupService

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/build/IDynamicDefaultPackageSetupService.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/build/IDynamicDefaultPackageSetupService.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.build;
+
+/**
+ * This interface is used when a default package needs to be initialized.
+ */
+public interface IDynamicDefaultPackageSetupService {
+
+  /**
+   * Returns the name of the package.
+   *
+   * @return the name
+   */
+  String getPackageName();
+
+  /**
+   * Initialize package.
+   */
+  void doPackageSetup();
+
+}


### PR DESCRIPTION
Through introduction of this interface a builder can get all implementations of
this service and call the "doPackageSetup" method which performs the
package initialization.

Closes #301