### PR TITLE
generate "ide" package into an "ide" project

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/model/project/ProjectConfig.xtend
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/model/project/ProjectConfig.xtend
@@ -20,7 +20,7 @@ class ProjectConfig extends StandardProjectConfig {
   @Accessors var String runtimeSuffix = ""
   @Accessors var String testSuffix = "test"
   @Accessors var String eclipsePluginSuffix = "ui"
-  @Accessors var String genericIdeSuffix = eclipsePluginSuffix
+  @Accessors var String genericIdeSuffix = "ide"
   @Accessors var boolean forceDisableIdeProject = true
 
   override protected computeName(SubProjectConfig project) {
@@ -41,6 +41,7 @@ class ProjectConfig extends StandardProjectConfig {
     super.setDefaults
     if (forceDisableIdeProject) {
       genericIde.enabled = false
+      genericIdeSuffix = eclipsePluginSuffix
     }
   }
 


### PR DESCRIPTION
As is standard Xtext behavior.

Do that unless forceDisableIdeProject is set, in which case still
default to generating into the "ui" project, so that the "ide" package
is still available for content assist implementation.