### PR TITLE
Support Case Sensitive and Insensitive fragments

### DIFF
--- a/com.avaloq.tools.ddk.typesystem/model/TypeModel.ecore
+++ b/com.avaloq.tools.ddk.typesystem/model/TypeModel.ecore
@@ -17,6 +17,8 @@
       <details key="documentation" value="The reason for this class is technical and,  in general, one should use the interface INamedElement instead&#xD;&#xA;of this class. This class is defined in the model because Xtext needs to find an instantiable class for&#xD;&#xA;INamedElement during the first phase of linking."/>
     </eAnnotations>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ICaseSensitiveNamedElement" abstract="true"
+      interface="true"/>
   <eClassifiers xsi:type="ecore:EClass" name="INamedType" abstract="true" interface="true"
       eSuperTypes="#//INamedElement #//IType"/>
   <eClassifiers xsi:type="ecore:EClass" name="NamedType" eSuperTypes="#//NamedElement #//INamedType">

--- a/com.avaloq.tools.ddk.typesystem/model/TypeModel.genmodel
+++ b/com.avaloq.tools.ddk.typesystem/model/TypeModel.genmodel
@@ -22,6 +22,7 @@
       <genOperations ecoreOperation="TypeModel.ecore#//OverrideDeclaration/isOverride"/>
     </genClasses>
     <genClasses ecoreClass="TypeModel.ecore#//NamedElement"/>
+    <genClasses image="false" ecoreClass="TypeModel.ecore#//ICaseSensitiveNamedElement"/>
     <genClasses image="false" ecoreClass="TypeModel.ecore#//INamedType"/>
     <genClasses ecoreClass="TypeModel.ecore#//NamedType"/>
     <genClasses image="false" ecoreClass="TypeModel.ecore#//IFormalParameter">

--- a/com.avaloq.tools.ddk.typesystem/plugin.properties
+++ b/com.avaloq.tools.ddk.typesystem/plugin.properties
@@ -34,3 +34,4 @@ _UI_Procedure_eparameters_feature = Eparameters
 _UI_OverrideDeclaration_type = Override Declaration
 _UI_ICallable_type = ICallable
 _UI_Callable_type = Callable
+_UI_ICaseSensitiveNamedElement_type = ICase Sensitive Named Element

--- a/com.avaloq.tools.ddk.typesystem/src-gen/com/avaloq/tools/ddk/typesystem/typemodel/ICaseSensitiveNamedElement.java
+++ b/com.avaloq.tools.ddk.typesystem/src-gen/com/avaloq/tools/ddk/typesystem/typemodel/ICaseSensitiveNamedElement.java
@@ -1,0 +1,19 @@
+/**
+ */
+package com.avaloq.tools.ddk.typesystem.typemodel;
+
+import org.eclipse.emf.ecore.EObject;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>ICase Sensitive Named Element</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ *
+ * @see com.avaloq.tools.ddk.typesystem.typemodel.TypeModelPackage#getICaseSensitiveNamedElement()
+ * @model interface="true" abstract="true"
+ * @generated
+ */
+public interface ICaseSensitiveNamedElement extends EObject
+{
+} // ICaseSensitiveNamedElement

--- a/com.avaloq.tools.ddk.typesystem/src-gen/com/avaloq/tools/ddk/typesystem/typemodel/TypeModelPackage.java
+++ b/com.avaloq.tools.ddk.typesystem/src-gen/com/avaloq/tools/ddk/typesystem/typemodel/TypeModelPackage.java
@@ -150,6 +150,25 @@ public interface TypeModelPackage extends EPackage
 	int NAMED_ELEMENT_FEATURE_COUNT = INAMED_ELEMENT_FEATURE_COUNT + 0;
 
 	/**
+	 * The meta object id for the '{@link com.avaloq.tools.ddk.typesystem.typemodel.ICaseSensitiveNamedElement <em>ICase Sensitive Named Element</em>}' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see com.avaloq.tools.ddk.typesystem.typemodel.ICaseSensitiveNamedElement
+	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getICaseSensitiveNamedElement()
+	 * @generated
+	 */
+	int ICASE_SENSITIVE_NAMED_ELEMENT = 5;
+
+	/**
+	 * The number of structural features of the '<em>ICase Sensitive Named Element</em>' class.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int ICASE_SENSITIVE_NAMED_ELEMENT_FEATURE_COUNT = 0;
+
+	/**
 	 * The meta object id for the '{@link com.avaloq.tools.ddk.typesystem.typemodel.INamedType <em>INamed Type</em>}' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -157,7 +176,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getINamedType()
 	 * @generated
 	 */
