### PR TITLE
Fix NPE running tests with DiscerningSuite and JUnit 4.13

### DIFF
--- a/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/DiscerningSuite.java
+++ b/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/DiscerningSuite.java
@@ -27,7 +27,7 @@ import org.junit.runners.model.RunnerBuilder;
  */
 public class DiscerningSuite extends Suite {
 
-  private boolean descriptionOutdated;
+  private boolean descriptionOutdated = true;
   private Description description;
   private Filter testFilter;
 


### PR DESCRIPTION
The ParentRunner in JUnit 4.13 has a changed behavior which causes an
NPE because the description of a DiscerningSuite is initially null. This
change fixes the problem.