### PR TITLE
Make generation of content assist parser optional when the ide plugin is

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/ide/contentAssist/AnnotationAwareFollowElementCalculator.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/ide/contentAssist/AnnotationAwareFollowElementCalculator.java
@@ -44,7 +44,6 @@ public class AnnotationAwareFollowElementCalculator extends FollowElementCalcula
 
   private boolean canContainKeywordRule(final ParserRule rule) {
     Set<AbstractRule> visitedRules = Sets.newHashSet(rule);
-    visitedRules.add(rule);
     Deque<RuleCall> ruleCallsToVisit = new ArrayDeque<>(EcoreUtil2.getAllContentsOfType(rule, RuleCall.class));
     while (!ruleCallsToVisit.isEmpty()) {
       AbstractRule referencedRule = ruleCallsToVisit.pollFirst().getRule();

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareXtextAntlrGeneratorFragment2.xtend
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareXtextAntlrGeneratorFragment2.xtend
@@ -51,6 +51,7 @@ import org.eclipse.xtext.xtext.generator.parser.antlr.XtextAntlrGeneratorFragmen
 import static extension org.eclipse.xtext.GrammarUtil.*
 import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 import static extension org.eclipse.xtext.xtext.generator.parser.antlr.AntlrGrammarGenUtil.*
+import org.eclipse.xtend.lib.annotations.Accessors
 
 class AnnotationAwareXtextAntlrGeneratorFragment2 extends XtextAntlrGeneratorFragment2 {
 
@@ -65,6 +66,8 @@ class AnnotationAwareXtextAntlrGeneratorFragment2 extends XtextAntlrGeneratorFra
   @Inject extension PredicatesNaming predicatesNaming
   @Inject extension GrammarAccessExtensions grammarUtil
   @Inject extension GrammarRuleAnnotations annotations
+
+  @Accessors boolean generateContentAssistIfIdeMissing
 
   boolean removeBacktrackingGuards
   int lookaheadThreshold
@@ -123,7 +126,7 @@ class AnnotationAwareXtextAntlrGeneratorFragment2 extends XtextAntlrGeneratorFra
   protected override doGenerate() {
     super.doGenerate()
     // if there is no ide plugin, write the content assist parser to the ui plugin.
-    if (projectConfig.genericIde.srcGen === null) {
+    if (generateContentAssistIfIdeMissing && projectConfig.genericIde.srcGen === null) {
       generateUiContentAssistGrammar()
       generateContentAssistParser().writeTo(projectConfig.eclipsePlugin.srcGen)
       if (hasSyntheticTerminalRule()) {


### PR DESCRIPTION
not present.