### PR TITLE
Add metamodel folders to the binary build

### DIFF
--- a/com.avaloq.tools.ddk.xtext.expression/build.properties
+++ b/com.avaloq.tools.ddk.xtext.expression/build.properties
@@ -3,4 +3,5 @@ source.. = src/,\
            xtend-gen/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               metamodel/

--- a/com.avaloq.tools.ddk.xtext.scope/build.properties
+++ b/com.avaloq.tools.ddk.xtext.scope/build.properties
@@ -3,4 +3,5 @@ source.. = src/,\
            xtend-gen/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               metamodel/

--- a/com.avaloq.tools.ddk.xtext.valid/build.properties
+++ b/com.avaloq.tools.ddk.xtext.valid/build.properties
@@ -2,4 +2,5 @@ source.. = src/,\
            src-gen/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               metamodel/


### PR DESCRIPTION
Add metamodel folders to the binary build, otherwise, downstream
projects cannot reference the ecore files which have been moved from the
src-gen to the metamodel folder.