### PR TITLE
Do not use a live view of the ExtensionFactoryMap

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceServiceProviderUtil.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceServiceProviderUtil.java
@@ -12,12 +12,10 @@ package com.avaloq.tools.ddk.xtext.resource;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.resource.IResourceServiceProvider;
-
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
 
 
 /**
@@ -31,14 +29,7 @@ public final class ResourceServiceProviderUtil {
    * @return the registered resource extensions, never {@code null}
    */
   public static Collection<String> getExtensions() {
-    final Set<String> extensions = IResourceServiceProvider.Registry.INSTANCE.getExtensionToFactoryMap().keySet();
-    Collection<String> decodedExtensions = Collections2.transform(extensions, new Function<String, String>() {
-      @Override
-      public String apply(final String from) {
-        return URI.decode(from);
-      }
-    });
-    return decodedExtensions;
+    return IResourceServiceProvider.Registry.INSTANCE.getExtensionToFactoryMap().keySet().stream().map(URI::decode).collect(Collectors.toSet());
   }
 
   /**


### PR DESCRIPTION
as this means that each time the extensions are accesed, the transform method will be applied. This has a high cost when the extension map is used for all the sources in the workspace. Since the registered extensions do not change once the system is setup, it is much more efficient to map the keys only once.