-	int INAMED_TYPE = 5;
+	int INAMED_TYPE = 6;
 
 	/**
 	 * The number of structural features of the '<em>INamed Type</em>' class.
@@ -176,7 +195,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getNamedType()
 	 * @generated
 	 */
-	int NAMED_TYPE = 6;
+	int NAMED_TYPE = 7;
 
 	/**
 	 * The number of structural features of the '<em>Named Type</em>' class.
@@ -195,7 +214,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getIFormalParameter()
 	 * @generated
 	 */
-	int IFORMAL_PARAMETER = 7;
+	int IFORMAL_PARAMETER = 8;
 
 	/**
 	 * The number of structural features of the '<em>IFormal Parameter</em>' class.
@@ -214,7 +233,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getIActualParameter()
 	 * @generated
 	 */
-	int IACTUAL_PARAMETER = 8;
+	int IACTUAL_PARAMETER = 9;
 
 	/**
 	 * The number of structural features of the '<em>IActual Parameter</em>' class.
@@ -233,7 +252,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getINamedActualParameter()
 	 * @generated
 	 */
-	int INAMED_ACTUAL_PARAMETER = 9;
+	int INAMED_ACTUAL_PARAMETER = 10;
 
 	/**
 	 * The number of structural features of the '<em>INamed Actual Parameter</em>' class.
@@ -252,7 +271,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getICallable()
 	 * @generated
 	 */
-	int ICALLABLE = 16;
+	int ICALLABLE = 17;
 
 	/**
 	 * The number of structural features of the '<em>ICallable</em>' class.
@@ -271,7 +290,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getISubprogram()
 	 * @generated
 	 */
-	int ISUBPROGRAM = 10;
+	int ISUBPROGRAM = 11;
 
 	/**
 	 * The number of structural features of the '<em>ISubprogram</em>' class.
@@ -290,7 +309,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getIProcedure()
 	 * @generated
 	 */
-	int IPROCEDURE = 11;
+	int IPROCEDURE = 12;
 
 	/**
 	 * The number of structural features of the '<em>IProcedure</em>' class.
@@ -309,7 +328,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getIFunction()
 	 * @generated
 	 */
-	int IFUNCTION = 12;
+	int IFUNCTION = 13;
 
 	/**
 	 * The number of structural features of the '<em>IFunction</em>' class.
@@ -328,7 +347,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getIFormalParameterList()
 	 * @generated
 	 */
-	int IFORMAL_PARAMETER_LIST = 13;
+	int IFORMAL_PARAMETER_LIST = 14;
 
 	/**
 	 * The number of structural features of the '<em>IFormal Parameter List</em>' class.
@@ -347,7 +366,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getNamedFormalParameter()
 	 * @generated
 	 */
-	int NAMED_FORMAL_PARAMETER = 14;
+	int NAMED_FORMAL_PARAMETER = 15;
 
 	/**
 	 * The number of structural features of the '<em>Named Formal Parameter</em>' class.
@@ -366,7 +385,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getINamedFormalParameter()
 	 * @generated
 	 */
-	int INAMED_FORMAL_PARAMETER = 15;
+	int INAMED_FORMAL_PARAMETER = 16;
 
 	/**
 	 * The number of structural features of the '<em>INamed Formal Parameter</em>' class.
@@ -385,7 +404,7 @@ public interface TypeModelPackage extends EPackage
 	 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getCallable()
 	 * @generated
 	 */
-	int CALLABLE = 17;
+	int CALLABLE = 18;
 
 	/**
 	 * The number of structural features of the '<em>Callable</em>' class.
@@ -446,6 +465,16 @@ public interface TypeModelPackage extends EPackage
 	 * @generated
 	 */
 	EClass getNamedElement();
+
+	/**
+	 * Returns the meta object for class '{@link com.avaloq.tools.ddk.typesystem.typemodel.ICaseSensitiveNamedElement <em>ICase Sensitive Named Element</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for class '<em>ICase Sensitive Named Element</em>'.
+	 * @see com.avaloq.tools.ddk.typesystem.typemodel.ICaseSensitiveNamedElement
+	 * @generated
+	 */
+	EClass getICaseSensitiveNamedElement();
 
 	/**
 	 * Returns the meta object for class '{@link com.avaloq.tools.ddk.typesystem.typemodel.INamedType <em>INamed Type</em>}'.
@@ -650,6 +679,16 @@ public interface TypeModelPackage extends EPackage
 		 * @generated
 		 */
 		EClass NAMED_ELEMENT = eINSTANCE.getNamedElement();
