### PR TITLE
Register the Namespace URI with the correct EPackage

### DIFF
--- a/com.avaloq.tools.ddk.xtext.valid/src/com/avaloq/tools/ddk/xtext/valid/ValidStandaloneSetup.java
+++ b/com.avaloq.tools.ddk.xtext.valid/src/com/avaloq/tools/ddk/xtext/valid/ValidStandaloneSetup.java
@@ -10,6 +10,12 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.valid;
 
+import org.eclipse.emf.ecore.EPackage;
+
+import com.avaloq.tools.ddk.xtext.valid.valid.ValidPackage;
+import com.google.inject.Injector;
+
+
 /**
  * Initialization support for running Xtext languages without equinox extension registry.
  */
@@ -20,5 +26,9 @@ public class ValidStandaloneSetup extends ValidStandaloneSetupGenerated {
     new ValidStandaloneSetup().createInjectorAndDoEMFRegistration();
   }
 
+  @Override
+  public void register(final Injector injector) {
+    EPackage.Registry.INSTANCE.put(ValidPackage.eINSTANCE.getNsURI(), ValidPackage.eINSTANCE);
+    super.register(injector);
+  }
 }
-


### PR DESCRIPTION
Register the Namespace URI with the correct EPackage, this was
previously part of ValidStandaloneSetupGenerated, but was removed when
we upgraded to the new Xtext generator and regenerated the language.