### PR TITLE
Move content assist runtime classes to runtime plugin.

### DIFF
--- a/com.avaloq.tools.ddk.sample.helloworld.ide/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.sample.helloworld.ide/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: com.avaloq.tools.ddk.sample.helloworld,
  com.google.inject,
  org.eclipse.xtext,
  org.eclipse.xtext.ide,
- com.avaloq.tools.ddk.xtext.generator,
+ com.avaloq.tools.ddk.xtext.ide,
  com.avaloq.tools.ddk.xtext
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/com.avaloq.tools.ddk.sample.helloworld.ide/src/com/avaloq/tools/ddk/sample/helloworld/ide/HelloWorldIdeModule.java
+++ b/com.avaloq.tools.ddk.sample.helloworld.ide/src/com/avaloq/tools/ddk/sample/helloworld/ide/HelloWorldIdeModule.java
@@ -6,8 +6,8 @@ package com.avaloq.tools.ddk.sample.helloworld.ide;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElementCalculator;
 import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElementComputer;
 
-import com.avaloq.tools.ddk.xtext.generator.ide.contentAssist.AnnotationAwareFollowElementCalculator;
-import com.avaloq.tools.ddk.xtext.generator.ide.contentAssist.AnnotationAwareFollowElementComputer;
+import com.avaloq.tools.ddk.xtext.ide.contentAssist.AnnotationAwareFollowElementCalculator;
+import com.avaloq.tools.ddk.xtext.ide.contentAssist.AnnotationAwareFollowElementComputer;
 
 /**
  * Use this class to register ide components.

--- a/com.avaloq.tools.ddk.sample.helloworld.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.sample.helloworld.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: com.avaloq.tools.ddk.sample.helloworld,
  com.avaloq.tools.ddk.check.runtime.core,
  com.avaloq.tools.ddk.xtext.ui,
  com.avaloq.tools.ddk.sample.helloworld.ide,
- com.avaloq.tools.ddk.xtext.generator
+ com.avaloq.tools.ddk.xtext.ide
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: com.avaloq.tools.ddk.sample.helloworld.ui.quickfix,

--- a/com.avaloq.tools.ddk.sample.helloworld.ui/src/com/avaloq/tools/ddk/sample/helloworld/ui/HelloWorldUiModule.java
+++ b/com.avaloq.tools.ddk.sample.helloworld.ui/src/com/avaloq/tools/ddk/sample/helloworld/ui/HelloWorldUiModule.java
@@ -10,8 +10,8 @@ import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElementComputer;
 
 import com.avaloq.tools.ddk.check.runtime.configuration.CheckConfigurationStore;
 import com.avaloq.tools.ddk.check.runtime.configuration.ICheckConfigurationStore;
-import com.avaloq.tools.ddk.xtext.generator.ide.contentAssist.AnnotationAwareFollowElementCalculator;
-import com.avaloq.tools.ddk.xtext.generator.ide.contentAssist.AnnotationAwareFollowElementComputer;
+import com.avaloq.tools.ddk.xtext.ide.contentAssist.AnnotationAwareFollowElementCalculator;
+import com.avaloq.tools.ddk.xtext.ide.contentAssist.AnnotationAwareFollowElementComputer;
 
 /**
  * Use this class to register components to be used within the Eclipse IDE.

--- a/com.avaloq.tools.ddk.xtext.ide/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.ide/META-INF/MANIFEST.MF
@@ -5,9 +5,11 @@ Bundle-SymbolicName: com.avaloq.tools.ddk.xtext.ide;singleton:=true
 Bundle-Version: 10.0.0.qualifier
 Bundle-Vendor: Avaloq Evolution AG
 Require-Bundle: org.eclipse.lsp4j,
- org.eclipse.xtext.ide
+ org.eclipse.xtext.ide,
+ com.avaloq.tools.ddk.xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-Export-Package: com.avaloq.tools.ddk.xtext.ide.formatting
+Export-Package: com.avaloq.tools.ddk.xtext.ide.contentAssist,
+ com.avaloq.tools.ddk.xtext.ide.formatting
 Import-Package: org.apache.log4j
 Automatic-Module-Name: com.avaloq.tools.ddk.xtext.ide

--- a/com.avaloq.tools.ddk.xtext.ide/src/com/avaloq/tools/ddk/xtext/ide/contentAssist/AnnotationAwareFollowElementCalculator.java
+++ b/com.avaloq.tools.ddk.xtext.ide/src/com/avaloq/tools/ddk/xtext/ide/contentAssist/AnnotationAwareFollowElementCalculator.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.ide.contentAssist;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Set;
+
+import org.eclipse.xtext.AbstractRule;
+import org.eclipse.xtext.EcoreUtil2;
+import org.eclipse.xtext.GrammarUtil;
+import org.eclipse.xtext.ParserRule;
+import org.eclipse.xtext.RuleCall;
+import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElementCalculator;
+
+import com.avaloq.tools.ddk.xtext.parser.ISemanticPredicates;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+
+
+public class AnnotationAwareFollowElementCalculator extends FollowElementCalculator {
+  @Inject
+  private ISemanticPredicates keywordPredicates;
+
+  @Override
+  public Boolean caseParserRule(final ParserRule object) {
+    // copy of super class, but also descend into rules that contain keyword rules, rules that are just KeyWords, and rules that only delegate to other rules.
+    if (GrammarUtil.isDatatypeRule(object) && !canContainKeywordRule(object) && !ParserRuleUtil.isEnumLikeDatatypeRule(object)
+        && !ParserRuleUtil.isDelegatingDatatypeRule(object)) {
+      return Boolean.FALSE;
+    }
+    return doSwitch(object.getAlternatives());
+  }
+
+  private boolean canContainKeywordRule(final ParserRule rule) {
+    Set<AbstractRule> visitedRules = Sets.newHashSet(rule);
+    Deque<RuleCall> ruleCallsToVisit = new ArrayDeque<>(EcoreUtil2.getAllContentsOfType(rule, RuleCall.class));
+    while (!ruleCallsToVisit.isEmpty()) {
+      AbstractRule referencedRule = ruleCallsToVisit.pollFirst().getRule();
+      if (visitedRules.add(referencedRule)) {
+        if (keywordPredicates.isKeywordRule(referencedRule.getName())) {
+          return true;
+        }
+        ruleCallsToVisit.addAll(EcoreUtil2.getAllContentsOfType(referencedRule, RuleCall.class));
+      }
+    }
+    return false;
+  }
+
+}

--- a/com.avaloq.tools.ddk.xtext.ide/src/com/avaloq/tools/ddk/xtext/ide/contentAssist/AnnotationAwareFollowElementComputer.java
+++ b/com.avaloq.tools.ddk.xtext.ide/src/com/avaloq/tools/ddk/xtext/ide/contentAssist/AnnotationAwareFollowElementComputer.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.ide.contentAssist;
+
+import java.util.Collection;
+
+import org.eclipse.xtext.AbstractElement;
+import org.eclipse.xtext.GrammarUtil;
+import org.eclipse.xtext.ParserRule;
+import org.eclipse.xtext.RuleCall;
+import org.eclipse.xtext.ide.editor.contentassist.IFollowElementAcceptor;
+import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElement;
+import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElementCalculator;
+import org.eclipse.xtext.ide.editor.contentassist.antlr.FollowElementComputer;
+
+import com.avaloq.tools.ddk.xtext.parser.ISemanticPredicates;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+
+public class AnnotationAwareFollowElementComputer extends FollowElementComputer {
+  @Inject
+  private Provider<FollowElementCalculator> feCalculatorProvider;
+  @Inject
+  private ISemanticPredicates keywordPredicates;
+
+  @Override
+  public void computeFollowElements(final Collection<FollowElement> followElements, final IFollowElementAcceptor followElementAcceptor) {
+    // copy of super class but initialisation of calculator moved to protected method.
+    FollowElementCalculator calculator = feCalculatorProvider.get();
+    initialiseCalculator(calculator, followElementAcceptor);
+    for (FollowElement element : followElements) {
+      computeFollowElements(calculator, element);
+    }
+  }
+
+  protected void initialiseCalculator(final FollowElementCalculator calculator, final IFollowElementAcceptor followElementAcceptor) {
+    // copied from super class but calls to keyword rules are also accepted.
+    calculator.setAcceptor(element -> {
+      ParserRule rule = GrammarUtil.containingParserRule(element);
+      if (rule == null || !GrammarUtil.isDatatypeRule(rule) || isKeywordRuleCall(element) || ParserRuleUtil.isEnumLikeDatatypeRule(rule)) {
+        followElementAcceptor.accept(element);
+      }
+    });
+  }
+
+  private boolean isKeywordRuleCall(final AbstractElement element) {
+    if (element instanceof RuleCall) {
+      RuleCall ruleCall = (RuleCall) element;
+      return keywordPredicates.isKeywordRule(ruleCall.getRule().getName());
+    }
+    return false;
+  }
+
+}

--- a/com.avaloq.tools.ddk.xtext.ide/src/com/avaloq/tools/ddk/xtext/ide/contentAssist/ParserRuleUtil.java
+++ b/com.avaloq.tools.ddk.xtext.ide/src/com/avaloq/tools/ddk/xtext/ide/contentAssist/ParserRuleUtil.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Evolution AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.ide.contentAssist;
+
+import org.eclipse.xtext.GrammarUtil;
+import org.eclipse.xtext.ParserRule;
+
+
+public final class ParserRuleUtil {
+  private ParserRuleUtil() {
+    // prevent construction of util class.
+  }
+
+  /**
+   * Determines whether a ParserRule is a datatype rule containing keywords only.
+   *
+   * @param rule
+   *          the rule to be tested
+   * @return true if datatype rule contains keywords only
+   */
+  public static boolean isEnumLikeDatatypeRule(final ParserRule rule) {
+    if (!GrammarUtil.isDatatypeRule(rule) || !GrammarUtil.containedRuleCalls(rule).isEmpty()) {
+      return false;
+    }
+    return !GrammarUtil.containedKeywords(rule).isEmpty();
+  }
+
+  /**
+   * Determines whether a ParserRule is a datatype rule containing RuleCalls only.
+   *
+   * @param rule
+   *          the rule to be tested
+   * @return true if datatype rule contains RuleCalls only
+   */
+  public static boolean isDelegatingDatatypeRule(final ParserRule rule) {
+    if (!GrammarUtil.isDatatypeRule(rule) || !GrammarUtil.containedKeywords(rule).isEmpty()) {
+      return false;
+    }
+    return !GrammarUtil.containedRuleCalls(rule).isEmpty();
+  }
+
+}


### PR DESCRIPTION
The AnnotationAwareFollowElementCalculator and
AnnotationAwareFollowElementComputer are runtime components of the
content assist functionality, so should be in a plugin that is part of
the ddk runtime feature. This change puts them in ddk.xtext.ide, but
leaves the old classes in place until the downstream projects are
adapted.