### PR TITLE
Support IDE Bindings in the AnnotationAwareXtextAntlrGeneratorFragment2

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/modelinference/ModelInferenceFragment2.xtend
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/modelinference/ModelInferenceFragment2.xtend
@@ -41,6 +41,9 @@ class ModelInferenceFragment2 extends AbstractXtextGeneratorFragment {
     if (projectConfig.eclipsePlugin.manifest !== null) {
       projectConfig.eclipsePlugin.manifest.requiredBundles += "com.avaloq.tools.ddk.xtext.ui"
     }
+    if (projectConfig.genericIde.manifest !== null) {
+      projectConfig.genericIde.manifest.requiredBundles += "com.avaloq.tools.ddk.xtext.ide"
+    }
   }
 
 }

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareXtextAntlrGeneratorFragment2.xtend
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareXtextAntlrGeneratorFragment2.xtend
@@ -272,6 +272,23 @@ class AnnotationAwareXtextAntlrGeneratorFragment2 extends XtextAntlrGeneratorFra
     file
   }
 
+  override protected void addIdeBindingsAndImports() {
+    /* Overridden to prevent conflicting bindings related to Content Assist. */
+
+    val ideBindings = new GuiceModuleAccess.BindingFactory()
+      .addConfiguredBinding("HighlightingLexer", '''
+        binder.bind(«Lexer».class)
+          .annotatedWith(«Names».named(«"org.eclipse.xtext.ide.LexerIdeBindings".typeRef».HIGHLIGHTING))
+          .to(«productionNaming.getLexerClass(grammar)».class);
+      ''')
+      .addConfiguredBinding("HighlightingTokenDefProvider", '''
+        binder.bind(«ITokenDefProvider».class)
+          .annotatedWith(«Names».named(«"org.eclipse.xtext.ide.LexerIdeBindings".typeRef».HIGHLIGHTING))
+          .to(«AntlrTokenDefProvider».class);
+      ''')
+    ideBindings.contributeTo(language.ideGenModule)
+  }
+
   override protected void addUiBindingsAndImports() {
     /* Overridden to prevent conflicting bindings related to Content Assist. */
 


### PR DESCRIPTION
Support IDE Bindings in the AnnotationAwareXtextAntlrGeneratorFragment2,
also add other hooks where it will be possibly needed.