### PR TITLE
Generate binary models for *.check files

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/CheckRuntimeModule.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/CheckRuntimeModule.java
@@ -17,6 +17,7 @@ import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.parser.antlr.IPartialParsingHelper;
 import org.eclipse.xtext.preferences.IPreferenceValuesProvider;
 import org.eclipse.xtext.resource.ILocationInFileProvider;
+import org.eclipse.xtext.resource.persistence.IResourceStorageFacade;
 import org.eclipse.xtext.scoping.IGlobalScopeProvider;
 import org.eclipse.xtext.scoping.IScopeProvider;
 import org.eclipse.xtext.xbase.compiler.XbaseCompiler;
@@ -30,6 +31,7 @@ import com.avaloq.tools.ddk.check.generator.CheckCompiler;
 import com.avaloq.tools.ddk.check.generator.CheckOutputConfigurationProvider;
 import com.avaloq.tools.ddk.check.imports.CheckRewritableImportSectionFactory;
 import com.avaloq.tools.ddk.check.naming.CheckDeclarativeQualifiedNameProvider;
+import com.avaloq.tools.ddk.check.resource.CheckBatchLinkableResourceStorageFacade;
 import com.avaloq.tools.ddk.check.resource.CheckLocationInFileProvider;
 import com.avaloq.tools.ddk.check.resource.CheckResourceDescriptionStrategy;
 import com.avaloq.tools.ddk.check.scoping.CheckLinkingService;
@@ -46,6 +48,10 @@ import com.google.inject.name.Names;
  */
 @SuppressWarnings({"PMD.CouplingBetweenObjects", "restriction"})
 public class CheckRuntimeModule extends com.avaloq.tools.ddk.check.AbstractCheckRuntimeModule {
+
+  public Class<? extends IResourceStorageFacade> bindIResourceStorageFacade() {
+    return CheckBatchLinkableResourceStorageFacade.class;
+  }
 
   @Override
   public Class<? extends ILinkingService> bindILinkingService() {

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/resource/CheckBatchLinkableResourceStorageFacade.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/resource/CheckBatchLinkableResourceStorageFacade.java
@@ -1,0 +1,29 @@
+package com.avaloq.tools.ddk.check.resource;
+
+import org.eclipse.xtext.generator.IFileSystemAccess;
+import org.eclipse.xtext.generator.IFileSystemAccessExtension3;
+import org.eclipse.xtext.resource.persistence.StorageAwareResource;
+import org.eclipse.xtext.xbase.resource.BatchLinkableResourceStorageFacade;
+
+
+@SuppressWarnings("restriction")
+public class CheckBatchLinkableResourceStorageFacade extends BatchLinkableResourceStorageFacade {
+
+  /**
+   * If the resource contains errors, any existing storage will be deleted.
+   */
+  @Override
+  @SuppressWarnings({"checkstyle:IllegalCatch"})
+  public void saveResource(final StorageAwareResource resource, final IFileSystemAccessExtension3 fsa) {
+    try {
+      if (resource.getErrors().isEmpty()) {
+        super.saveResource(resource, fsa);
+      } else {
+        ((IFileSystemAccess) fsa).deleteFile(computeOutputPath(resource));
+      }
+    } catch (Exception e) {
+      ((IFileSystemAccess) fsa).deleteFile(computeOutputPath(resource));
+      throw e;
+    }
+  }
+}

--- a/com.avaloq.tools.ddk.check.ui.test/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.check.ui.test/META-INF/MANIFEST.MF
@@ -20,6 +20,7 @@ Require-Bundle: org.junit,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.core.runtime,
+ org.slf4j.ext,
  org.eclipse.ui.workbench;resolution:=optional,
  org.objectweb.asm;resolution:=optional
 Export-Package: com.avaloq.tools.ddk.check.ui.test,

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
@@ -55,11 +55,17 @@ public class DirectLinkingResourceStorageFacade extends ResourceStorageFacade {
    * If the resource contains errors, any existing storage will be deleted.
    */
   @Override
+  @SuppressWarnings({"checkstyle:IllegalCatch"})
   public void saveResource(final StorageAwareResource resource, final IFileSystemAccessExtension3 fsa) {
-    // delete storage first in case saving fails
-    deleteStorage(resource.getURI(), (IFileSystemAccess) fsa);
-    if (resource.getErrors().isEmpty()) {
-      super.saveResource(resource, fsa);
+    try {
+      if (resource.getErrors().isEmpty()) {
+        super.saveResource(resource, fsa);
+      } else {
+        deleteStorage(resource.getURI(), (IFileSystemAccess) fsa);
+      }
+    } catch (Exception e) {
+      deleteStorage(resource.getURI(), (IFileSystemAccess) fsa);
+      throw e;
     }
   }
 


### PR DESCRIPTION
We modify `CheckRuntimeModule` to generate binary models for all `*.check` files.

Also includes a minor change to resolve an error that Eclipse reported due to `org.slf4j.ext` not being included in the `MANIFEST.MD` associated with `ddk.check.ui.test`.