### PR TITLE
Revert "Bump tycho.version from 1.6.0 to 2.7.1 in /ddk-parent"

### DIFF
--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -54,7 +54,7 @@
     <spotbugs.version>4.6.0</spotbugs.version>
     <pmd.plugin.version>3.16.0</pmd.plugin.version>
     <pmd.version>6.44.0</pmd.version>
-    <tycho.version>2.7.1</tycho.version>
+    <tycho.version>2.6.0</tycho.version>
     <xtend.version>2.26.0</xtend.version>
   </properties>
 


### PR DESCRIPTION
Reverts dsldevkit/dsl-devkit#564. 
Our local builds get stuck when trying to deploy build result with Tycho 2.7.1, reverting to 2.6.0