### PR TITLE
Do not reject tasks for storing binary models

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -178,7 +178,10 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
     return new ThreadPoolExecutor(
         BINARY_STORAGE_EXECUTOR_PARALLELISM, BINARY_STORAGE_EXECUTOR_PARALLELISM, // corePoolSize, maximumPoolSize
         0, TimeUnit.MILLISECONDS,                                                 // keepAliveTime
-        new LinkedBlockingQueue<>(BINARY_STORAGE_EXECUTOR_QUEUE_CAPACITY), makeThreadFactory());
+        new LinkedBlockingQueue<>(BINARY_STORAGE_EXECUTOR_QUEUE_CAPACITY),
+        makeThreadFactory(),
+        new ThreadPoolExecutor.CallerRunsPolicy()
+        );
     // @Format-On
   }
 


### PR DESCRIPTION
In commit 4c15019, a upper limit for the number of unprocessed binary models was introduced. If this limit is reached, tasks are rejected if the default RejectedExecutionHandler of ThreadPoolExecutor is used. That is not what is intended, this commit changes the
RejectedExecutionHandler to CallerRunsPolicy.