### PR TITLE
New utility method getScope in EObjectUtil

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AbstractPolymorphicScopeProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AbstractPolymorphicScopeProvider.java
@@ -212,11 +212,11 @@ public abstract class AbstractPolymorphicScopeProvider extends AbstractScopeProv
    * @return the scope
    */
   public IScope getScope(final EObject context, final EClass type) {
-    return getScope(context, type, null, context.eResource());
+    return getScope(context, type, null);
   }
 
   /**
-   * Gets the scope given a context object and an expected type, using the given scope name.
+   * Gets the scope given a context object and an expected type, using the given scope name and an original resource.
    *
    * @param context
    *          the context
@@ -233,6 +233,22 @@ public abstract class AbstractPolymorphicScopeProvider extends AbstractScopeProv
       registerForeignObject(context, (XtextResource) context.eResource(), originalResource);
     }
     final IScope result = internalGetScope(context, type, scopeName == null ? SCOPE_STRING : scopeName, originalResource);
+    return (result == null) ? IScope.NULLSCOPE : result;
+  }
+
+  /**
+   * Gets the scope given a context object and an expected type, using the given scope name.
+   *
+   * @param context
+   *          the context
+   * @param type
+   *          the type
+   * @param scopeName
+   *          the scope name
+   * @return the scope
+   */
+  public IScope getScope(final EObject context, final EClass type, final String scopeName) {
+    final IScope result = internalGetScope(context, type, scopeName == null ? SCOPE_STRING : scopeName, context.eResource());
     return (result == null) ? IScope.NULLSCOPE : result;
   }
 

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/util/EObjectUtil.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/util/EObjectUtil.java
@@ -11,16 +11,20 @@
 package com.avaloq.tools.ddk.xtext.util;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.linking.impl.DefaultLinkingService;
 import org.eclipse.xtext.linking.lazy.LazyLinkingResource;
 import org.eclipse.xtext.linking.lazy.LazyURIEncoder;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.scoping.IScope;
 import org.eclipse.xtext.scoping.IScopeProvider;
 
+import com.avaloq.tools.ddk.xtext.scoping.AbstractPolymorphicScopeProvider;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
@@ -30,6 +34,7 @@ import com.google.common.collect.Iterables;
  */
 public final class EObjectUtil {
 
+  private static final String WRONG_SCOPE_PROVIDER = "Scope provider can only be returned if given a LazyLinkingResource"; //$NON-NLS-1$
   /**
    * Predicate to filter out null and EMF proxy objects. I.e. only non-null and non-proxy objects pass this predicate.
    */
@@ -88,8 +93,28 @@ public final class EObjectUtil {
   }
 
   /**
-   * Gets the scope provider given an object part of a {@link org.eclipse.xtext.linking.lazy.LazyLinkingResource
-   * LazyLinkingResource}.
+   * Gets the scope given an object part of a {@link org.eclipse.xtext.linking.lazy.LazyLinkingResource}, a type and an optional scope name.
+   *
+   * @param object
+   *          the object, never {@code null}
+   * @param type
+   *          the type, never {@code null}
+   * @param scopeName
+   *          the scope name, may be {@code null}
+   * @return the scope provider by e object
+   */
+  public static IScope getScope(final EObject object, final EClass type, final String scopeName) {
+    Resource resource = object.eResource();
+    if (resource instanceof LazyLinkingResource) {
+      AbstractPolymorphicScopeProvider scopeProvider = (AbstractPolymorphicScopeProvider) getScopeProviderByResource((LazyLinkingResource) resource);
+      return scopeProvider.getScope(object, type, scopeName);
+    } else {
+      throw new IllegalArgumentException(WRONG_SCOPE_PROVIDER);
+    }
+  }
+
+  /**
+   * Gets the scope provider given an object part of a {@link org.eclipse.xtext.linking.lazy.LazyLinkingResource}.
    *
    * @param object
    *          the object
@@ -99,7 +124,7 @@ public final class EObjectUtil {
     if (object.eResource() instanceof LazyLinkingResource) {
       return getScopeProviderByResource((LazyLinkingResource) object.eResource());
     } else {
-      throw new IllegalArgumentException("Scope provider can only be returned if given a LazyLinkingResource"); //$NON-NLS-1$
+      throw new IllegalArgumentException(WRONG_SCOPE_PROVIDER);
     }
   }
 


### PR DESCRIPTION
Add an utility method getScope to EObjectUtil to avoid boilerplate on
consumers. In the end most of the consumers call the method
getScopeProviderByEObject to get the IScope, which requires casting the
return value to AbstractPolymorphicScopeProvider.