### PR TITLE
Upgrade to actions/setup-java@v2

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,15 +10,11 @@ jobs:
           maven-version: 3.3.9
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
-      - name: Cache Maven Packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
       - name: Set up Workspace Enviroment Variable
         run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV        
       - name: Build with Maven  within a virtual X Server Environment


### PR DESCRIPTION
Upgrade to actions/setup-java@v2 as preparation for upgrading to Java 11.

Caching Maven packages is now integrated into  actions/setup-java@v2 and requires less configuration