### PR TITLE
Add option to skip loading the derived state when loading resources

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
@@ -42,6 +42,7 @@ import org.eclipse.xtext.util.Triple;
 import com.avaloq.tools.ddk.xtext.build.BuildPhases;
 import com.avaloq.tools.ddk.xtext.parser.IResourceAwareParser;
 import com.avaloq.tools.ddk.xtext.resource.IResourceSetServiceCache;
+import com.avaloq.tools.ddk.xtext.resource.ResourceSetOptions;
 import com.avaloq.tools.ddk.xtext.resource.ServiceCacheAdapter;
 import com.avaloq.tools.ddk.xtext.resource.persistence.ResourceLoadMode;
 import com.avaloq.tools.ddk.xtext.tracing.ITraceSet;
@@ -334,7 +335,9 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
       try {
         traceSet.started(ResourceInferenceEvent.class, getURI());
         isInitializing = true;
-        derivedStateComputer.installDerivedState(this, isPrelinkingPhase);
+        if (ResourceSetOptions.installDerivedState(resourceSet)) {
+          derivedStateComputer.installDerivedState(this, isPrelinkingPhase);
+        }
         fullyInitialized = true;
       } finally {
         isInitializing = false;

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceSetOptions.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceSetOptions.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.xtext.resource;
+
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+
+
+/**
+ * A class to set and get DDK specific options over an EMF ResourceSet, similar to {@link org.eclipse.xtext.resource.ResourceSetContext}.
+ */
+@SuppressWarnings("nls")
+public final class ResourceSetOptions {
+
+  private static final String INSTALL_DERIVED_STATE = "com.avaloq.tools.ddk.xtext.resource.ResourceSetOptions.installDerivedState";
+
+  private ResourceSetOptions() {
+    // utility class
+  }
+
+  /**
+   * If the derived state should be installed.
+   *
+   * @param resourceSet
+   *          the resource set
+   * @return true, If the derived state should be installed
+   */
+  public static boolean installDerivedState(final @NonNull ResourceSet resourceSet) {
+    Object object = resourceSet.getLoadOptions().get(INSTALL_DERIVED_STATE);
+    return object == null || (boolean) object;
+  }
+
+  /**
+   * Sets the install derived state property.
+   *
+   * @param resourceSet
+   *          the resource set
+   * @param installDerivedState
+   *          {@code true} if the derived state should be installed
+   */
+  public static void setInstallDerivedState(final @NonNull ResourceSet resourceSet, final @Nullable Boolean installDerivedState) {
+    resourceSet.getLoadOptions().put(INSTALL_DERIVED_STATE, installDerivedState);
+  }
+
+}


### PR DESCRIPTION
Add option to skip loading the derived state when loading resources,
be it loading a binary models or a lazy linking resource.