### PR TITLE
Fix crashes in the context of a Language Server

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/CurrentDescriptions2.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/CurrentDescriptions2.java
@@ -81,7 +81,7 @@ public class CurrentDescriptions2 extends CurrentDescriptions implements IResour
   /**
    * Context-aware instance of our index.
    * FIXME: This is needed only because our ContainerManager needs access to the delegate as it uses it for its cache key. If we could do away with this, we
-   * couls remove this whole class and also its Guice binding in all languages. This class is used *only* when linking; it doesn't need to support the new
+   * could remove this whole class and also its Guice binding in all languages. This class is used *only* when linking; it doesn't need to support the new
    * IResourceDEscriptions2 interface with the findReferences operations.
    */
   public static class ResourceSetAware extends CurrentDescriptions.ResourceSetAware implements IResourceDescriptions2 {
@@ -102,8 +102,10 @@ public class CurrentDescriptions2 extends CurrentDescriptions implements IResour
       IResourceDescriptions adapter = (IResourceDescriptions) EcoreUtil2.getAdapter(resourceSet.eAdapters(), CurrentDescriptions.class);
       if (adapter instanceof IResourceDescriptions2) {
         delegate = (IResourceDescriptions2) adapter;
-      } else {
+      } else if (adapter != null) {
         delegate = new ResourceDescriptions2(adapter);
+      } else {
+        delegate = new NullResourceDescriptionsData();
       }
     }
 

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/extensions/ResourceDescriptionsUtil.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/extensions/ResourceDescriptionsUtil.java
@@ -33,7 +33,8 @@ import com.google.common.collect.Sets;
  */
 public final class ResourceDescriptionsUtil {
 
-  private ResourceDescriptionsUtil() {}
+  private ResourceDescriptionsUtil() {
+  }
 
   /**
    * Returns all URIs in the given resource descriptions object.
@@ -85,23 +86,25 @@ public final class ResourceDescriptionsUtil {
       }
     }
 
-    return Iterables.filter(descriptions.getAllResourceDescriptions(), input -> {
-      if (matchNames) {
-        for (QualifiedName name : input.getImportedNames()) {
-          if (exportedNames.contains(name.toLowerCase())) { // NOPMD
-            return true;
+    return Iterables.filter(//
+        Iterables.filter(descriptions.getAllResourceDescriptions(), input -> !targetResources.contains(input)) //
+        , input -> {
+          if (matchNames) {
+            for (QualifiedName name : input.getImportedNames()) {
+              if (exportedNames.contains(name.toLowerCase())) { // NOPMD
+                return true;
+              }
+            }
           }
-        }
-      }
-      if (matchPolicy.includes(ReferenceMatchPolicy.REFERENCES)) {
-        for (IReferenceDescription ref : input.getReferenceDescriptions()) {
-          if (targetUris.contains(ref.getTargetEObjectUri().trimFragment())) {
-            return true;
+          if (matchPolicy.includes(ReferenceMatchPolicy.REFERENCES)) {
+            for (IReferenceDescription ref : input.getReferenceDescriptions()) {
+              if (targetUris.contains(ref.getTargetEObjectUri().trimFragment())) {
+                return true;
+              }
+            }
           }
-        }
-      }
-      return false;
-    });
+          return false;
+        });
   }
 
   /**


### PR DESCRIPTION
* As in the previous change, do not create a ResourceSetAware without a
delegate as this will crash with an NPE whenever any method is called
(all of them used the delegate). Instead, create a
NullResourceDescriptionsData.

* Avoid processing the resource description currently being added to the
index in ResourceDescriptionsUtil.findReferencesToResources. The class
used by the language server for those descriptors
(Indexer$ResolvedResourceDescription) logs an error if getImportedNames
or getReferenceDescriptions is called. The reason of the Xtext project
for this exception is to detect errors
(https://github.com/eclipse/xtext-core/pull/1807#discussion_r786297617):
"It's noteworthy that these descriptions have been created for resources
that have not been fully processed. If they remain in the index after
the build, subsequent changes cannot correctly detect the affected
resources and the index state will gradually erode and become different
from the actual project contents on disk.
The ResolvedDescriptions should be local to a single build run and never
survive that single build cycle. Within the build loop, there imported
names and reference descriptions should never be necessary."

* Inline with this reasoning, we bring
FixedCopiedResourceDescription closer to the Xtext class
CopiedResourceDescription and log the exceptional case whenever
possible.