### PR TITLE
Fix broken link to Xpand 2.0.0

### DIFF
--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -1,28 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="DDK Target" sequenceNumber="11">
+<?pde version="3.8"?><target name="DDK Target" sequenceNumber="9">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.xpand.feature.group" version="2.0.0.v201406030414"/>
-<repository location="https://download.eclipse.org/modeling/m2t/xpand/updates/releases/R201406030414/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.pde.source.feature.group" version="3.12.3.v20170301-0400"/>
-<unit id="org.eclipse.jdt.source.feature.group" version="3.12.3.v20170301-0400"/>
-<unit id="org.eclipse.platform.feature.group" version="4.6.3.v20170301-0400"/>
-<unit id="org.eclipse.platform.source.feature.group" version="4.6.3.v20170301-0400"/>
-<repository location="http://download.eclipse.org/releases/neon/201705151400/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.emf.codegen.ecore.ui.feature.group" version="2.10.0.v20150123-0452"/>
-<repository location="http://download.eclipse.org/modeling/emf/emf/updates/2.10.x/core/S201501230452/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.mockito" version="1.9.5.v201605172210"/>
-<unit id="org.mockito.source" version="1.9.5.v201605172210"/>
-<unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
-<unit id="org.hamcrest.text" version="1.1.0.v20090501071000"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
-</location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="0.0.0"/>
@@ -32,9 +10,31 @@
 <repository location="http://download.eclipse.org/technology/swtbot/releases/2.5.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.mockito" version="1.9.5.v201605172210"/>
+<unit id="org.mockito.source" version="1.9.5.v201605172210"/>
+<unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+<unit id="org.hamcrest.text" version="1.1.0.v20090501071000"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.pde.source.feature.group" version="3.12.3.v20170301-0400"/>
+<unit id="org.eclipse.jdt.source.feature.group" version="3.12.3.v20170301-0400"/>
+<unit id="org.eclipse.platform.feature.group" version="4.6.3.v20170301-0400"/>
+<unit id="org.eclipse.platform.source.feature.group" version="4.6.3.v20170301-0400"/>
+<repository location="http://download.eclipse.org/releases/neon/201705151400/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xtend.sdk.feature.group" version="2.14.0.v20180523-0937"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="2.14.0.v20180523-0937"/>
 <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.14.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.emf.codegen.ecore.ui.feature.group" version="2.10.0.v20150123-0452"/>
+<repository location="http://download.eclipse.org/modeling/emf/emf/updates/2.10.x/core/S201501230452/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.xpand.sdk.feature.group" version="2.0.0.v201406030414"/>
+<repository location="https://download.eclipse.org/modeling/m2t/xpand/updates/releases/R201406030414/"/>
 </location>
 </locations>
 </target>

--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="DDK Target" sequenceNumber="9">
+<?pde version="3.8"?><target name="DDK Target" sequenceNumber="11">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.swtbot.ide.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/technology/swtbot/releases/2.5.0/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.mockito" version="1.9.5.v201605172210"/>
-<unit id="org.mockito.source" version="1.9.5.v201605172210"/>
-<unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
-<unit id="org.hamcrest.text" version="1.1.0.v20090501071000"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
+<unit id="org.eclipse.xpand.feature.group" version="2.0.0.v201406030414"/>
+<repository location="https://download.eclipse.org/modeling/m2t/xpand/updates/releases/R201406030414/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.pde.source.feature.group" version="3.12.3.v20170301-0400"/>
@@ -24,17 +13,28 @@
 <repository location="http://download.eclipse.org/releases/neon/201705151400/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.xtend.sdk.feature.group" version="2.14.0.v20180523-0937"/>
-<unit id="org.eclipse.xtext.sdk.feature.group" version="2.14.0.v20180523-0937"/>
-<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.14.0/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.codegen.ecore.ui.feature.group" version="2.10.0.v20150123-0452"/>
 <repository location="http://download.eclipse.org/modeling/emf/emf/updates/2.10.x/core/S201501230452/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.xpand.sdk.feature.group" version="2.0.0.v201406030414"/>
-<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/xpand/R201406030414/"/>
+<unit id="org.mockito" version="1.9.5.v201605172210"/>
+<unit id="org.mockito.source" version="1.9.5.v201605172210"/>
+<unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
+<unit id="org.hamcrest.text" version="1.1.0.v20090501071000"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.swtbot.ide.feature.group" version="0.0.0"/>
+<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/2.5.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.xtend.sdk.feature.group" version="2.14.0.v20180523-0937"/>
+<unit id="org.eclipse.xtext.sdk.feature.group" version="2.14.0.v20180523-0937"/>
+<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.14.0/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
The location we use for Xpand 2.0.0 in the DDK target broke some time ago - this change fixes it.