### PR TITLE
Only perform detailed diff when both old and new resource descriptions exist.

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractCachingResourceDescriptionManager.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractCachingResourceDescriptionManager.java
@@ -21,8 +21,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.xtext.Constants;
@@ -243,14 +243,14 @@ public abstract class AbstractCachingResourceDescriptionManager extends DerivedS
 
     for (Delta delta : deltas) {
       if (delta.haveEObjectDescriptionsChanged()) {
-        if (delta instanceof ResourceDescriptionDelta && ((ResourceDescriptionDelta) delta).hasObjectFingerprints()) {
+        IResourceDescription oldDesc = delta.getOld();
+        IResourceDescription newDesc = delta.getNew();
+        if (oldDesc != null && newDesc != null && delta instanceof ResourceDescriptionDelta && ((ResourceDescriptionDelta) delta).hasObjectFingerprints()) {
           ResourceDescriptionDelta detailedDelta = (ResourceDescriptionDelta) delta;
           changedOrDeletedObjects.addAll(detailedDelta.getChangedObjects());
           changedOrDeletedObjects.addAll(detailedDelta.getDeletedObjects());
           addedObjects.putAll(containersState.getContainerHandle(delta.getUri()), detailedDelta.getAddedObjects());
         } else {
-          IResourceDescription oldDesc = delta.getOld();
-          IResourceDescription newDesc = delta.getNew();
           if (oldDesc != null) {
             changedOrDeletedResources.add(newDesc != null ? newDesc : oldDesc);
           } else {


### PR DESCRIPTION
The resource description manager only needs to perform a detailed diff of the resource descriptions if both the new and old descriptions exist. This fixes an issue where new resources failed to resolve linking errors because only resource references were present in the unresolved imported names.