### PR TITLE
Update to format of check issue code values.

### DIFF
--- a/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/generator/IssueCodeValueTest.xtend
+++ b/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/generator/IssueCodeValueTest.xtend
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.check.core.generator
+
+import org.eclipse.xtext.testing.InjectWith
+import org.junit.runner.RunWith
+import com.avaloq.tools.ddk.check.CheckInjectorProvider
+import org.eclipse.xtext.testing.XtextRunner
+import com.avaloq.tools.ddk.check.core.test.AbstractCheckGenerationTestCase
+import org.junit.Test
+import java.util.List
+import org.eclipse.xtext.xbase.testing.JavaSource
+import java.io.ByteArrayInputStream
+
+@InjectWith(CheckInjectorProvider)
+@RunWith(XtextRunner)
+class IssueCodeValueTest extends AbstractCheckGenerationTestCase {
+
+  static final String PACKAGE_NAME = "mypackage"
+  static final String CATALOG_NAME = "MyCatalog"
+
+  /**
+   * Test the map generated from a catalog with checks.
+   */
+  @Test
+  def void testIssueCodeValue() {
+    // ARRANGE
+    // @Format-Off
+    val source = '''
+      package «PACKAGE_NAME»
+
+      import com.avaloq.tools.ddk.check.check.Check
+      import com.avaloq.tools.ddk.check.check.Context
+      import com.avaloq.tools.ddk.check.check.Documented
+
+      catalog «CATALOG_NAME»
+      for grammar com.avaloq.tools.ddk.check.Check {
+
+        live error MyCheck1 "Label 1"
+        message "Message 1" {
+          for Documented elem {
+            switch elem {
+              Context : issue on elem
+              Check : issue on elem
+            }
+          }
+        }
+
+        live error MyCheck2 "Label 2"
+        message "Message 2" {
+          for Documented elem {
+            switch elem {
+              Context : issue on elem
+              Check : issue on elem
+            }
+          }
+        }
+      }
+    ''';
+    // @Format-On
+
+    val expectedIssueCodeValues = #{'MY_CHECK_1' -> 'MyCheck1', 'MY_CHECK_2' -> 'MyCheck2'}
+
+    // ACT
+    var List<JavaSource> compiledClassesList
+    val sourceStream = new ByteArrayInputStream(source.getBytes());
+    try {
+      compiledClassesList = generateAndCompile(sourceStream);
+    } finally {
+      sourceStream.close
+    }
+
+    // ASSERT
+    val issueCodesClassName = '''«CATALOG_NAME»«ISSUE_CODES_SUFFIX»'''
+
+    val issueCodesClass = compiledClassesList.findFirst[s | s.fileName.equals(issueCodesClassName)].code;
+
+    for (issueCode: expectedIssueCodeValues.entrySet) {
+      val expectedIssueCodeAssignment = '''public static final String «issueCode.key» = "«PACKAGE_NAME».«CATALOG_NAME»«ISSUE_CODES_SUFFIX».«issueCode.value»";'''
+      assertTrue('''«issueCodesClassName» was generated correctly''', issueCodesClass.contains(expectedIssueCodeAssignment))
+    }
+  }
+
+}

--- a/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/AbstractCheckGenerationTestCase.java
+++ b/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/AbstractCheckGenerationTestCase.java
@@ -40,6 +40,7 @@ import com.google.inject.Injector;
 /**
  * An abstract test class for tests on Check models. Allows creating a project, adding files, and generating and compiling the project.
  */
