### PR TITLE
Added exclude rule for AbstractQuickfixTest.

### DIFF
--- a/ddk-configuration/pmd/ruleset.xml
+++ b/ddk-configuration/pmd/ruleset.xml
@@ -10,6 +10,7 @@
   <exclude-pattern>.*/src-gen/.*</exclude-pattern>
   <exclude-pattern>.*/src-model/.*</exclude-pattern>
   <exclude-pattern>.*/xtend-gen/.*</exclude-pattern>
+  <exclude-pattern>.*/ddk/xtext/test/ui/quickfix/AbstractQuickFixTest.*</exclude-pattern>
 
   <rule ref="category/java/errorprone.xml">
     <exclude name="AssignmentInOperand"/><!--Checkstyle-->


### PR DESCRIPTION
This file causes PMD to crash, so excluding it from PMD check via ruleset.

Change-Id: Ic586f15461e1c0a1294df6a335cae9120edecd49