### PR TITLE
Get rid of annoying errors in eclipse

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export.test/.classpath
+++ b/com.avaloq.tools.ddk.xtext.export.test/.classpath
@@ -3,6 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="resource"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/com.avaloq.tools.ddk.xtext.export.test/.project
+++ b/com.avaloq.tools.ddk.xtext.export.test/.project
@@ -96,4 +96,15 @@
 			<locationURI>PARENT-1-PROJECT_LOC/ddk-configuration/.settings/org.eclipse.pde.core.prefs</locationURI>
 		</link>
 	</linkedResources>
+	<filteredResources>
+		<filter>
+			<id>1637059887092</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-resource</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/com.avaloq.tools.ddk.xtext.format.test/.classpath
+++ b/com.avaloq.tools.ddk.xtext.format.test/.classpath
@@ -3,6 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="resource"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/com.avaloq.tools.ddk.xtext.format.test/.project
+++ b/com.avaloq.tools.ddk.xtext.format.test/.project
@@ -96,4 +96,15 @@
 			<locationURI>PARENT-1-PROJECT_LOC/ddk-configuration/.settings/org.eclipse.pde.core.prefs</locationURI>
 		</link>
 	</linkedResources>
+	<filteredResources>
+		<filter>
+			<id>1637059931624</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-resource</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/com.avaloq.tools.ddk.xtext.test/.classpath
+++ b/com.avaloq.tools.ddk.xtext.test/.classpath
@@ -6,7 +6,6 @@
 			<attribute name="ignore_optional_problems" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="resource"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>

--- a/com.avaloq.tools.ddk.xtext.test/.project
+++ b/com.avaloq.tools.ddk.xtext.test/.project
@@ -96,4 +96,15 @@
 			<locationURI>PARENT-1-PROJECT_LOC/ddk-configuration/.settings/org.eclipse.pde.core.prefs</locationURI>
 		</link>
 	</linkedResources>
+	<filteredResources>
+		<filter>
+			<id>1637059976450</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-resource</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/com.avaloq.tools.ddk.xtext.valid.test/.classpath
+++ b/com.avaloq.tools.ddk.xtext.valid.test/.classpath
@@ -4,7 +4,6 @@
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="resource"/>
 	<classpathentry kind="src" path="model"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/com.avaloq.tools.ddk.xtext.valid.test/.project
+++ b/com.avaloq.tools.ddk.xtext.valid.test/.project
@@ -96,4 +96,15 @@
 			<locationURI>PARENT-1-PROJECT_LOC/ddk-configuration/.settings/org.eclipse.pde.core.prefs</locationURI>
 		</link>
 	</linkedResources>
+	<filteredResources>
+		<filter>
+			<id>1637060015537</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-resource</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
When the DSLSDK projects are placed in an Eclipse workspace, Eclipse
reports errors in various test projects which are expected and should be
ignored. This change changes the project configuration to get rid of
those errors.