### PR TITLE
Add LSP content assist for CheckCfg configuration parameters.

### DIFF
--- a/com.avaloq.tools.ddk.checkcfg.core/src/com/avaloq/tools/ddk/checkcfg/checkcfg/impl/CheckConfigurationImplCustom.java
+++ b/com.avaloq.tools.ddk.checkcfg.core/src/com/avaloq/tools/ddk/checkcfg/checkcfg/impl/CheckConfigurationImplCustom.java
@@ -13,10 +13,13 @@ package com.avaloq.tools.ddk.checkcfg.checkcfg.impl;
 
 import org.eclipse.emf.common.util.ECollections;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EObjectContainmentEList;
 import org.eclipse.xtext.EcoreUtil2;
+import org.eclipse.xtext.resource.XtextResource;
 
 import com.avaloq.tools.ddk.check.check.FormalParameter;
+import com.avaloq.tools.ddk.checkcfg.checkcfg.CheckConfiguration;
 import com.avaloq.tools.ddk.checkcfg.checkcfg.CheckcfgPackage;
 import com.avaloq.tools.ddk.checkcfg.checkcfg.ConfigurableSection;
 import com.avaloq.tools.ddk.checkcfg.util.PropertiesInferenceHelper;
@@ -26,13 +29,17 @@ import com.avaloq.tools.ddk.checkcfg.util.PropertiesInferenceHelper;
  * The Class CheckConfigurationImplCustom.
  */
 public class CheckConfigurationImplCustom extends CheckConfigurationImpl {
+  private static final String PROPERTIES_KEY = CheckConfiguration.class.getName() + "#properties"; //$NON-NLS-1$
 
   /** {@inheritDoc} */
   @Override
   public EList<FormalParameter> getProperties() {
-    EList<FormalParameter> properties = new EObjectContainmentEList<FormalParameter>(FormalParameter.class, this, CheckcfgPackage.CHECK_CONFIGURATION__PROPERTIES);
-    PropertiesInferenceHelper helper = PropertiesInferenceHelper.getHelper();
-    return helper.getProperties(this, properties);
+    Resource resource = eResource();
+    return ((XtextResource) resource).getCache().get(PROPERTIES_KEY, resource, () -> {
+      EList<FormalParameter> properties = new EObjectContainmentEList<FormalParameter>(FormalParameter.class, this, CheckcfgPackage.CHECK_CONFIGURATION__PROPERTIES);
+      PropertiesInferenceHelper helper = PropertiesInferenceHelper.getHelper();
+      return helper.getProperties(this, properties);
+    });
   }
 
   @Override

--- a/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/CheckCfgIdeModule.java
+++ b/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/CheckCfgIdeModule.java
@@ -24,6 +24,7 @@ import com.google.inject.name.Names;
  */
 @SuppressWarnings("restriction")
 public class CheckCfgIdeModule extends AbstractCheckCfgIdeModule {
+  private static final String LANGUAGE_LABEL = "languageLabel"; //$NON-NLS-1$
 
   @Override
   public void configureIResourceDescriptionsLiveScope(final Binder binder) {
@@ -105,5 +106,9 @@ public class CheckCfgIdeModule extends AbstractCheckCfgIdeModule {
   @Override
   public Class<? extends IdeContentProposalProvider> bindIdeContentProposalProvider() {
     return CheckCfgIdeContentProposalProvider.class;
+  }
+
+  public void configureLanguageLabel(final Binder binder) {
+    binder.bind(String.class).annotatedWith(Names.named(LANGUAGE_LABEL)).toInstance("CheckCfg"); //$NON-NLS-1$
   }
 }

--- a/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/contentassist/CheckCfgIdeContentProposalProvider.java
+++ b/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/contentassist/CheckCfgIdeContentProposalProvider.java
@@ -18,6 +18,7 @@ import java.util.StringJoiner;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.Assignment;
+import org.eclipse.xtext.CrossReference;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.Keyword;
 import org.eclipse.xtext.RuleCall;
@@ -80,6 +81,15 @@ public class CheckCfgIdeContentProposalProvider extends XbaseIdeContentProposalP
     } else {
       super._createProposals(assignment, context, acceptor);
     }
+  }
+
+  @Override
+  protected Predicate<IEObjectDescription> getCrossrefFilter(final CrossReference reference, final ContentAssistContext context) {
+    // we don't want references to dummy java classes to be proposed, and 'real' proposals come from completeParameterValue() anyway.
+    if (context.getCurrentModel() instanceof ConfiguredParameter) {
+      return Predicates.alwaysFalse();
+    }
+    return Predicates.alwaysTrue();
   }
 
   @Override


### PR DESCRIPTION
Use the service loader to find configuration parameters as the extension point registry does not exist in the LSP server.
Filter out dummy java classes from proposals for configuration parameter values.

Also contains improvement to CheckCfg build performance and a fix to allow markers to be sent back to the client.