### PR TITLE
Make additional property of MonitoredClusteredBuilderState accessible

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -311,6 +311,16 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
     return rawData;
   }
 
+  /**
+   * Provide access to the resourceServiceProviderRegistry to subclasses.
+   *
+   * @return the resourceServiceProviderRegistry.
+   */
+  protected IResourceServiceProvider.Registry getResourceServiceProviderRegistry() {
+    ensureLoaded();
+    return resourceServiceProviderRegistry;
+  }
+
   @Override
   @SuppressWarnings("PMD.AvoidInstanceofChecksInCatchClause")
   public synchronized ImmutableList<Delta> update(final BuildData buildData, final IProgressMonitor monitor) {


### PR DESCRIPTION
This commit provides access to resourceServiceProviderRegistry for subclasses of MonitoredClusteredBuilderState