### PR TITLE
Remove underscores from check issue code values.

### DIFF
--- a/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/generator/IssueCodeValueTest.xtend
+++ b/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/generator/IssueCodeValueTest.xtend
@@ -55,7 +55,7 @@ class IssueCodeValueTest extends AbstractCheckGenerationTestCase {
           }
         }
 
-        live error MyCheck2 "Label 2"
+        live error MyCheck_2 "Label 2"
         message "Message 2" {
           for Documented elem {
             switch elem {

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorExtensions.xtend
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorExtensions.xtend
@@ -33,6 +33,7 @@ import org.eclipse.xtext.EcoreUtil2
 import org.eclipse.xtext.validation.CheckType
 
 import static extension com.avaloq.tools.ddk.check.generator.CheckGeneratorNaming.*
+import static extension com.avaloq.tools.ddk.check.util.CheckUtil.*
 
 class CheckGeneratorExtensions {
 
@@ -101,7 +102,7 @@ class CheckGeneratorExtensions {
   /* Returns the <b>value</b> of an issue code. */
   def static issueCodeValue(EObject object, String issueName) {
     val catalog = object.parent(typeof(CheckCatalog))
-    catalog.issueCodePrefix + issueName
+    catalog.issueCodePrefix + issueName.toIssueCodeName
   }
 
   /* Gets the issue label for a Check. */

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/util/CheckUtil.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/util/CheckUtil.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.check.util;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.WordUtils;
+
 import com.avaloq.tools.ddk.check.runtime.registry.ICheckValidatorStandaloneSetup;
 
 
@@ -55,5 +58,17 @@ public final class CheckUtil {
    */
   public static String serviceRegistryClassName() {
     return ICheckValidatorStandaloneSetup.class.getName();
+  }
+
+  /**
+   * Convert the given issue name into an issue code name by removing any underscores and
+   * making camel case.
+   *
+   * @param issueName
+   *          the name of the issue to convert.
+   * @return the issue code name for the given issue name.
+   */
+  public static String toIssueCodeName(final String issueName) {
+    return StringUtils.remove(WordUtils.capitalize(issueName, new char[] {'_'}), '_');
   }
 }


### PR DESCRIPTION
The change to the check issue code values introduced underscores if the original check name contained underscores. This change fixes the issue code values to not contain underscores by using the check names converted to camel case.