### PR TITLE
Fix for builds containing CheckCfg sources.

### DIFF
--- a/com.avaloq.tools.ddk.checkcfg.core/src-gen/com/avaloq/tools/ddk/checkcfg/CheckCfgStandaloneSetupGenerated.java
+++ b/com.avaloq.tools.ddk.checkcfg.core/src-gen/com/avaloq/tools/ddk/checkcfg/CheckCfgStandaloneSetupGenerated.java
@@ -33,7 +33,5 @@ public class CheckCfgStandaloneSetupGenerated implements ISetup {
 		
 		Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put("checkcfg", resourceFactory);
 		IResourceServiceProvider.Registry.INSTANCE.getExtensionToFactoryMap().put("checkcfg", serviceProvider);
-		Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put("CHECKCFG", resourceFactory);
-		IResourceServiceProvider.Registry.INSTANCE.getExtensionToFactoryMap().put("CHECKCFG", serviceProvider);
 	}
 }

--- a/com.avaloq.tools.ddk.checkcfg.ui/plugin.xml_gen
+++ b/com.avaloq.tools.ddk.checkcfg.ui/plugin.xml_gen
@@ -228,19 +228,6 @@
 	    uriExtension="checkcfg">
 	  </resourceServiceProvider>
 	</extension>
-	<extension
-	  point="org.eclipse.emf.ecore.extension_parser">
-	  <parser
-	    class="com.avaloq.tools.ddk.checkcfg.ui.CheckCfgExecutableExtensionFactory:org.eclipse.xtext.resource.IResourceFactory"
-	    type="CHECKCFG">
-	  </parser>
-	</extension>
-	<extension point="org.eclipse.xtext.extension_resourceServiceProvider">
-	  <resourceServiceProvider
-	    class="com.avaloq.tools.ddk.checkcfg.ui.CheckCfgExecutableExtensionFactory:org.eclipse.xtext.ui.resource.IResourceUIServiceProvider"
-	    uriExtension="CHECKCFG">
-	  </resourceServiceProvider>
-	</extension>
 	<!-- marker definitions for com.avaloq.tools.ddk.checkcfg.CheckCfg -->
 	<extension
 			id="checkcfg.check.fast"

--- a/com.avaloq.tools.ddk.workflow/src/com/avaloq/tools/ddk/workflow/GenerateCheckCfg.mwe2
+++ b/com.avaloq.tools.ddk.workflow/src/com/avaloq/tools/ddk/workflow/GenerateCheckCfg.mwe2
@@ -25,5 +25,4 @@ var generateLspSetup = true
     languageName = "CheckCfg"
     registerGenModelFiles = "${check.genmodel}"
     editorFileExtensions = "checkcfg"
-    resourceFactoryFileExtensions = "checkcfg, CHECKCFG"
 }


### PR DESCRIPTION
Don't register a resource service against CHECKCFG extension otherwise these sources get incorrectly included in standalone builds.