### PR TITLE
Revert "Do not force eager singleton"

### DIFF
--- a/com.avaloq.tools.ddk.xtext.valid.generator/src/com/avaloq/tools/ddk/xtext/valid/generator/ValidValidatorFragment.java
+++ b/com.avaloq.tools.ddk.xtext.valid.generator/src/com/avaloq/tools/ddk/xtext/valid/generator/ValidValidatorFragment.java
@@ -285,7 +285,7 @@ public class ValidValidatorFragment extends JavaValidatorFragment {
   @Override
   public Set<Binding> getGuiceBindingsRt(final Grammar grammar) {
 
-    return new BindFactory().addTypeToTypeSingleton(getJavaValidatorName(grammar, ""), getJavaValidatorName(grammar, "")).addTypeToType(CompositeEValidator.class.getName(), ValidCompositeEValidator.class.getName()).getBindings(); //$NON-NLS-1$ //$NON-NLS-2$
+    return new BindFactory().addTypeToTypeEagerSingleton(getJavaValidatorName(grammar, ""), getJavaValidatorName(grammar, "")).addTypeToType(CompositeEValidator.class.getName(), ValidCompositeEValidator.class.getName()).getBindings(); //$NON-NLS-1$ //$NON-NLS-2$
   }
 
   /**


### PR DESCRIPTION
Reverts dsldevkit/dsl-devkit#651

The change must be reverted because validations are registered during injection. If the injector does not create the singleton eagerly, the classes are never registered and its validations will never be called. The patter exists already in Xtext, so we shall keep it.