### PR TITLE
Fixes for when to load associations from the binary model.

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
@@ -271,9 +271,9 @@ public class InferredModelAssociator implements IInferredModelAssociations, IInf
       unloader.unloadRoot(eObject);
       derived.add(eObject);
     }
-    resourcesContentsList.removeAll(derived);
     getSourceToInferredModelMap(resource).clear();
     getInferredModelToSourceMap(resource).clear();
+    resourcesContentsList.removeAll(derived);
   }
 
   private static <K, V> Map<K, V> newLinkedHashMapWithCapacity(final int capacity) {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyModelAssociationsAdapter.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyModelAssociationsAdapter.java
@@ -36,7 +36,7 @@ final class ProxyModelAssociationsAdapter extends InferredModelAssociator.Adapte
 
   /**
    * Installs a {@link ProxyModelAssociationsAdapter} unless the given resource already has an {@link InferredModelAssociator.Adapter}.
-   * 
+   *
    * @param resource
    *          resource to add adapter to, must not be {@code null}
    */
@@ -50,30 +50,32 @@ final class ProxyModelAssociationsAdapter extends InferredModelAssociator.Adapte
 
   @Override
   public Map<EObject, Deque<EObject>> getSourceToInferredModelMap() {
-    DirectLinkingResourceStorageLoadable loadable = (DirectLinkingResourceStorageLoadable) ((DirectLinkingResourceStorageFacade) resource.getResourceStorageFacade()).getOrCreateResourceStorageLoadable(resource);
-    try {
-      uninstall();
-      loadable.loadIntoResource(resource, ResourceLoadMode.ONLY_ASSOCIATIONS);
-    } catch (IOException e) {
-      throw new WrappedException(e);
+    if (uninstall()) {
+      DirectLinkingResourceStorageLoadable loadable = (DirectLinkingResourceStorageLoadable) ((DirectLinkingResourceStorageFacade) resource.getResourceStorageFacade()).getOrCreateResourceStorageLoadable(resource);
+      try {
+        loadable.loadIntoResource(resource, ResourceLoadMode.ONLY_ASSOCIATIONS);
+      } catch (IOException e) {
+        throw new WrappedException(e);
+      }
     }
     return ((InferredModelAssociator.Adapter) EcoreUtil.getAdapter(resource.eAdapters(), InferredModelAssociator.Adapter.class)).getSourceToInferredModelMap();
   }
 
   @Override
   public Map<EObject, Deque<EObject>> getInferredModelToSourceMap() {
-    DirectLinkingResourceStorageLoadable loadable = (DirectLinkingResourceStorageLoadable) ((DirectLinkingResourceStorageFacade) resource.getResourceStorageFacade()).getOrCreateResourceStorageLoadable(resource);
-    try {
-      uninstall();
-      loadable.loadIntoResource(resource, ResourceLoadMode.ONLY_ASSOCIATIONS);
-    } catch (IOException e) {
-      throw new WrappedException(e);
+    if (uninstall()) {
+      DirectLinkingResourceStorageLoadable loadable = (DirectLinkingResourceStorageLoadable) ((DirectLinkingResourceStorageFacade) resource.getResourceStorageFacade()).getOrCreateResourceStorageLoadable(resource);
+      try {
+        loadable.loadIntoResource(resource, ResourceLoadMode.ONLY_ASSOCIATIONS);
+      } catch (IOException e) {
+        throw new WrappedException(e);
+      }
     }
     return ((InferredModelAssociator.Adapter) EcoreUtil.getAdapter(resource.eAdapters(), InferredModelAssociator.Adapter.class)).getInferredModelToSourceMap();
   }
 
-  private void uninstall() {
-    resource.eAdapters().remove(this);
+  private boolean uninstall() {
+    return resource.eAdapters().remove(this);
   }
 
 }


### PR DESCRIPTION
This includes the following specific fixes:
* When the derived state is discarded, clear the association maps before
removing the derived state because the state needs to exist if the maps
have not been loaded until that point.
* If the proxy associations adapter is not on the resource at the point
when the associations are loaded, then it means that the associations
have already been loaded by a different resource, so there is no need to
load them again.