+@SuppressWarnings("nls")
 public class AbstractCheckGenerationTestCase extends AbstractCheckTestCase {
 
   @Inject
@@ -53,7 +54,8 @@ public class AbstractCheckGenerationTestCase extends AbstractCheckTestCase {
 
   protected static final String VALIDATOR_NAME_SUFFIX = "CheckImpl";
   protected static final String CATALOG_NAME_SUFFIX = "CheckCatalog";
-  protected static final ImmutableSet<String> GENERATED_FILES = ImmutableSet.of(VALIDATOR_NAME_SUFFIX, CATALOG_NAME_SUFFIX, "IssueCodes", "PreferenceInitializer", "StandaloneSetup");
+  protected static final String ISSUE_CODES_SUFFIX = "IssueCodes";
+  protected static final ImmutableSet<String> GENERATED_FILES = ImmutableSet.of(VALIDATOR_NAME_SUFFIX, CATALOG_NAME_SUFFIX, ISSUE_CODES_SUFFIX, "PreferenceInitializer", "StandaloneSetup");
 
   /**
    * Generate and compile a Check.

--- a/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/test/core/CheckCoreTestSuite.java
+++ b/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/test/core/CheckCoreTestSuite.java
@@ -13,6 +13,7 @@ package com.avaloq.tools.ddk.check.test.core;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
+import com.avaloq.tools.ddk.check.core.generator.IssueCodeValueTest;
 import com.avaloq.tools.ddk.check.core.test.BasicModelTest;
 import com.avaloq.tools.ddk.check.core.test.BugAig1314;
 import com.avaloq.tools.ddk.check.core.test.BugAig830;
@@ -44,7 +45,8 @@ import com.avaloq.tools.ddk.check.validation.CheckValidationTest;
   BugDsl27.class,
   ProjectBasedTests.class,
   CheckApiAccessValidationsTest.class,
-  IssueCodeToLabelMapGenerationTest.class
+  IssueCodeToLabelMapGenerationTest.class,
+  IssueCodeValueTest.class
 // @Format-On
 })
 public class CheckCoreTestSuite {

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGenerator.xtend
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGenerator.xtend
@@ -116,7 +116,7 @@ class CheckGenerator extends JvmModelGenerator {
     */
   def compileIssueCodes(CheckCatalog catalog) {
     val allIssues = catalog.checkAndImplementationIssues // all Issue instances
-    val allIssueNames = allIssues.map(issue|issue.issueCode()).toSet // *all* issue names, unordered
+    val allIssueNames = allIssues.toMap([issue|issue.issueCode()], [issue|issue.issueName()]) // *all* issue names, unordered
 
     '''
     «IF !(catalog.packageName.isNullOrEmpty)»
@@ -129,8 +129,8 @@ class CheckGenerator extends JvmModelGenerator {
     @SuppressWarnings("all")
     public final class «catalog.issueCodesClassName» {
 
-      «FOR name:allIssueNames.sort»
-      public static final String «name» = "«issueCodeValue(catalog, name)»";
+      «FOR issueCode:allIssueNames.keySet.sort»
+      public static final String «issueCode» = "«issueCodeValue(catalog, allIssueNames.get(issueCode))»";
       «ENDFOR»
 
       private «catalog.issueCodesClassName»() {

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorExtensions.xtend
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorExtensions.xtend
@@ -72,14 +72,36 @@ class CheckGeneratorExtensions {
     }
   }
 
+  /* Gets the simple issue code name for a check. */
+  def static dispatch String issueName(Check check) {
+    if (null !== check.name) {
+      check.name
+    } else {
+      "ErrorIssueCodeNameCheck" // should only happen if the ID is missing, which will fail a validation
+    }
+  }
+
+  /* Gets the simple issue code name for an issue expression. */
+  def static dispatch String issueName(XIssueExpression issue) {
+    if (issue.issueCode !== null) {
+      issue.issueCode
+    } else if (issue.check !== null && !issue.check.eIsProxy) {
+      issueName(issue.check)
+    } else if (issue.parent(Check) !== null) {
+      issueName(issue.parent(Check))
+    } else {
+      "ErrorIssueCodeName_XIssueExpresion" // should not happen
+    }
+  }
+
   def static issueCodePrefix(CheckCatalog catalog) {
     catalog.packageName + "." + catalog.issueCodesClassName + "."
   }
 
   /* Returns the <b>value</b> of an issue code. */
-  def static issueCodeValue(EObject object, String issueCode) {
+  def static issueCodeValue(EObject object, String issueName) {
     val catalog = object.parent(typeof(CheckCatalog))
-    catalog.issueCodePrefix + issueCode.replaceAll("_", ".").toLowerCase
+    catalog.issueCodePrefix + issueName
   }
 
   /* Gets the issue label for a Check. */

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckPropertiesGenerator.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckPropertiesGenerator.java
@@ -86,7 +86,7 @@ public final class CheckPropertiesGenerator {
    * @return the key prefix, in this case the runtime issue code value
    */
   public static String issueCodeKeyPrefix(final EObject object) {
-    String issueName = CheckGeneratorExtensions.issueCode(object);
+    String issueName = CheckGeneratorExtensions.issueName(object);
     return CheckGeneratorExtensions.issueCodeValue(EcoreUtil2.getContainerOfType(object, CheckCatalog.class), issueName);
   }
 

--- a/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/builder/CheckMarkerHelpExtensionTest.java
+++ b/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/builder/CheckMarkerHelpExtensionTest.java
@@ -173,7 +173,7 @@ public class CheckMarkerHelpExtensionTest {
 
     List<String> issueCodesOfCheck = Lists.newArrayList();
     for (final XIssueExpression i : generatorExtension.issues(twoIssueCodes.getChecks().get(0))) {
-      issueCodesOfCheck.add(CheckGeneratorExtensions.issueCodeValue(twoIssueCodes.getChecks().get(0), CheckGeneratorExtensions.issueCode(i)));
+      issueCodesOfCheck.add(CheckGeneratorExtensions.issueCodeValue(twoIssueCodes.getChecks().get(0), CheckGeneratorExtensions.issueName(i)));
     }
     List<String> issueCodesInExtension = Lists.newArrayList();
     for (IPluginObject obj : extension.getChildren()) {

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckMarkerHelpExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckMarkerHelpExtensionHelper.java
@@ -113,8 +113,8 @@ public class CheckMarkerHelpExtensionHelper extends AbstractCheckDocumentationEx
     return Iterables.transform(generatorExtension.issues(check), new Function<XIssueExpression, String>() {
       @Override
       public String apply(final XIssueExpression input) {
-        String issueCode = CheckGeneratorExtensions.issueCode(input);
-        return CheckGeneratorExtensions.issueCodeValue(input, issueCode);
+        String issueName = CheckGeneratorExtensions.issueName(input);
+        return CheckGeneratorExtensions.issueCodeValue(input, issueName);
       }
     });
   }
@@ -131,8 +131,8 @@ public class CheckMarkerHelpExtensionHelper extends AbstractCheckDocumentationEx
     return Iterables.transform(generatorExtension.issues(catalog), new Function<XIssueExpression, String>() {
       @Override
       public String apply(final XIssueExpression input) {
-        String issueCode = CheckGeneratorExtensions.issueCode(input);
-        return CheckGeneratorExtensions.issueCodeValue(input, issueCode);
+        String issueName = CheckGeneratorExtensions.issueName(input);
+        return CheckGeneratorExtensions.issueCodeValue(input, issueName);
       }
     });
   }


### PR DESCRIPTION
Generated issue code values for checks no longer split the check name with dots ('.') but leave the check name in camel case.