### PR TITLE
Added an EmptyAdapter in InferedModelAssociator 

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
@@ -72,7 +72,7 @@ public class InferredModelAssociator implements IInferredModelAssociations, IInf
       this(CAPACITY);
     }
 
-    protected Adapter(int capacity) {
+    protected Adapter(final int capacity) {
       sourceToInferredModelMap = newLinkedHashMapWithCapacity(capacity);
       inferredModelToSourceMap = newLinkedHashMapWithCapacity(capacity);
     }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
@@ -64,18 +64,8 @@ public class InferredModelAssociator implements IInferredModelAssociations, IInf
    * An adapter that holds the mapping between source- and inferred-model elements.
    */
   public static class Adapter extends AdapterImpl {
-    private Map<EObject, Deque<EObject>> sourceToInferredModelMap;
-    private Map<EObject, Deque<EObject>> inferredModelToSourceMap;
-    private static final int CAPACITY = 40;
-
-    public Adapter() {
-      this(CAPACITY);
-    }
-
-    protected Adapter(final int capacity) {
-      sourceToInferredModelMap = newLinkedHashMapWithCapacity(capacity);
-      inferredModelToSourceMap = newLinkedHashMapWithCapacity(capacity);
-    }
+    private final Map<EObject, Deque<EObject>> sourceToInferredModelMap = newLinkedHashMapWithCapacity(40);
+    private final Map<EObject, Deque<EObject>> inferredModelToSourceMap = newLinkedHashMapWithCapacity(40);
 
     @Override
     public boolean isAdapterForType(final Object type) {
@@ -92,14 +82,20 @@ public class InferredModelAssociator implements IInferredModelAssociations, IInf
   }
 
   /**
-   * An adapter that has a 0 capacity map.
+   * An adapter that has a empty maps.
    */
   public static class EmptyAdapter extends Adapter{
-    private static final int CAPACITY = 0;
 
-    public EmptyAdapter() {
-      super(CAPACITY);
+    @Override
+    public Map<EObject, Deque<EObject>> getSourceToInferredModelMap() {
+      return Collections.EMPTY_MAP;
     }
+
+    @Override
+    public Map<EObject, Deque<EObject>> getInferredModelToSourceMap() {
+      return Collections.EMPTY_MAP;
+    }
+
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
@@ -88,12 +88,12 @@ public class InferredModelAssociator implements IInferredModelAssociations, IInf
 
     @Override
     public Map<EObject, Deque<EObject>> getSourceToInferredModelMap() {
-      return Collections.EMPTY_MAP;
+      return Collections.emptyMap();
     }
 
     @Override
     public Map<EObject, Deque<EObject>> getInferredModelToSourceMap() {
-      return Collections.EMPTY_MAP;
+      return Collections.emptyMap();
     }
 
   }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
@@ -64,8 +64,18 @@ public class InferredModelAssociator implements IInferredModelAssociations, IInf
    * An adapter that holds the mapping between source- and inferred-model elements.
    */
   public static class Adapter extends AdapterImpl {
-    protected final Map<EObject, Deque<EObject>> sourceToInferredModelMap = newLinkedHashMapWithCapacity(40);
-    protected final Map<EObject, Deque<EObject>> inferredModelToSourceMap = newLinkedHashMapWithCapacity(40);
+    private Map<EObject, Deque<EObject>> sourceToInferredModelMap;
+    private Map<EObject, Deque<EObject>> inferredModelToSourceMap;
+    private static final int CAPACITY = 40;
+
+    public Adapter() {
+      Adapter(CAPACITY);
+    }
+
+    protected Adapter(int capacity) {
+      sourceToInferredModelMap = newLinkedHashMapWithCapacity(capacity);
+      inferredModelToSourceMap = newLinkedHashMapWithCapacity(capacity);
+    }
 
     @Override
     public boolean isAdapterForType(final Object type) {
@@ -85,12 +95,12 @@ public class InferredModelAssociator implements IInferredModelAssociations, IInf
    * An adapter that has a 0 capacity map.
    */
   public static class EmptyAdapter extends Adapter{
+    private static final int CAPACITY = 0;
+
     public EmptyAdapter() {
-      sourceToInferredModelMap = newLinkedHashMapWithCapacity(0);
-      inferredModelToSourceMap = newLinkedHashMapWithCapacity(0);
+      super(CAPACITY);
     }
   }
-
 
   /**
    * Get the adaptor mapping for the resource and install it if not already installed.

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
@@ -69,7 +69,7 @@ public class InferredModelAssociator implements IInferredModelAssociations, IInf
     private static final int CAPACITY = 40;
 
     public Adapter() {
-      Adapter(CAPACITY);
+      this(CAPACITY);
     }
 
     protected Adapter(int capacity) {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelAssociator.java
@@ -64,8 +64,8 @@ public class InferredModelAssociator implements IInferredModelAssociations, IInf
    * An adapter that holds the mapping between source- and inferred-model elements.
    */
   public static class Adapter extends AdapterImpl {
-    private final Map<EObject, Deque<EObject>> sourceToInferredModelMap = newLinkedHashMapWithCapacity(40);
-    private final Map<EObject, Deque<EObject>> inferredModelToSourceMap = newLinkedHashMapWithCapacity(40);
+    protected final Map<EObject, Deque<EObject>> sourceToInferredModelMap = newLinkedHashMapWithCapacity(40);
+    protected final Map<EObject, Deque<EObject>> inferredModelToSourceMap = newLinkedHashMapWithCapacity(40);
 
     @Override
     public boolean isAdapterForType(final Object type) {
@@ -80,6 +80,17 @@ public class InferredModelAssociator implements IInferredModelAssociations, IInf
       return inferredModelToSourceMap;
     }
   }
+
+  /**
+   * An adapter that has a 0 capacity map.
+   */
+  public static class EmptyAdapter extends Adapter{
+    public EmptyAdapter() {
+      sourceToInferredModelMap = newLinkedHashMapWithCapacity(0);
+      inferredModelToSourceMap = newLinkedHashMapWithCapacity(0);
+    }
+  }
+
 
   /**
    * Get the adaptor mapping for the resource and install it if not already installed.

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
@@ -225,12 +225,16 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
    */
   protected void readAssociationsAdapter(final StorageAwareResource resource, final InputStream stream) throws IOException {
     DirectLinkingEObjectInputStream objIn = new DirectLinkingEObjectInputStream(stream, null);
+    InferredModelAssociator.Adapter adapter = (InferredModelAssociator.Adapter) EcoreUtil.getAdapter(resource.eAdapters(), InferredModelAssociator.Adapter.class);
+
     int size = objIn.readCompressedInt();
     if (size == 0) {
+      if(adapter == null) {
+        resource.eAdapters().add(new InferredModelAssociator.EmptyAdapter());
+      }
       return;
     }
 
-    InferredModelAssociator.Adapter adapter = (InferredModelAssociator.Adapter) EcoreUtil.getAdapter(resource.eAdapters(), InferredModelAssociator.Adapter.class);
     if (adapter == null) {
       adapter = new InferredModelAssociator.Adapter();
       resource.eAdapters().add(adapter);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
@@ -225,15 +225,14 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
    */
   protected void readAssociationsAdapter(final StorageAwareResource resource, final InputStream stream) throws IOException {
     DirectLinkingEObjectInputStream objIn = new DirectLinkingEObjectInputStream(stream, null);
-    InferredModelAssociator.Adapter adapter = (InferredModelAssociator.Adapter) EcoreUtil.getAdapter(resource.eAdapters(), InferredModelAssociator.Adapter.class);
 
     int size = objIn.readCompressedInt();
     if (size == 0) {
-      if(adapter == null) {
-        resource.eAdapters().add(new InferredModelAssociator.EmptyAdapter());
-      }
+      resource.eAdapters().add(new InferredModelAssociator.EmptyAdapter());
       return;
     }
+
+    InferredModelAssociator.Adapter adapter = (InferredModelAssociator.Adapter) EcoreUtil.getAdapter(resource.eAdapters(), InferredModelAssociator.Adapter.class);
 
     if (adapter == null) {
       adapter = new InferredModelAssociator.Adapter();


### PR DESCRIPTION
this is to ensure that in
DirectLinkingResourceStorageLoadable#readAssociationsAdapter the
resource will always have an adapter even when there's nothing to be
mapped.
