### PR TITLE
Downgrade Tycho to 2.6.0

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,12 +9,11 @@ jobs:
         with:
           maven-version: 3.8.4
       - uses: actions/checkout@v3
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
-          cache: 'maven'
       - name: Set up Workspace Enviroment Variable
         run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV        
       - name: Build with Maven  within a virtual X Server Environment

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -54,7 +54,7 @@
     <spotbugs.version>4.6.0</spotbugs.version>
     <pmd.plugin.version>3.16.0</pmd.plugin.version>
     <pmd.version>6.44.0</pmd.version>
-    <tycho.version>2.7.1</tycho.version>
+    <tycho.version>2.6.0</tycho.version>
     <xtend.version>2.26.0</xtend.version>
   </properties>
 


### PR DESCRIPTION
Tycho v2.7.1 causes problems in our builds when trying to deploy the
build results. This commit downgrades back to 2.6.0. It also temporarily
disables Maven caching on GitHub to get the GitHub verify action to
work.