### PR TITLE
Fix NPE in ParallelResourceLoader

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
@@ -127,7 +127,7 @@ public class ParallelResourceLoader extends AbstractResourceLoader {
     Resource resource = super.loadResource(uri, localResourceSet, parentResourceSet);
     if (localResourceSet.getResources().size() > 1) {
       for (Resource loadedResource : Lists.newArrayList(localResourceSet.getResources())) {
-        if (!loadedResource.equals(resource)) {
+        if (loadedResource != null && !loadedResource.equals(resource)) {
           loadedResource.unload();
         }
       }


### PR DESCRIPTION
We have observed NPEs when loading resources with the parallel resource
loader. It is unclear where the null pointer in question comes from, but
avoiding the exception is simple.