### PR TITLE
Skip the creation of the resource-description entry in binary models

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/resource/CheckBatchLinkableResourceStorageWritable.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/resource/CheckBatchLinkableResourceStorageWritable.java
@@ -73,15 +73,8 @@ public class CheckBatchLinkableResourceStorageWritable extends BatchLinkableReso
       zipOut.closeEntry();
     }
 
-    zipEntry = new ZipEntry("resource-description");
-    zipEntry.setLastModifiedTime(FIXED_LAST_MODIFIED_DATETIME); // Unique to this class
-    zipOut.putNextEntry(zipEntry);
-    try {
-      writeResourceDescription(resource, bufferedOutput);
-    } finally {
-      bufferedOutput.flush();
-      zipOut.closeEntry();
-    }
+    // "resource-description" entry would go here but is skipped in this class's implementation
+
     if (storeNodeModel) {
       zipEntry = new ZipEntry("node-model");
       zipEntry.setLastModifiedTime(FIXED_LAST_MODIFIED_DATETIME); // Unique to this class


### PR DESCRIPTION
The "resource-description" entry can give rise to non-deterministic binary model files. In addition, it may result in slower overall loading times.

As a result, we bypass the step for the creation of the "resource-description" entry in the overriden writeEntries method.