### PR TITLE
remove setting of genericIdeSuffix

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/model/project/ProjectConfig.xtend
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/model/project/ProjectConfig.xtend
@@ -41,7 +41,6 @@ class ProjectConfig extends StandardProjectConfig {
     super.setDefaults
     if (forceDisableIdeProject) {
       genericIde.enabled = false
-      genericIdeSuffix = eclipsePluginSuffix
     }
   }
 


### PR DESCRIPTION
Don't unnecessarily assign the suffix in the forceDisableIdeProject case
as it apparently does not get used in that case.