### PR TITLE
Keep Sequence Number Suffix after call to addFragmentMapping

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/AbstractExportedNameProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/AbstractExportedNameProvider.java
@@ -18,7 +18,6 @@ import org.eclipse.xtext.util.IResourceScopeCache;
 import org.eclipse.xtext.util.Tuples;
 
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 
 
 /**
@@ -40,12 +39,7 @@ public abstract class AbstractExportedNameProvider extends IQualifiedNameProvide
    */
   @Override
   public QualifiedName getFullyQualifiedName(final EObject obj) {
-    return cache.get(Tuples.pair(obj, this.getClass()), obj.eResource(), new Provider<QualifiedName>() {
-      @Override
-      public QualifiedName get() {
-        return qualifiedName(obj);
-      }
-    });
+    return cache.get(Tuples.pair(obj, this.getClass()), obj.eResource(), () -> qualifiedName(obj));
   }
 
   /**


### PR DESCRIPTION
Keep the sequence number suffix of the last iteration after the call to
addFragmentMapping.

If the counter starts each time at one, the while loop will increment
the counter by one and check the fragmentToObjectMap for existence of
the newly generated key until it reaches the last computed index,
always. This algorithm of O(n^2) complexity is a problem since the
existence check on fragmentToObjectMap is relatively expensive. Since we
know that all the previous indexes have already been given, we can start
at the last free index.

In AbstractExportedNameProvider.getFullyQualifiedName(EObject) a small
code cleanup has been performed.