### PR TITLE
added a guard to prevent calling reference.isMany() when reference is null

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/ShortFragmentProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/ShortFragmentProvider.java
@@ -51,6 +51,9 @@ public class ShortFragmentProvider extends AbstractFragmentProvider {
       featureId = Integer.parseUnsignedInt(segment.substring(0, listSeparatorIndex));
     }
     final EReference reference = (EReference) container.eClass().getEStructuralFeature(featureId);
+    if (reference == null) {
+      return null;
+    }
     if (reference.isMany()) {
       if (listSeparatorIndex == -1) {
         // if the model expects a list but the uri does not provide a listIndex, or the model changed and the URI is outdated,


### PR DESCRIPTION
NPE occurs when the ShortFragmentProvider hits a StringLiteral which has no reference object (this happens when the source is setup like the reproducer).