### PR TITLE
Moved ParserSemanticPredicatesUtil, AcfKeywordHelper to exported ddk.xtext.generator.util package.

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareAntlrGrammarGenerator.xtend
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareAntlrGrammarGenerator.xtend
@@ -44,6 +44,7 @@ import com.avaloq.tools.ddk.xtext.generator.parser.common.GrammarRuleAnnotations
 import com.avaloq.tools.ddk.xtext.generator.parser.common.PredicatesNaming
 import org.eclipse.xtext.xtext.generator.CodeConfig
 import org.eclipse.xtend.lib.annotations.Accessors
+import com.avaloq.tools.ddk.xtext.generator.util.AcfKeywordHelper
 
 /**
  *

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/AcfKeywordHelper.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/AcfKeywordHelper.java
@@ -9,7 +9,7 @@
  *     Avaloq Evolution AG - initial API and implementation
  *******************************************************************************/
 
-package com.avaloq.tools.ddk.xtext.generator.parser.antlr;
+package com.avaloq.tools.ddk.xtext.generator.util;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -266,7 +266,6 @@ public class AcfKeywordHelper implements Adapter {
   @Override
   public void setTarget(final Notifier newTarget) {
   }
-
 }
 
 /* Copyright (c) Avaloq Evolution AG */

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/IgnoreCaseString.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/IgnoreCaseString.java
@@ -9,7 +9,7 @@
  *     Avaloq Evolution AG - initial API and implementation
  *******************************************************************************/
 
-package com.avaloq.tools.ddk.xtext.generator.parser.antlr;
+package com.avaloq.tools.ddk.xtext.generator.util;
 
 import com.google.common.base.Preconditions;
 

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/ParserSemanticPredicatesUtil.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/ParserSemanticPredicatesUtil.java
@@ -9,7 +9,7 @@
  *     Avaloq Evolution AG - initial API and implementation
  *******************************************************************************/
 
-package com.avaloq.tools.ddk.xtext.generator.parser.antlr;
+package com.avaloq.tools.ddk.xtext.generator.util;
 
 import static org.eclipse.xtext.EcoreUtil2.typeSelect;
 
@@ -607,7 +607,6 @@ public final class ParserSemanticPredicatesUtil {
     }
     return result;
   }
-
 }
 
 /* Copyright (c) Avaloq Evolution AG */


### PR DESCRIPTION
Moved ParserSemanticPredicatesUtil, AcfKeywordHelper, and IgnoreCaseString to exported package
com.avaloq.tools.ddk.xtext.generator.util, in order for them to be externally accessible.