### PR TITLE
Remove context insensitive api from UniquenessValidValidationHelper.

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/validation/UniquenessValidValidationHelper.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/validation/UniquenessValidValidationHelper.java
@@ -38,31 +38,6 @@ public class UniquenessValidValidationHelper<T extends EObject> extends Uniquene
   /**
    * Check whether the possiblyDuplicateObjects (in the given context) contain duplicates.
    *
-   * @param possiblyDuplicateObjects
-   *          a set of elements of type T, into which one must look for duplicate objects
-   * @param message
-   *          the duplicate error message, in which {0} is the type of T and {1} is the duplicate representation
-   * @return a compound message (a set of simple messages)
-   */
-  public CompoundValidMessage<T> checkDuplicates(final Iterable<T> possiblyDuplicateObjects, final String message) {
-    if (possiblyDuplicateObjects == null) {
-      return null; // NO_ERROR
-    }
-
-    Set<T> duplicateEObjects = findDuplicates(possiblyDuplicateObjects);
-
-    final CompoundValidMessage<T> messages = new CompoundValidMessage<T>();
-    for (final T duplicate : duplicateEObjects) {
-      // emit a message for all duplicates (incl. the first element, not just the followers)
-      messages.add(NLS.bind(message, getNameFunction().apply(duplicate)), duplicate);
-    }
-
-    return messages;
-  }
-
-  /**
-   * Check whether the possiblyDuplicateObjects (in the given context) contain duplicates.
-   *
    * @param context
    *          the context containing the possible duplicates.
    * @param possiblyDuplicateObjects


### PR DESCRIPTION
Consumers of this api should be using the context sensitive api instead.