### PR TITLE
Fix a bug in ResourceDescriptionStrategyGenerator 

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ResourceDescriptionStrategyGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ResourceDescriptionStrategyGenerator.xtend
@@ -88,7 +88,7 @@ class ResourceDescriptionStrategyGenerator {
                     if («guard») {
                       «generateCaseBody(c, ctx, genModelUtil)»
                     }
-                  «ELSE»
+                  «ELSEIF c.guard === null»
                     «generateCaseBody(c, ctx, genModelUtil)»
                   «ENDIF»
 


### PR DESCRIPTION
from commit #439, where it supposed to not generate the code anymore when the guard is null