### PR TITLE
Update target: replace Orbit integration build

### DIFF
--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -41,8 +41,8 @@
     <unit id="org.mockito" version="2.23.0.v20200310-1642"/>
     <unit id="org.mockito.source" version="2.23.0.v20200310-1642"/>
   </location>
-  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-    <repository location="https://download.eclipse.org/tools/orbit/downloads/drops2/I20220111151929/repository"/>
+  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository"/>
     <unit id="org.apache.logging.log4j" version="2.17.1.v20220106-2156"/>
   </location>
 </locations>


### PR DESCRIPTION
The Orbit integration build repo I20220111151929 has disappeared which
needs a change in our target.