### PR TITLE
Ignore NM_SAME_SIMPLE_NAME_AS_SUPERCLASS everywhere

### DIFF
--- a/ddk-configuration/findbugs/exclusion-filter.xml
+++ b/ddk-configuration/findbugs/exclusion-filter.xml
@@ -45,12 +45,6 @@
   </Match>
   <Match>
      <Bug pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS" />
-     <Or>
-       <Class name="~.*\.builder\.RegistryBuilderParticipant" />
-       <Class name="~.*\.builder\.BuilderIntegrationFragment" />
-       <Class name="~.*\.util\.StandaloneSetup" />
-       <Class name="~.*\.formatting\.FormatterFragment" />
-     </Or>
   </Match>
   <Match>
      <Bug pattern="MF_CLASS_MASKS_FIELD" />


### PR DESCRIPTION
The NM_SAME_SIMPLE_NAME_AS_SUPERCLASS SpotBug error was only ignored in
certain classes. This commit changes this to ignore the error
everywhere.