+
+		/**
+		 * The meta object literal for the '{@link com.avaloq.tools.ddk.typesystem.typemodel.ICaseSensitiveNamedElement <em>ICase Sensitive Named Element</em>}' class.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see com.avaloq.tools.ddk.typesystem.typemodel.ICaseSensitiveNamedElement
+		 * @see com.avaloq.tools.ddk.typesystem.typemodel.impl.TypeModelPackageImpl#getICaseSensitiveNamedElement()
+		 * @generated
+		 */
+		EClass ICASE_SENSITIVE_NAMED_ELEMENT = eINSTANCE.getICaseSensitiveNamedElement();
 
 		/**
 		 * The meta object literal for the '{@link com.avaloq.tools.ddk.typesystem.typemodel.INamedType <em>INamed Type</em>}' class.

--- a/com.avaloq.tools.ddk.typesystem/src-gen/com/avaloq/tools/ddk/typesystem/typemodel/impl/TypeModelPackageImpl.java
+++ b/com.avaloq.tools.ddk.typesystem/src-gen/com/avaloq/tools/ddk/typesystem/typemodel/impl/TypeModelPackageImpl.java
@@ -5,6 +5,7 @@ package com.avaloq.tools.ddk.typesystem.typemodel.impl;
 import com.avaloq.tools.ddk.typesystem.typemodel.Callable;
 import com.avaloq.tools.ddk.typesystem.typemodel.IActualParameter;
 import com.avaloq.tools.ddk.typesystem.typemodel.ICallable;
+import com.avaloq.tools.ddk.typesystem.typemodel.ICaseSensitiveNamedElement;
 import com.avaloq.tools.ddk.typesystem.typemodel.IExpression;
 import com.avaloq.tools.ddk.typesystem.typemodel.IFormalParameter;
 import com.avaloq.tools.ddk.typesystem.typemodel.IFunction;
@@ -69,6 +70,13 @@ public class TypeModelPackageImpl extends EPackageImpl implements TypeModelPacka
 	 * @generated
 	 */
 	private EClass namedElementEClass = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EClass iCaseSensitiveNamedElementEClass = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -279,6 +287,16 @@ public class TypeModelPackageImpl extends EPackageImpl implements TypeModelPacka
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EClass getICaseSensitiveNamedElement()
+	{
+		return iCaseSensitiveNamedElementEClass;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EClass getINamedType()
 	{
 		return iNamedTypeEClass;
@@ -444,6 +462,8 @@ public class TypeModelPackageImpl extends EPackageImpl implements TypeModelPacka
 
 		namedElementEClass = createEClass(NAMED_ELEMENT);
 
+		iCaseSensitiveNamedElementEClass = createEClass(ICASE_SENSITIVE_NAMED_ELEMENT);
+
 		iNamedTypeEClass = createEClass(INAMED_TYPE);
 
 		namedTypeEClass = createEClass(NAMED_TYPE);
@@ -534,6 +554,8 @@ public class TypeModelPackageImpl extends EPackageImpl implements TypeModelPacka
 		addEOperation(overrideDeclarationEClass, ecorePackage.getEBoolean(), "isOverride", 0, 1, IS_UNIQUE, IS_ORDERED);
 
 		initEClass(namedElementEClass, NamedElement.class, "NamedElement", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+
+		initEClass(iCaseSensitiveNamedElementEClass, ICaseSensitiveNamedElement.class, "ICaseSensitiveNamedElement", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
 		initEClass(iNamedTypeEClass, INamedType.class, "INamedType", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 

--- a/com.avaloq.tools.ddk.typesystem/src-gen/com/avaloq/tools/ddk/typesystem/typemodel/util/TypeModelAdapterFactory.java
+++ b/com.avaloq.tools.ddk.typesystem/src-gen/com/avaloq/tools/ddk/typesystem/typemodel/util/TypeModelAdapterFactory.java
@@ -100,6 +100,11 @@ public class TypeModelAdapterFactory extends AdapterFactoryImpl
 				return createNamedElementAdapter();
 			}
 			@Override
+			public Adapter caseICaseSensitiveNamedElement(ICaseSensitiveNamedElement object)
+			{
+				return createICaseSensitiveNamedElementAdapter();
+			}
+			@Override
 			public Adapter caseINamedType(INamedType object)
 			{
 				return createINamedTypeAdapter();
@@ -257,6 +262,21 @@ public class TypeModelAdapterFactory extends AdapterFactoryImpl
 	 * @generated
 	 */
 	public Adapter createNamedElementAdapter()
+	{
+		return null;
+	}
+
+	/**
+	 * Creates a new adapter for an object of class '{@link com.avaloq.tools.ddk.typesystem.typemodel.ICaseSensitiveNamedElement <em>ICase Sensitive Named Element</em>}'.
+	 * <!-- begin-user-doc -->
+	 * This default implementation returns null so that we can easily ignore cases;
+	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
+	 * <!-- end-user-doc -->
+	 * @return the new adapter.
+	 * @see com.avaloq.tools.ddk.typesystem.typemodel.ICaseSensitiveNamedElement
+	 * @generated
+	 */
+	public Adapter createICaseSensitiveNamedElementAdapter()
 	{
 		return null;
 	}

--- a/com.avaloq.tools.ddk.typesystem/src-gen/com/avaloq/tools/ddk/typesystem/typemodel/util/TypeModelSwitch.java
+++ b/com.avaloq.tools.ddk.typesystem/src-gen/com/avaloq/tools/ddk/typesystem/typemodel/util/TypeModelSwitch.java
@@ -109,6 +109,13 @@ public class TypeModelSwitch<T> extends Switch<T>
 				if (result == null) result = defaultCase(theEObject);
 				return result;
 			}
+			case TypeModelPackage.ICASE_SENSITIVE_NAMED_ELEMENT:
+			{
+				ICaseSensitiveNamedElement iCaseSensitiveNamedElement = (ICaseSensitiveNamedElement)theEObject;
+				T result = caseICaseSensitiveNamedElement(iCaseSensitiveNamedElement);
+				if (result == null) result = defaultCase(theEObject);
+				return result;
+			}
 			case TypeModelPackage.INAMED_TYPE:
 			{
 				INamedType iNamedType = (INamedType)theEObject;
@@ -305,6 +312,22 @@ public class TypeModelSwitch<T> extends Switch<T>
 	 * @generated
 	 */
 	public T caseNamedElement(NamedElement object)
+	{
+		return null;
+	}
+
+	/**
+	 * Returns the result of interpreting the object as an instance of '<em>ICase Sensitive Named Element</em>'.
+	 * <!-- begin-user-doc -->
+	 * This implementation returns null;
+	 * returning a non-null result will terminate the switch.
+	 * <!-- end-user-doc -->
+	 * @param object the target of the switch.
+	 * @return the result of interpreting the object as an instance of '<em>ICase Sensitive Named Element</em>'.
+	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+	 * @generated
+	 */
+	public T caseICaseSensitiveNamedElement(ICaseSensitiveNamedElement object)
 	{
 		return null;
 	}

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractSelectorFragmentProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractSelectorFragmentProvider.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.resource;
 
-import java.util.concurrent.ConcurrentMap;
+import java.util.Map;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
@@ -42,7 +42,7 @@ public abstract class AbstractSelectorFragmentProvider extends AbstractFragmentP
   @Inject
   private ShortFragmentProvider shortFragmentProvider;
 
-  private final ConcurrentMap<Object, Object> eclassToCaseSensitive = Maps.newConcurrentMap();
+  private final Map<Object, Object> eClassToCaseSensitive = Maps.newHashMap();
 
   /**
    * Computes a segment of the fragment with a selector for the given object and appends it to the given {@link StringBuilder}.
@@ -125,7 +125,7 @@ public abstract class AbstractSelectorFragmentProvider extends AbstractFragmentP
   }
 
   private Boolean isCaseSensitive(final EClass eClass) {
-    return (Boolean) eclassToCaseSensitive.computeIfAbsent(eClass, k -> eClass.getEAllSuperTypes().stream().map(EClass::getName).anyMatch(n -> "ICaseSensitiveNamedElement".equals(n))); //$NON-NLS-1$
+    return (Boolean) eClassToCaseSensitive.computeIfAbsent(eClass, k -> eClass.getEAllSuperTypes().stream().map(EClass::getName).anyMatch(n -> "ICaseSensitiveNamedElement".equals(n))); //$NON-NLS-1$
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
Support Case Sensitive and Insensitive fragments by adding a new marker
interface EClass ICaseSensitiveNamedElemnt.

By default, when selecting the fragments, it is considered that the
fragment is case insensitive unless the EClass inherits from the new
marker interface.

Change-Id: I81cd2654089d0a320a5632d2f7054b6cd5a84c46