### PR TITLE
Fix NPE running tests with ClassRunner and JUnit 4.13

### DIFF
--- a/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/ClassRunner.java
+++ b/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/ClassRunner.java
@@ -107,7 +107,7 @@ public class ClassRunner extends XtextRunner {
   private final int testRetries;
   private final boolean unstableFail;
   private Description description;
-  private boolean descriptionOutdated;
+  private boolean descriptionOutdated = true;
 
   /**
    * Creates a new test class runner.


### PR DESCRIPTION
The ParentRunner in JUnit 4.13 has a changed behavior which causes an
NPE because the description of a ClassRunner is initially null. This
change fixes the problem.
(same fix as the one for DiscerningSuite in pull request 451)