### PR TITLE
Revert "Provide a default qualified name"

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/DefaultInferredElementFragmentProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/DefaultInferredElementFragmentProvider.java
@@ -78,11 +78,7 @@ public class DefaultInferredElementFragmentProvider implements IInferredElementF
    * @return qualified name or {@code null} if none can be derived
    */
   protected QualifiedName getQualifiedName(final EObject object) {
-    QualifiedName name = getQualifiedNameProvider().getFullyQualifiedName(object);
-    if (name != null) {
-      return name;
-    }
-    return QualifiedName.create(object.toString());
+    return getQualifiedNameProvider().getFullyQualifiedName(object);
   }
 
   protected IQualifiedNameProvider getQualifiedNameProvider() {


### PR DESCRIPTION
Reverts dsldevkit/dsl-devkit#397 as using object.toString() does not create framents which are stable when the object is deserialized and serialized again, breaking links to binary models.