### PR TITLE
Revert "Do not force eager singleton"

### DIFF
--- a/com.avaloq.tools.ddk.check.generator/src/com/avaloq/tools/ddk/check/generator/CheckValidatorFragment.java
+++ b/com.avaloq.tools.ddk.check.generator/src/com/avaloq/tools/ddk/check/generator/CheckValidatorFragment.java
@@ -17,6 +17,10 @@ import org.eclipse.xtext.generator.AbstractGeneratorFragment;
 import org.eclipse.xtext.generator.BindFactory;
 import org.eclipse.xtext.generator.Binding;
 
+import com.avaloq.tools.ddk.check.runtime.validation.AbstractCheckValidator;
+import com.avaloq.tools.ddk.check.runtime.validation.DefaultCheckValidator;
+
+
 /**
  * This generator fragment supplies default bindings for languages using Static Code Analysis.
  */
@@ -27,6 +31,7 @@ public class CheckValidatorFragment extends AbstractGeneratorFragment {
   public Set<Binding> getGuiceBindingsRt(final Grammar grammar) {
     BindFactory factory = new BindFactory();
 
+    factory.addTypeToTypeEagerSingleton(AbstractCheckValidator.class.getName(), DefaultCheckValidator.class.getName());
     // Uncomment once not conflicting with ValidValidatorFragment anymore
     // factory.addTypeToType(CompositeEValidator.class.getName(), CheckCompositeEValidator.class.getName()).getBindings();
 

--- a/com.avaloq.tools.ddk.check.generator/src/com/avaloq/tools/ddk/check/generator/CheckValidatorFragment2.xtend
+++ b/com.avaloq.tools.ddk.check.generator/src/com/avaloq/tools/ddk/check/generator/CheckValidatorFragment2.xtend
@@ -12,14 +12,18 @@
 package com.avaloq.tools.ddk.check.generator
 
 import org.eclipse.xtext.xtext.generator.AbstractXtextGeneratorFragment
+import static extension org.eclipse.xtext.xtext.generator.model.TypeReference.*
 import org.eclipse.xtext.xtext.generator.model.GuiceModuleAccess
+import com.avaloq.tools.ddk.check.runtime.validation.AbstractCheckValidator
+import com.avaloq.tools.ddk.check.runtime.validation.DefaultCheckValidator
 
 class CheckValidatorFragment2 extends AbstractXtextGeneratorFragment {
 
   static val RUNTIME_PLUGIN = "com.avaloq.tools.ddk.check.runtime.core"
 
   override generate() {
-    new GuiceModuleAccess.BindingFactory().contributeTo(language.runtimeGenModule)
+    new GuiceModuleAccess.BindingFactory().addTypeToTypeEagerSingleton(AbstractCheckValidator.typeRef,
+      DefaultCheckValidator.typeRef).contributeTo(language.runtimeGenModule)
 
     if (projectConfig.runtime.manifest !== null) {
       projectConfig.runtime.manifest.requiredBundles += RUNTIME_PLUGIN


### PR DESCRIPTION
Reverts dsldevkit/dsl-devkit#650

The change must be reverted because validations are registered during injection. If the injector does not create the singleton eagerly, the classes are never registered and its validations will never be called. The patter exists already in Xtext, so we shall keep it.