### PR TITLE
Fix broken unit tests in Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /*/bin/
+/*/bin-res/
 /*/target/
 *.java._trace
 *.smap

--- a/com.avaloq.tools.ddk.check.core/metamodel/com/avaloq/tools/ddk/check/Check.xtext
+++ b/com.avaloq.tools.ddk.check.core/metamodel/com/avaloq/tools/ddk/check/Check.xtext
@@ -164,5 +164,6 @@ FeatureCallID:
 enum SeverityKind:
   error='error' | warning='warning' | info='info' | ignore='ignore';
 
-enum TriggerKind:  // we avoid using CheckKind to simplify writing expressions...
+// we avoid using CheckKind to simplify writing expressions...
+enum TriggerKind:
   fast='live' | normal='onSave' | expensive='onDemand';

--- a/com.avaloq.tools.ddk.xtext.export.test/.classpath
+++ b/com.avaloq.tools.ddk.xtext.export.test/.classpath
@@ -3,5 +3,10 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" output="bin-res" path="resource">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/com.avaloq.tools.ddk.xtext.export.test/.project
+++ b/com.avaloq.tools.ddk.xtext.export.test/.project
@@ -96,15 +96,4 @@
 			<locationURI>PARENT-1-PROJECT_LOC/ddk-configuration/.settings/org.eclipse.pde.core.prefs</locationURI>
 		</link>
 	</linkedResources>
-	<filteredResources>
-		<filter>
-			<id>1637059887092</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-resource</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/com.avaloq.tools.ddk.xtext.format.test/.classpath
+++ b/com.avaloq.tools.ddk.xtext.format.test/.classpath
@@ -3,5 +3,10 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" output="bin-res" path="resource">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/com.avaloq.tools.ddk.xtext.format.test/.project
+++ b/com.avaloq.tools.ddk.xtext.format.test/.project
@@ -96,15 +96,4 @@
 			<locationURI>PARENT-1-PROJECT_LOC/ddk-configuration/.settings/org.eclipse.pde.core.prefs</locationURI>
 		</link>
 	</linkedResources>
-	<filteredResources>
-		<filter>
-			<id>1637059931624</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-resource</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/com.avaloq.tools.ddk.xtext.test/.classpath
+++ b/com.avaloq.tools.ddk.xtext.test/.classpath
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" output="bin-res" path="resource">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src-gen">
 		<attributes>
 			<attribute name="ignore_optional_problems" value="true"/>

--- a/com.avaloq.tools.ddk.xtext.test/.project
+++ b/com.avaloq.tools.ddk.xtext.test/.project
@@ -96,15 +96,4 @@
 			<locationURI>PARENT-1-PROJECT_LOC/ddk-configuration/.settings/org.eclipse.pde.core.prefs</locationURI>
 		</link>
 	</linkedResources>
-	<filteredResources>
-		<filter>
-			<id>1637059976450</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-resource</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/com.avaloq.tools.ddk.xtext.valid.test/.classpath
+++ b/com.avaloq.tools.ddk.xtext.valid.test/.classpath
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src-model"/>
+	<classpathentry kind="src" output="bin-res" path="resource">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>

--- a/com.avaloq.tools.ddk.xtext.valid.test/.project
+++ b/com.avaloq.tools.ddk.xtext.valid.test/.project
@@ -96,15 +96,4 @@
 			<locationURI>PARENT-1-PROJECT_LOC/ddk-configuration/.settings/org.eclipse.pde.core.prefs</locationURI>
 		</link>
 	</linkedResources>
-	<filteredResources>
-		<filter>
-			<id>1637060015537</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-resource</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="DDK Target" sequenceNumber="12">
+<target name="DDK Target" sequenceNumber="13">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -35,5 +35,9 @@
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/"/>
 </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <repository location="http://download.eclipse.org/lsp4j/updates/releases/0.10.0"/>
+    <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.10.0.v20201105-1605"/>
+  </location>
 </locations>
 </target>


### PR DESCRIPTION
The Eclipse project config change in PR 474 (commit
de70e081725e08007bcb1fe6491a971e13c9108e) had the consequence that unit
tests failed in Eclipse.
This change fixes the problem by changing the project config back, but
keeping the ability to at least filter the errors on test sources from
the Problems view in Eclipse.
It also includes a minor fix for an error in Eclipse and the addition of lsp4e to the dslsdk target.