### PR TITLE
Cache classes in getService

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
@@ -11,6 +11,8 @@
 package com.avaloq.tools.ddk.xtext.linking;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.log4j.Logger;
@@ -35,6 +37,8 @@ import org.eclipse.xtext.util.Triple;
 
 import com.avaloq.tools.ddk.xtext.build.BuildPhases;
 import com.avaloq.tools.ddk.xtext.parser.IResourceAwareParser;
+import com.avaloq.tools.ddk.xtext.resource.IResourceSetServiceCache;
+import com.avaloq.tools.ddk.xtext.resource.ServiceCacheAdapter;
 import com.avaloq.tools.ddk.xtext.resource.persistence.ResourceLoadMode;
 import com.avaloq.tools.ddk.xtext.tracing.ITraceSet;
 import com.avaloq.tools.ddk.xtext.tracing.ResourceInferenceEvent;
@@ -184,7 +188,22 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
    */
   @Override
   public <T> T getService(final Class<? extends T> key) {
-    return injector.getInstance(key);
+    IResourceSetServiceCache serviceCache = ServiceCacheAdapter.getServiceCacheAdapter(getResourceSet());
+    String fileExtension = getURI().fileExtension();
+    Map<Class<?>, Object> map = serviceCache.get(fileExtension);
+    if (map == null) {
+      map = new HashMap<>();
+      serviceCache.put(fileExtension, map);
+    }
+    @SuppressWarnings("unchecked")
+    T service = (T) map.get(key);
+    if (service != null) {
+      return service;
+    }
+    service = injector.getInstance(key);
+    map.put(key, service);
+
+    return service;
   }
 
   /** Simple flag class for use in an IResourceScopeCache. */

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/IResourceSetServiceCache.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/IResourceSetServiceCache.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.resource;
+
+import java.util.Map;
+
+
+/**
+ * A cache for services.
+ */
+public interface IResourceSetServiceCache extends IResourceSetCache<Map<Class<?>, Object>> {
+}

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ServiceCacheAdapter.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ServiceCacheAdapter.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.resource;
+
+import java.util.Map;
+
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import com.avaloq.tools.ddk.caching.CacheConfiguration;
+
+
+/**
+ * A cache adapter for services.
+ */
+public class ServiceCacheAdapter extends CacheAdapter<Map<Class<?>, Object>> implements IResourceSetServiceCache {
+
+  public ServiceCacheAdapter(final CacheConfiguration configuration) {
+    super(configuration);
+  }
+
+  /**
+   * Returns the {@link ServiceCacheAdapter} attached to a {@link ResourceSet} if it is supported by the given resource set.
+   *
+   * @param resourceSet
+   *          the {@link ResourceSet}, must not be {@code null}
+   * @return the resource set cache adapter attached to the resource set if there is one, never {@code null}
+   */
+  public static IResourceSetServiceCache getServiceCacheAdapter(final ResourceSet resourceSet) {
+    final IResourceSetServiceCache cache = (IResourceSetServiceCache) EcoreUtil.getAdapter(resourceSet.eAdapters(), IResourceSetServiceCache.class);
+    if (cache == null) {
+      final ServiceCacheAdapter adapter = new ServiceCacheAdapter(new CacheConfiguration().useSoftValues());
+      resourceSet.eAdapters().add(adapter);
+      return adapter;
+    }
+    return cache;
+  }
+
+}


### PR DESCRIPTION
Cache classes in getService, as calling getInstance() on each injector
of each resource is expensive, and we know, for the same file extension,
always the same class will be returned.