### PR TITLE
Mr QA: fix Java warning

### DIFF
--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/DynamicViewMenu.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/DynamicViewMenu.java
@@ -98,7 +98,6 @@ public class DynamicViewMenu {
           break;
         }
       }
-      int dummy = 0;
     }
     return theItem;
   }


### PR DESCRIPTION
The previous change left an unused dummy variable in the code, this change removes it.