### PR TITLE
Update class filter to reflect change in test runner.

### DIFF
--- a/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/SwtBotClassFilter.java
+++ b/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/SwtBotClassFilter.java
@@ -27,7 +27,7 @@ public class SwtBotClassFilter extends Filter {
   public boolean shouldRun(final Description description) {
     assert FilterRegistry.isTestClass(description);
     final RunWith runWithAnnotation = description.getAnnotation(RunWith.class);
-    return runWithAnnotation != null && "com.avaloq.tools.ddk.test.ui.junit.runners.SwtBotRecordingTestRunner".equals(runWithAnnotation.value().getName());
+    return runWithAnnotation != null && "com.avaloq.tools.ddk.xtext.test.junit.runners.SwtBotRecordingTestRunner".equals(runWithAnnotation.value().getName());
   }
 
   @Override


### PR DESCRIPTION
The SwtBotRecordingTestRunner is now in a different package, so the SwtBotClassFilter needs to be updated otherwise no tests are found.