### PR TITLE
Add context sensitive api to UniquenessValidValidationHelper.

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/validation/UniquenessValidValidationHelper.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/validation/UniquenessValidValidationHelper.java
@@ -10,9 +10,11 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.validation;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.osgi.util.NLS;
 
 import com.avaloq.tools.ddk.xtext.scoping.INameFunction;
@@ -53,6 +55,36 @@ public class UniquenessValidValidationHelper<T extends EObject> extends Uniquene
     for (final T duplicate : duplicateEObjects) {
       // emit a message for all duplicates (incl. the first element, not just the followers)
       messages.add(NLS.bind(message, getNameFunction().apply(duplicate)), duplicate);
+    }
+
+    return messages;
+  }
+
+  /**
+   * Check whether the possiblyDuplicateObjects (in the given context) contain duplicates.
+   *
+   * @param context
+   *          the context containing the possible duplicates.
+   * @param possiblyDuplicateObjects
+   *          a set of elements of type T, into which one must look for duplicate objects
+   * @param message
+   *          the duplicate error message, in which {0} is the type of T and {1} is the duplicate representation
+   * @return a compound message (a set of simple messages)
+   */
+  public CompoundValidMessage<T> checkDuplicates(final EObject context, final Iterable<T> possiblyDuplicateObjects, final String message) {
+    if (possiblyDuplicateObjects == null || context == null) {
+      return null; // NO_ERROR
+    }
+
+    Set<T> duplicateEObjects = findDuplicates(possiblyDuplicateObjects);
+
+    final CompoundValidMessage<T> messages = new CompoundValidMessage<T>();
+    final Resource contextResource = context.eResource();
+    for (final T duplicate : duplicateEObjects) {
+      // emit a message for all duplicates in the same resource as the context (incl. the first element, not just the followers)
+      if (Objects.equals(contextResource, duplicate.eResource())) {
+        messages.add(NLS.bind(message, getNameFunction().apply(duplicate)), duplicate);
+      }
     }
 
     return messages;


### PR DESCRIPTION
Added checkDuplicates api to UniquenessValidValidationHelper that takes
a context so that only messages for the context's resource are returned.
This api prevents exceptions being thrown when there are duplicates
outside the current resource and we try to attach messages for them.