### PR TITLE
Track changed name of build job

### DIFF
--- a/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/util/JobChangeListener.java
+++ b/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/util/JobChangeListener.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Sets;
 public class JobChangeListener extends JobChangeAdapter {
   public static final String JOB_REFRESHING_WORKSPACE = "Refreshing workspace";
   public static final String JOB_REFRESHING_CONTEXT = "Refreshing Context";
-  public static final String JOB_BUILDING_WORKSPACE = "Building workspace";
+  public static final String JOB_BUILDING_WORKSPACE = "Building";
   public static final String JOB_UPDATING_PROJECTS = "Updating projects";
   public static final String JOB_LOAD_PLATFORM = "Load Platform";
   public static final String JOB_INITIALIZING_JAVA_TOOLING = "Initializing Java Tooling";


### PR DESCRIPTION
The name of the job which builds the workspace has changed between
eclipse 4.11 and 4.16, which we are upgrading to. This leads to problems
in our system tests because we wait for the build job to be done. This
change fixes those problems.