### PR TITLE
Mr QA: partial revert of PR 771

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
@@ -105,6 +105,8 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
     } catch (IOException | RuntimeException e) {
       // CHECKSTYLE:ON
       LOG.info("Error loading " + resource.getURI() + " from binary storage", e); //$NON-NLS-1$ //$NON-NLS-2$
+      resource.getContents();
+      resource.eAdapters();
       if (e instanceof IOException) { // NOPMD
         throw e;
       }


### PR DESCRIPTION
In https://github.com/dsldevkit/dsl-devkit/pull/771, we removed the calls to resource.getContents() and resource.eAdapters() in the exception handler of the loadIntoResource methods. The XText bug which was the reason for having those 2 calls is closed, however, it turns out that removing them causes test failures in at least one consumer. Therefore, this PR re-introduces them pending a fuller investigation.