### PR TITLE
catch stack overflows when loading from storage

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -92,6 +92,7 @@ import com.avaloq.tools.ddk.xtext.scoping.ImplicitReferencesAdapter;
 import com.avaloq.tools.ddk.xtext.tracing.ITraceSet;
 import com.avaloq.tools.ddk.xtext.tracing.ResourceValidationRuleSummaryEvent;
 import com.avaloq.tools.ddk.xtext.util.EmfResourceSetUtil;
+import com.avaloq.tools.ddk.xtext.util.ThrowableUtil;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Iterables;
@@ -119,7 +120,6 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
   public static final long CANCELLATION_POLLING_TIMEOUT = 5000; // ms
   public static final long CANCELLATION_POLLING_DELAY = 200; // ms
 
-  public static final int STACK_TRACE_LIMIT = 10;
   private static final int COMMIT_WARN_WAIT_SEC = 30;
 
   /** Class-wide logger. */
@@ -560,7 +560,8 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
                 }
               } catch (StackOverflowError ex) {
                 queue.remove(changedURI);
-                logStackOverflowErrorStackTrace(ex, changedURI);
+                ThrowableUtil.trimStackOverflowErrorStackTrace(ex);
+                LOGGER.warn(NLS.bind(Messages.MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR, changedURI), ex);
               }
             }
             // CHECKSTYLE:CHECK-OFF IllegalCatch - guard against ill behaved implementations
@@ -612,7 +613,8 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
               updateMarkers(newDelta, resourceSet, subProgress.newChild(1, SubMonitor.SUPPRESS_ALL_LABELS));
             } catch (StackOverflowError ex) {
               queue.remove(changedURI);
-              logStackOverflowErrorStackTrace(ex, changedURI);
+              ThrowableUtil.trimStackOverflowErrorStackTrace(ex);
+              LOGGER.warn(NLS.bind(Messages.MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR, changedURI), ex);
             }
           } else {
             subProgress.worked(2);
@@ -752,24 +754,6 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
       LOGGER.warn(String.format("Binary resource storage tasks not completed in time, start with task / queue %d / %d; now have %d / %d", //$NON-NLS-1$
           activeThreadCount, queuedTaskCount, binaryStorageExecutor.getActiveThreadCount(), binaryStorageExecutor.getQueuedTaskCount()));
     }
-  }
-
-  /**
-   * Log the first and last 10 StackOverflowError Stack Trace.
-   *
-   * @param ex
-   *          the StackOverflowError
-   * @param binding
-   *          the object to be inserted into the message
-   */
-  protected void logStackOverflowErrorStackTrace(final StackOverflowError ex, final URI binding) {
-    int stackTraceLength = ex.getStackTrace().length;
-    StackTraceElement[] stackTraceElements = new StackTraceElement[(STACK_TRACE_LIMIT * 2) + 1];
-    System.arraycopy(ex.getStackTrace(), 0, stackTraceElements, 0, STACK_TRACE_LIMIT);
-    stackTraceElements[STACK_TRACE_LIMIT] = new StackTraceElement("", "\n\t\t\t <Skipped multiple lines> \n", null, -1); //$NON-NLS-1$ //$NON-NLS-2$
-    System.arraycopy(ex.getStackTrace(), stackTraceLength - STACK_TRACE_LIMIT, stackTraceElements, STACK_TRACE_LIMIT + 1, STACK_TRACE_LIMIT);
-    ex.setStackTrace(stackTraceElements);
-    LOGGER.warn(NLS.bind(Messages.MonitoredClusteringBuilderState_COULD_NOT_PROCESS_DUE_TO_STACK_OVERFLOW_ERROR, binding), ex);
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
@@ -15,8 +15,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
@@ -43,6 +43,7 @@ import com.avaloq.tools.ddk.xtext.resource.ServiceCacheAdapter;
 import com.avaloq.tools.ddk.xtext.resource.persistence.ResourceLoadMode;
 import com.avaloq.tools.ddk.xtext.tracing.ITraceSet;
 import com.avaloq.tools.ddk.xtext.tracing.ResourceInferenceEvent;
+import com.avaloq.tools.ddk.xtext.util.ThrowableUtil;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -134,7 +135,44 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
     isLoading = loading;
   }
 
-  /** {@inheritDoc} */
+  /**
+   * Like the superclass implementation, but additionally handles any {@link StackOverflowError}s.
+   * Stack overflows can occur for deeply nested models.
+   * {@inheritDoc}
+   */
+  @Override
+  public void load(final Map<?, ?> options) throws IOException {
+    try {
+      super.load(options);
+    } catch (StackOverflowError e) {
+      ThrowableUtil.trimStackOverflowErrorStackTrace(e);
+      LOGGER.warn("Failed to load " + uri + " from storage", e); //$NON-NLS-1$//$NON-NLS-2$
+
+      /*
+       * As for IOExceptions in the superclass implementation,
+       * clear and unload so that can fall back to reloading.
+       */
+      if (contents != null) {
+        contents.clear();
+      }
+      if (eAdapters != null) {
+        eAdapters.clear();
+      }
+      unload();
+
+      /*
+       * We actually want to call the super super class method.
+       * This should do something similar.
+       */
+      isLoading = true;
+      try {
+        super.load(options);
+      } finally {
+        isLoading = false;
+      }
+    }
+  }
+
   @Override
   public synchronized EObject getEObject(final String uriFragment) {
     try {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/util/ThrowableUtil.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/util/ThrowableUtil.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.util;
+
+public final class ThrowableUtil {
+
+  public static final int STACK_TRACE_LIMIT = 10;
+
+  /**
+   * Modify the argument StackOverflowError so that it only retains
+   * the first and last {@link #STACK_TRACE_LIMIT} stack trace elements of {@code ex}
+   * if it has more than that.
+   *
+   * @param ex
+   *          the StackOverflowError; may get modified
+   */
+  @SuppressWarnings("nls")
+  public static void trimStackOverflowErrorStackTrace(final StackOverflowError ex) {
+    int stackTraceLength = ex.getStackTrace().length;
+    if (stackTraceLength > STACK_TRACE_LIMIT * 2 + 1) {
+      StackTraceElement[] stackTraceElements = new StackTraceElement[(STACK_TRACE_LIMIT * 2) + 1];
+      System.arraycopy(ex.getStackTrace(), 0, stackTraceElements, 0, STACK_TRACE_LIMIT);
+      stackTraceElements[STACK_TRACE_LIMIT] = new StackTraceElement("", "\n\t\t\t <Skipped multiple lines> \n", null, -1);
+      System.arraycopy(ex.getStackTrace(), stackTraceLength - STACK_TRACE_LIMIT, stackTraceElements, STACK_TRACE_LIMIT + 1, STACK_TRACE_LIMIT);
+      ex.setStackTrace(stackTraceElements);
+    }
+  }
+
+  private ThrowableUtil() {
+  }
+
+}


### PR DESCRIPTION
That is, catch and log StackOverflowErrors when loading resources from
storage, and fall back to recreating the resource from source.