### PR TITLE
Added a default case for fragment generation of export files 

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGenerator.xtend
@@ -106,7 +106,7 @@ class ExportGenerator implements IGenerator {
     val fileName = model.fragmentProvider.toFileName
     if (model.exports.exists(e|e.fingerprint && e.fragmentAttribute !== null) || model.isExtension) {
       fsa.generateFile(fileName, fragmentProviderGenerator.generate(model, compilationContext, genModelUtil))
-    } else {
+    } else if (!model.exports.empty){
       fsa.generateFile(fileName, '''
         package «model.fragmentProvider.toJavaPackage»;
 

--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGenerator.xtend
@@ -103,9 +103,20 @@ class ExportGenerator implements IGenerator {
   }
 
   def generateFragmentProvider(ExportModel model, IFileSystemAccess fsa) {
+    val fileName = model.fragmentProvider.toFileName
     if (model.exports.exists(e|e.fingerprint && e.fragmentAttribute !== null) || model.isExtension) {
-      val fileName = model.fragmentProvider.toFileName
       fsa.generateFile(fileName, fragmentProviderGenerator.generate(model, compilationContext, genModelUtil))
+    } else {
+      fsa.generateFile(fileName, '''
+        package «model.fragmentProvider.toJavaPackage»;
+
+        import com.avaloq.tools.ddk.xtext.linking.ShortFragmentProvider;
+
+
+        public class «model.fragmentProvider.toSimpleName» extends ShortFragmentProvider {
+
+        }
+      ''')
     }
   }
 

--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ResourceDescriptionStrategyGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ResourceDescriptionStrategyGenerator.xtend
@@ -82,7 +82,7 @@ class ResourceDescriptionStrategyGenerator {
                 «javaContributorComment(c.location)»
                 @Override
                 public Boolean case«c.type.name»(final «c.type.instanceClassName()» obj) {
-                  «IF c.guard !== null»
+                  «IF c.guard !== null && !c.guard.javaExpression(ctx.clone('obj', c.type)).equalsIgnoreCase("false")»
                     «javaContributorComment(c.guard.location)»
                     if («c.guard.javaExpression(ctx.clone('obj', c.type))») {
                       «generateCaseBody(c, ctx, genModelUtil)»


### PR DESCRIPTION
creates an empty class inherited from ShortFragmentProvider as a
'default' fragment provider class
