### PR TITLE
Re-export org.eclipse.xtext.xbase

### DIFF
--- a/com.avaloq.tools.ddk.xtext.format/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.format/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.core.resources,
  org.eclipse.xtend.lib,
  org.eclipse.xtext.common.types,
- org.eclipse.xtext.xbase,
+ org.eclipse.xtext.xbase;visibility:=reexport,
  org.eclipse.xtext.xbase.lib,
  org.objectweb.asm;resolution:=optional
 Import-Package: org.apache.log4j


### PR DESCRIPTION
FormatStandaloneSetup requires XbaseWithAnnotationsStandaloneSetup from
org.eclipse.xtext.xbase, therefore dependency should be re-exported