### PR TITLE
Fix for NullPointerException in DirectLinkingResourceStorageLoadable. 

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
@@ -97,6 +97,8 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
     } catch (IOException | RuntimeException e) {
       // CHECKSTYLE:ON
       LOG.info("Error loading " + resource.getURI() + " from binary storage", e); //$NON-NLS-1$ //$NON-NLS-2$
+      resource.getContents();
+      resource.eAdapters();
       if (e instanceof IOException) { // NOPMD
         throw e;
       }


### PR DESCRIPTION
initialization done by calling resource.getContents() and resource.eAdapters()