### PR TITLE
Fix regressions in issue code values.

### DIFF
--- a/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/generator/IssueCodeValueTest.xtend
+++ b/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/generator/IssueCodeValueTest.xtend
@@ -64,11 +64,21 @@ class IssueCodeValueTest extends AbstractCheckGenerationTestCase {
             }
           }
         }
+
+        live error MYCheck3 "Label 3"
+        message "Message 3" {
+          for Documented elem {
+            switch elem {
+              Context : issue on elem
+              Check : issue on elem
+            }
+          }
+        }
       }
     ''';
     // @Format-On
 
-    val expectedIssueCodeValues = #{'MY_CHECK_1' -> 'MyCheck1', 'MY_CHECK_2' -> 'MyCheck2'}
+    val expectedIssueCodeValues = #{'MY_CHECK_1' -> 'MyCheck1', 'MY_CHECK_2' -> 'MyCheck2', 'MY_CHECK_3' -> 'MyCheck3'}
 
     // ACT
     var List<JavaSource> compiledClassesList
@@ -86,7 +96,7 @@ class IssueCodeValueTest extends AbstractCheckGenerationTestCase {
 
     for (issueCode: expectedIssueCodeValues.entrySet) {
       val expectedIssueCodeAssignment = '''public static final String «issueCode.key» = "«PACKAGE_NAME».«CATALOG_NAME»«ISSUE_CODES_SUFFIX».«issueCode.value»";'''
-      assertTrue('''«issueCodesClassName» was generated correctly''', issueCodesClass.contains(expectedIssueCodeAssignment))
+      assertTrue('''«issueCodesClassName» contains correct initialization of «issueCode.key»''', issueCodesClass.contains(expectedIssueCodeAssignment))
     }
   }
 

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorExtensions.xtend
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorExtensions.xtend
@@ -102,7 +102,7 @@ class CheckGeneratorExtensions {
   /* Returns the <b>value</b> of an issue code. */
   def static issueCodeValue(EObject object, String issueName) {
     val catalog = object.parent(typeof(CheckCatalog))
-    catalog.issueCodePrefix + issueName.toIssueCodeName
+    catalog.issueCodePrefix + issueName.splitCamelCase.toIssueCodeName
   }
 
   /* Gets the issue label for a Check. */

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/util/CheckUtil.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/util/CheckUtil.java
@@ -69,6 +69,6 @@ public final class CheckUtil {
    * @return the issue code name for the given issue name.
    */
   public static String toIssueCodeName(final String issueName) {
-    return StringUtils.remove(WordUtils.capitalize(issueName, new char[] {'_'}), '_');
+    return StringUtils.remove(WordUtils.capitalizeFully(issueName, new char[] {'_'}), '_');
   }
 }


### PR DESCRIPTION
Checks that have upper case words in their name now have their issue code values correctly converted to camel case.