### PR TITLE
Fix regression caused by 3c61eb59aa64b5d51b0be73f9ff71b77a20a3053

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/CachingStateBasedContainerManager.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/CachingStateBasedContainerManager.java
@@ -30,6 +30,7 @@ import org.eclipse.xtext.resource.containers.StateBasedContainerManager;
 import org.eclipse.xtext.resource.impl.DefaultResourceDescription;
 
 import com.avaloq.tools.ddk.xtext.build.BuildPhases;
+import com.avaloq.tools.ddk.xtext.resource.StateBasedContainerWithHandle;
 import com.avaloq.tools.ddk.xtext.scoping.IDomain;
 import com.google.inject.Inject;
 

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/StateBasedContainerWithHandle.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/StateBasedContainerWithHandle.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     Avaloq Evolution AG - initial API and implementation
  *******************************************************************************/
-package com.avaloq.tools.ddk.xtext.builder;
+package com.avaloq.tools.ddk.xtext.resource;
 
 import java.util.Collection;
 


### PR DESCRIPTION
Fix regression caused by 3c61eb59aa64b5d51b0be73f9ff71b77a20a3053 which
caused resources to be invalidated from containers which where not
visible to them.

In addition, make a couple of improvements to the class, like fixing one
log message to retain on the unresolvedNames variable (the right one),
use one lambda expression instead of an inner class, and remove useless
inhreitDoc annotations.