### PR TITLE
Revert "Upgrade to Xtext 2.21"

### DIFF
--- a/com.avaloq.tools.ddk.check.core/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.check.core/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.xbase.lib,
  com.avaloq.tools.ddk.xtext,
  org.apache.commons.lang,
- org.objectweb.asm;resolution:=optional
+ org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Export-Package: com.avaloq.tools.ddk.check,
  com.avaloq.tools.ddk.check.check,
  com.avaloq.tools.ddk.check.check.impl,

--- a/com.avaloq.tools.ddk.check.ui.test/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.check.ui.test/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle: org.junit,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,
- org.objectweb.asm;resolution:=optional
+ org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Export-Package: com.avaloq.tools.ddk.check.ui.test,
  com.avaloq.tools.ddk.check.ui.test.util,
  com.avaloq.tools.ddk.check

--- a/com.avaloq.tools.ddk.checkcfg.core.test/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.checkcfg.core.test/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: com.avaloq.tools.ddk.test.core,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.ui.workbench;resolution:=optional,
  org.apache.log4j,
- org.objectweb.asm;resolution:=optional
+ org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Import-Package: org.hamcrest.core,
  org.junit.runner;version="4.5.0",
  org.junit.runner.manipulation;version="4.5.0",

--- a/com.avaloq.tools.ddk.checkcfg.core/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.checkcfg.core/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle: org.eclipse.xtext,
  com.avaloq.tools.ddk.check.runtime.core,
  org.eclipse.xtext.xbase.lib,
  org.apache.log4j,
- org.objectweb.asm;resolution:=optional
+ org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Export-Package: com.avaloq.tools.ddk.checkcfg,
  com.avaloq.tools.ddk.checkcfg.checkcfg,
  com.avaloq.tools.ddk.checkcfg.checkcfg.impl,

--- a/com.avaloq.tools.ddk.xtext.format/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.format/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.common.types,
  org.eclipse.xtext.xbase,
  org.eclipse.xtext.xbase.lib,
- org.objectweb.asm;resolution:=optional
+ org.objectweb.asm;bundle-version="[7.1.0,7.2.0)";resolution:=optional
 Import-Package: org.apache.log4j
 Export-Package: com.avaloq.tools.ddk.xtext.format,
  com.avaloq.tools.ddk.xtext.format.format,

--- a/com.avaloq.tools.ddk.xtext.generator/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.generator/META-INF/MANIFEST.MF
@@ -7,11 +7,10 @@ Bundle-Vendor: Avaloq Evolution AG
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.jface,
  org.eclipse.ui.views,
- org.eclipse.emf.codegen.ecore,
+ org.eclipse.emf.codegen.ecore.ui,
  org.eclipse.xpand,
  org.eclipse.xtext,
  org.eclipse.xtext.generator,
- org.eclipse.emf.mwe2.lib,
  org.eclipse.emf.mwe2.runtime,
  org.eclipse.xtext.ui,
  com.avaloq.tools.ddk.xtext,

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -52,8 +52,8 @@
     <deploy.version>2.8.2</deploy.version>
     <findbugs.plugin.version>3.0.4</findbugs.plugin.version><!-- Maven plug-in 3.0.4 uses FindBugs 3.0.1 -->
     <pmd.plugin.version>3.6</pmd.plugin.version><!-- Maven plug-in 3.6 uses PMD 5.3.5 -->
-    <tycho.version>1.6.0</tycho.version>
-    <xtend.version>2.21.0</xtend.version>
+    <tycho.version>1.4.0</tycho.version>
+    <xtend.version>2.19.0</xtend.version>
   </properties>
 
   <modules>

--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?>
-<target name="DDK Target" sequenceNumber="10">
+<?pde version="3.8"?><target name="DDK Target" sequenceNumber="9">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -27,13 +26,13 @@
 <repository location="https://download.eclipse.org/releases/2019-03/201903201000/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2020-12/202012161000/"/>
-<unit id="org.eclipse.emf.mwe2.runtime.sdk.feature.group" version="2.12.0.v20201119-2018"/>
+<unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="2.11.0.201906111547"/>
+<repository location="https://download.eclipse.org/releases/2019-09/201909181001/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.21.0/"/>
+<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.19.0/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
Reverts dsldevkit/dsl-devkit#390, it causes the following failure on Avaloq private Jenkins infrastracture.
[ERROR] Cannot resolve project dependencies:
[ERROR]   Software being installed: ddk-repository raw:7.4.0.'SNAPSHOT'/format(n[.n=0;[.n=0;[-S]]]):7.4.0-SNAPSHOT
[ERROR]   Missing requirement: com.avaloq.tools.ddk.source.feature.feature.group 7.4.0.qualifier requires 'org.eclipse.equinox.p2.iu; com.avaloq.tools.ddk.xtext.export.source 0.0.0' but it could not be found
[ERROR]   Cannot satisfy dependency: ddk-repository raw:7.4.0.'SNAPSHOT'/format(n[.n=0;[.n=0;[-S]]]):7.4.0-SNAPSHOT depends on: org.eclipse.equinox.p2.iu; com.avaloq.tools.ddk.source.feature.feature.group [7.4.0,7.4.1)
[ERROR] 
[ERROR] See http://wiki.eclipse.org/Tycho/Dependency_Resolution_Troubleshooting for help.
[ERROR] Cannot resolve dependencies of MavenProject: com.avaloq.tools.ddk:ddk-repository:7.4.0-SNAPSHOT @ D:\work\jenkins-slave\workspace\ddk-master-compile\ddk-repository\pom.xml: See log for details -> [Help 1]