### PR TITLE
Remove rules which have been removed in PMD 7.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,7 @@ jobs:
         uses: pmd/pmd-github-action@v2.0.0
         id: pmd
         with:
-          version: '6.55.0'
+          version: '7.1.0'
           rulesets: 'ddk-configuration/pmd/ruleset.xml'
           analyzeModifiedFilesOnly: false
       - name: Fail build if there are violations

--- a/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/AbstractCheckGenerationTestCase.java
+++ b/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/AbstractCheckGenerationTestCase.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang.Validate;
 import org.eclipse.emf.common.util.URI;
@@ -55,7 +56,7 @@ public class AbstractCheckGenerationTestCase extends AbstractCheckTestCase {
   protected static final String VALIDATOR_NAME_SUFFIX = "CheckImpl";
   protected static final String CATALOG_NAME_SUFFIX = "CheckCatalog";
   protected static final String ISSUE_CODES_SUFFIX = "IssueCodes";
-  protected static final ImmutableSet<String> GENERATED_FILES = ImmutableSet.of(VALIDATOR_NAME_SUFFIX, CATALOG_NAME_SUFFIX, ISSUE_CODES_SUFFIX, "PreferenceInitializer", "StandaloneSetup");
+  protected static final Set<String> GENERATED_FILES = ImmutableSet.of(VALIDATOR_NAME_SUFFIX, CATALOG_NAME_SUFFIX, ISSUE_CODES_SUFFIX, "PreferenceInitializer", "StandaloneSetup");
 
   /**
    * Generate and compile a Check.

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGenModelUtil.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGenModelUtil.java
@@ -45,6 +45,7 @@ import com.google.common.collect.Iterables;
  */
 public final class CheckGenModelUtil {
 
+  private static final String EXCEPTION_IN_GENERATION = "Exception in generation ({0})"; //$NON-NLS-1$
   private static final String GENMODEL_EXTENSION = "genmodel"; //$NON-NLS-1$
   /** Class-wide logger. */
   private static final Logger LOGGER = LogManager.getLogger(CheckGenModelUtil.class);
@@ -117,6 +118,7 @@ public final class CheckGenModelUtil {
       }
       // CHECKSTYLE:CHECK-OFF IllegalCatch
     } catch (RuntimeException e) {
+      LOGGER.error(NLS.bind(EXCEPTION_IN_GENERATION, eModelElement), e);
       // CHECKSTYLE:CHECK-ON IllegalCatch
     }
     try {
@@ -162,6 +164,7 @@ public final class CheckGenModelUtil {
       }
       // CHECKSTYLE:CHECK-OFF IllegalCatch
     } catch (Exception ex) {
+      LOGGER.error(NLS.bind(EXCEPTION_IN_GENERATION, uri), ex);
       // CHECKSTYLE:CHECK-ON IllegalCatch
     }
     return null;

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/util/GrammarHelper.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/util/GrammarHelper.java
@@ -34,7 +34,7 @@ public class GrammarHelper {
 
   /**
    * Instantiates a new grammar helper.
-   * 
+   *
    * @param grammar
    *          the grammar
    */
@@ -44,7 +44,7 @@ public class GrammarHelper {
 
   /**
    * Gets the bundle symbolic name.
-   * 
+   *
    * @param classe
    *          the class
    * @return the bundle symbolic name
@@ -66,12 +66,12 @@ public class GrammarHelper {
    */
   public String getLabelName() {
     String name = getGrammar().getName();
-    return name.substring(name.lastIndexOf('.') == -1 ? 0 : name.lastIndexOf('.') + 1) + " - " + name;
+    return name.substring(name.lastIndexOf('.') == -1 ? 0 : name.lastIndexOf('.') + 1) + " - " + name; //$NON-NLS-1$
   }
 
   /**
    * Gets the Java interface that corresponds to a grammar's top-level grammar rule.
-   * 
+   *
    * @param metamodelDeclaration
    *          the metamodel declaration
    * @return the first interface corresponding to a grammar's top-level grammar rule
@@ -82,7 +82,7 @@ public class GrammarHelper {
 
   /**
    * Gets the Java interface that corresponds to a grammar's top-level grammar rule.
-   * 
+   *
    * @param ePackage
    *          the EPackage for the grammar
    * @return the first interface corresponding to a grammar's top-level grammar rule
@@ -93,7 +93,7 @@ public class GrammarHelper {
 
   /**
    * Gets the grammar.
-   * 
+   *
    * @return the grammar
    */
   public Grammar getGrammar() {
@@ -103,7 +103,7 @@ public class GrammarHelper {
 
   /**
    * Gets the name of the bundles required for this grammar.
-   * 
+   *
    * @return the required bundle symbolic names
    */
   public Set<String> getRequiredBundleSymbolicNames() {
@@ -123,11 +123,11 @@ public class GrammarHelper {
 
   /**
    * Returns the list of metamodel declarations Java packages.
-   * 
+   *
    * @return the metamodel packages
    */
   public List<String> getMetamodelPackages() {
-    ArrayList<String> list = new ArrayList<String>();
+    List<String> list = new ArrayList<String>();
     for (AbstractMetamodelDeclaration metamodelDeclaration : getGrammar().getMetamodelDeclarations()) {
       list.add(getFirstInterface(metamodelDeclaration).getPackage().getName());
     }

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/internal/LanguageCheckCatalogRegistryReader.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/internal/LanguageCheckCatalogRegistryReader.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.check.runtime.internal;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
 
@@ -84,7 +84,7 @@ class LanguageCheckCatalogRegistryReader extends AbstractCheckRegistryReader {
 
   @Override
   protected boolean readElement(final IConfigurationElement element, final boolean add) {
-    if (element.getAttribute(getAttribute()) == null) {
+    if (element.getAttribute(getAttribute()) == null) { // NOPMD SimplifyBooleanReturns
       return true; // the element is optional, no need to log an error
     }
     return super.readElement(element, add);

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/AbstractIssue.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/AbstractIssue.java
@@ -26,16 +26,16 @@ public abstract class AbstractIssue implements IIssue {
     switch (severityKind) {
     case ERROR:
       acceptor.acceptError(message, object, feature, index, issueCode, issueData);
-      return;
+      break;
     case WARNING:
       acceptor.acceptWarning(message, object, feature, index, issueCode, issueData);
-      return;
+      break;
     case INFO:
       acceptor.acceptInfo(message, object, feature, index, issueCode, issueData);
-      return;
+      break;
     case IGNORE:
     default:
-      return;
+      // empty
     }
   }
 

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/ICheckValidatorImpl.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/ICheckValidatorImpl.java
@@ -37,7 +37,7 @@ public interface ICheckValidatorImpl {
    *
    * @return Map of issue code to label.
    */
-  ImmutableMap<String, String> getIssueCodeToLabelMap();
+  ImmutableMap<String, String> getIssueCodeToLabelMap(); // NOPMD LooseCoupling
 
   /**
    * Validate given object of given class. Return {@code true} if the object validates without issues.

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/label/CheckRuleLabelProvider.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/label/CheckRuleLabelProvider.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.Logger;
 
 import com.avaloq.tools.ddk.check.runtime.issue.ICheckValidatorImpl;
 import com.avaloq.tools.ddk.check.runtime.registry.ICheckValidatorRegistry;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -79,7 +78,7 @@ public class CheckRuleLabelProvider implements ICheckRuleLabelProvider {
     final Collection<ICheckValidatorImpl> validators = checkValidatorRegistry.getValidators();
 
     // Get the maps from all validators
-    final Stream<ImmutableMap<String, String>> issueCodeToLabelMaps = validators.stream().map(validatorClass -> getIssueCodeToLabelMap(validatorClass)).filter(Objects::nonNull);
+    final Stream<Map<String, String>> issueCodeToLabelMaps = validators.stream().map(validatorClass -> getIssueCodeToLabelMap(validatorClass)).filter(Objects::nonNull);
 
     // Munge the maps together
     final Map<String, String> issueCodeToLabelMap = merge(issueCodeToLabelMaps);
@@ -94,7 +93,7 @@ public class CheckRuleLabelProvider implements ICheckRuleLabelProvider {
    *          validator from which to get the map, must not be {@code null}
    * @return map for translating Check rule issue codes into human-readable labels, or {@code null} if an error occurs
    */
-  private static ImmutableMap<String, String> getIssueCodeToLabelMap(final ICheckValidatorImpl validator) {
+  private static Map<String, String> getIssueCodeToLabelMap(final ICheckValidatorImpl validator) {
     try {
       return validator.getIssueCodeToLabelMap();
     } catch (AbstractMethodError e) {

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/registry/impl/CheckCatalogRegistryImpl.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/registry/impl/CheckCatalogRegistryImpl.java
@@ -11,7 +11,6 @@
 package com.avaloq.tools.ddk.check.runtime.registry.impl;
 
 import java.util.NavigableSet;
-import java.util.TreeSet;
 
 import com.avaloq.tools.ddk.check.runtime.configuration.BundleAwareModelLocation;
 import com.avaloq.tools.ddk.check.runtime.configuration.IModelLocation;
@@ -39,7 +38,7 @@ public class CheckCatalogRegistryImpl extends AbstractCheckImplDescriptorRegistr
   @Override
   @SuppressWarnings("unchecked")
   public NavigableSet<IModelLocation> getAllCheckModelLocations() {
-    TreeSet<IModelLocation> result = Sets.newTreeSet(concreteModelLocations.values());
+    NavigableSet<IModelLocation> result = Sets.newTreeSet(concreteModelLocations.values());
     for (Object v : getLanguageToDescriptorMap().values()) {
       if (v instanceof Provider<?>) {
         final BundleAwareModelLocation location = ((Provider<BundleAwareModelLocation>) v).get();

--- a/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/quickfix/DefaultCheckQuickfixProvider.java
+++ b/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/quickfix/DefaultCheckQuickfixProvider.java
@@ -16,8 +16,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.xtext.Constants;
 import org.eclipse.xtext.diagnostics.Diagnostic;
 import org.eclipse.xtext.ui.editor.quickfix.AbstractDeclarativeQuickfixProvider;
@@ -75,7 +75,7 @@ public class DefaultCheckQuickfixProvider extends DefaultQuickfixProvider {
 
   @Override
   public boolean hasResolutionFor(final String issueCode) {
-    if (Diagnostic.LINKING_DIAGNOSTIC.equals(issueCode)) {
+    if (Diagnostic.LINKING_DIAGNOSTIC.equals(issueCode)) { // NOPMD SimplifyBooleanReturns
       return false;
     }
     return super.hasResolutionFor(issueCode);

--- a/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/quickfix/XtextDocumentAdapter.java
+++ b/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/quickfix/XtextDocumentAdapter.java
@@ -57,7 +57,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
     try {
       return document.getChar(offset);
     } catch (org.eclipse.jface.text.BadLocationException e) {
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
   }
 
@@ -76,7 +76,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
     try {
       return document.get(offset, length);
     } catch (org.eclipse.jface.text.BadLocationException e) {
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
   }
 
@@ -90,7 +90,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
     try {
       document.replace(offset, length, text);
     } catch (org.eclipse.jface.text.BadLocationException e) {
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
   }
 
@@ -100,7 +100,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
       return document.getLineLength(line);
     } catch (org.eclipse.jface.text.BadLocationException e) {
 
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
   }
 
@@ -109,7 +109,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
     try {
       return document.getLineOfOffset(offset);
     } catch (org.eclipse.jface.text.BadLocationException e) {
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
   }
 
@@ -118,7 +118,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
     try {
       return document.getLineOffset(line);
     } catch (org.eclipse.jface.text.BadLocationException e) {
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
   }
 
@@ -138,7 +138,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
         }
       };
     } catch (org.eclipse.jface.text.BadLocationException e) {
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
   }
 
@@ -158,7 +158,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
         }
       };
     } catch (org.eclipse.jface.text.BadLocationException e) {
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
 
   }
@@ -173,7 +173,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
     try {
       return document.getNumberOfLines(offset, length);
     } catch (org.eclipse.jface.text.BadLocationException e) {
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
   }
 
@@ -192,7 +192,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
     try {
       return document.getLineDelimiter(line);
     } catch (org.eclipse.jface.text.BadLocationException e) {
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
   }
 
@@ -202,7 +202,7 @@ public class XtextDocumentAdapter implements ICoreXtextDocument {
     try {
       return document.search(startOffset, findString, forwardSearch, caseSensitive, wholeWord);
     } catch (org.eclipse.jface.text.BadLocationException e) {
-      throw new BadLocationException(e);
+      throw new BadLocationException(e); // NOPMD AvoidThrowingNewInstanceOfSameException
     }
   }
 }

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckExtensionGenerator.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckExtensionGenerator.java
@@ -22,8 +22,8 @@ import java.util.Locale;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
@@ -261,7 +261,7 @@ class CheckExtensionGenerator {
       void checkLoad(final Node node) {
         fName = node.getNodeName();
         if (fAttributes == null) {
-          fAttributes = new Hashtable();
+          fAttributes = new Hashtable(); // NOPMD LooseCoupling
         }
         NamedNodeMap attributes = node.getAttributes();
         for (int i = 0; i < attributes.getLength(); i++) {

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/AbstractCheckExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/AbstractCheckExtensionHelper.java
@@ -218,7 +218,7 @@ public abstract class AbstractCheckExtensionHelper implements ICheckExtensionHel
       return false; // disabled until https://bugs.eclipse.org/bugs/show_bug.cgi?id=369534 is fixed
     }
     String projectSetting = projectHelper.getProjectPreference(base.getUnderlyingResource().getProject(), getExtensionEnablementPreferenceName());
-    return projectSetting == null || Boolean.valueOf(projectSetting);
+    return projectSetting == null || Boolean.parseBoolean(projectSetting);
   }
 
   /**

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/hover/CheckHoverProvider.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/hover/CheckHoverProvider.java
@@ -82,10 +82,10 @@ public class CheckHoverProvider extends XbaseHoverProvider {
 
   private void appendSection(final StringBuffer buffer, final String title, final String content) {
     if (title != null && title.length() > 0) {
-      buffer.append("<p><b>" + title + ":</b></p>");
+      buffer.append("<p><b>").append(title).append(":</b></p>");
     }
     if (content != null && content.length() > 0) {
-      buffer.append("<p>" + content + "</p>");
+      buffer.append("<p>").append(content).append("</p>");
     }
   }
 }

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/popup/actions/DeployJob.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/popup/actions/DeployJob.java
@@ -234,14 +234,13 @@ public class DeployJob extends Job {
           if (isProjectJarIgnoreResource(resource)) {
             return false;
           }
-          if (resource instanceof IFolder && "bin".equals(resource.getName())) {
+          if (resource instanceof IFolder && "bin".equals(resource.getName())) { // NOPMD SimplifyBooleanReturns
             return false;
           }
           return true;
         }
       });
     } catch (CoreException e) {
-      LOGGER.error(e.getMessage(), e);
       throw new DeployException(e);
     }
     return checkCfgFiles;
@@ -263,7 +262,6 @@ public class DeployJob extends Job {
     try {
       buildProject();
     } catch (CoreException e) {
-      LOGGER.error("Failed to build project", e); //$NON-NLS-1$
       throw new DeployException(e);
     }
 
@@ -341,10 +339,7 @@ public class DeployJob extends Job {
    * @return true, if is project jar ignore resource
    */
   private boolean isProjectJarIgnoreResource(final IResource resource) {
-    if (IGNORED_RESOURCES.contains(resource.getName())) {
-      return true;
-    }
-    return getJavaOutputDirectory().toOSString().equals(resource.getLocation().toOSString());
+    return IGNORED_RESOURCES.contains(resource.getName()) && getJavaOutputDirectory().toOSString().equals(resource.getLocation().toOSString());
   }
 
   /**
@@ -360,7 +355,7 @@ public class DeployJob extends Job {
         outputLocation = javaProject.getOutputLocation();
       }
     } catch (JavaModelException e) {
-      LOGGER.error("Failed to get java output of the project", e); //$NON-NLS-1$
+      LOGGER.error("Failed to get java output of the project", e); //$NON-NLS-1$ // NOPMD InvalidLogMessageFormat
       return null;
     }
     return outputLocation;

--- a/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/ClassRunner.java
+++ b/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/ClassRunner.java
@@ -121,9 +121,9 @@ public class ClassRunner extends BlockJUnit4ClassRunner {
   public ClassRunner(final Class<?> klass) throws InitializationError {
     super(klass);
     SorterUtil.getInstance().initializeSorter(this);
-    testRuns = Integer.valueOf(System.getProperty(PROPERTY_TEST_RUNS, "1")); //$NON-NLS-1$
-    testRetries = Integer.valueOf(System.getProperty(PROPERTY_TEST_RETRIES, "0")); //$NON-NLS-1$
-    unstableFail = Boolean.valueOf(System.getProperty(PROPERTY_UNSTABLE_FAIL, "false")); //$NON-NLS-1$
+    testRuns = Integer.parseInt(System.getProperty(PROPERTY_TEST_RUNS, "1")); //$NON-NLS-1$
+    testRetries = Integer.parseInt(System.getProperty(PROPERTY_TEST_RETRIES, "0")); //$NON-NLS-1$
+    unstableFail = Boolean.parseBoolean(System.getProperty(PROPERTY_UNSTABLE_FAIL, "false")); //$NON-NLS-1$
   }
 
   /**
@@ -250,7 +250,7 @@ public class ClassRunner extends BlockJUnit4ClassRunner {
           LOGGER.info(stringWriter.toString());
         }
       }
-    } catch (AssumptionViolatedException e) {
+    } catch (AssumptionViolatedException e) { // NOPMD ExceptionAsFlowControl
       eachNotifier.addFailedAssumption(e);
       // CHECKSTYLE:CHECK-OFF IllegalCatch // we want to catch all possible errors
     } catch (Throwable e) {

--- a/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/DynamicSuite.java
+++ b/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/DynamicSuite.java
@@ -73,7 +73,7 @@ public class DynamicSuite extends Suite {
     // get annotation
     SuiteClasses annotation = clazz.getAnnotation(SuiteClasses.class);
     if (annotation == null) {
-      throw new InitializationError(String.format("class '%s' must have a SuiteClasses annotation", new Object[] {clazz.getName()}));
+      throw new InitializationError(String.format("class '%s' must have a SuiteClasses annotation", clazz.getName()));
     }
 
     // get classes from class names

--- a/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/UnresolvedIssueFilter.java
+++ b/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/UnresolvedIssueFilter.java
@@ -45,7 +45,7 @@ public class UnresolvedIssueFilter extends Filter {
       return true;
     }
     final BugTest bugTestAnnotation = description.getAnnotation(BugTest.class);
-    if (bugTestAnnotation != null && bugTestAnnotation.unresolved()) {
+    if (bugTestAnnotation != null && bugTestAnnotation.unresolved()) { // NOPMD SimplifyBooleanReturns
       return true;
     }
     return FilterRegistry.isTestClass(description); // if it is a test class we still want to check (and maybe run) its children

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/junit/runners/TestRunRecording.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/junit/runners/TestRunRecording.java
@@ -437,13 +437,15 @@ public class TestRunRecording extends RunListener implements TestStepListener, M
     boolean contention = THREAD_BEAN.isThreadContentionMonitoringEnabled();
     Set<Long> deadlockedThreads = getDeadlockThreadIds();
     ThreadInfo[] threadInfos = THREAD_BEAN.dumpAllThreads(true, true);
-    StringBuilder trace = new StringBuilder().append(threadInfos.length).append(" active threads").append(NEW_LINE);
+    // CHECKSTYLE:OFF MagicNumber
+    StringBuilder trace = new StringBuilder(150).append(threadInfos.length).append(" active threads").append(NEW_LINE);
+    // CHECKSTYLE:ON
     for (ThreadInfo info : threadInfos) {
       if (info == null) {
         trace.append("  Inactive").append(NEW_LINE);
         continue;
       }
-      boolean isDeadlocked = deadlockedThreads.contains(Long.valueOf(info.getThreadId()));
+      boolean isDeadlocked = deadlockedThreads.contains(info.getThreadId());
       trace.append("Thread ").append(getTaskName(info.getThreadId(), info.getThreadName()));
       if (isDeadlocked) {
         trace.append(" <<DEADLOCK>>");

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/DynamicContextActionUiTestUtil.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/DynamicContextActionUiTestUtil.java
@@ -12,8 +12,8 @@ package com.avaloq.tools.ddk.test.ui.swtbot.util;
 
 import java.util.Arrays;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
@@ -74,7 +74,7 @@ public final class DynamicContextActionUiTestUtil {
       new SwtBotDynamicContextMenu(bot.contextMenu(), predicate).menu(labels).click();
       return;
     } catch (WidgetNotFoundException widgetNotFound) {
-      LOGGER.debug("Menu item not found on first attempt.", widgetNotFound); //$NON-NLS-1$
+      LOGGER.debug("Menu item not found on first attempt.", widgetNotFound); //$NON-NLS-1$ // NOPMD InvalidLogMessageFormat
     }
 
     // maybe the UI was unstable at the point we set the selection - include delays between events to allow UI to catch up.
@@ -88,7 +88,7 @@ public final class DynamicContextActionUiTestUtil {
       new SwtBotDynamicContextMenu(bot.contextMenu(), predicate).menu(labels).click();
       return;
     } catch (WidgetNotFoundException widgetNotFound) {
-      LOGGER.debug("Menu item not found on second attempt.", widgetNotFound); //$NON-NLS-1$
+      LOGGER.debug("Menu item not found on second attempt.", widgetNotFound); //$NON-NLS-1$ // NOPMD InvalidLogMessageFormat
     }
 
     // maybe the item takes longer than the dynamic sub-menus to be added to the parent menu - give the item until TIMEOUT to appear.

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/FixedCopiedResourceDescription.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/FixedCopiedResourceDescription.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xtext.builder.clustering.CopiedResourceDescription;
 import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.resource.EObjectDescription;
 import org.eclipse.xtext.resource.IEObjectDescription;
@@ -53,7 +54,7 @@ public class FixedCopiedResourceDescription extends AbstractResourceDescription 
   private static final Logger LOG = LogManager.getLogger(FixedCopiedResourceDescription.class);
 
   private final URI uri;
-  private final ImmutableList<IEObjectDescription> exported;
+  private final List<IEObjectDescription> exported;
 
   @SuppressWarnings("unchecked")
   public FixedCopiedResourceDescription(final IResourceDescription original) {

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -555,7 +555,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
             traceSet.started(ResourceLinkingEvent.class, changedURI);
             final IResourceDescription.Manager manager = getResourceDescriptionManager(changedURI);
             if (manager != null) {
-              final Object[] bindings = {Integer.valueOf(index), Integer.valueOf(index + queue.size()), URI.decode(resource.getURI().lastSegment())};
+              final Object[] bindings = {index, index + queue.size(), URI.decode(resource.getURI().lastSegment())};
               subProgress.subTask(NLS.bind(Messages.MonitoredClusteringBuilderState_UPDATE_DESCRIPTIONS, bindings));
               // Resolve links here!
               try {
@@ -657,7 +657,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
         newDeltas.clear();
         changedDeltas.clear();
 
-        if (queue.size() > 0) {
+        if (!queue.isEmpty()) {
           loadOperation = crossLinkingResourceLoader.create(resourceSet, currentProject);
           loadOperation.load(queue);
         }
@@ -789,7 +789,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
       if (!binaryStorageExecutor.awaitTermination(1, TimeUnit.MINUTES)) {
         throw new InterruptedException();
       }
-    } catch (InterruptedException e) {
+    } catch (InterruptedException e) { // NOPMD ExceptionAsFlowControl
       LOGGER.warn(String.format("Binary resource storage tasks not completed in time, start with %d queued / %d active; now have %d / %d", //$NON-NLS-1$
           queuedTaskCount, activeTaskCount, binaryStorageExecutor.getQueue().size(), binaryStorageExecutor.getActiveCount()));
       binaryStorageExecutor.shutdownNow();
@@ -1005,7 +1005,7 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
         try {
           resource = addResource(loadOperation.next().getResource(), resourceSet);
           uri = resource.getURI();
-          final Object[] bindings = {Integer.valueOf(index), Integer.valueOf(resourcesToWriteSize), uri.fileExtension(), URI.decode(uri.lastSegment())};
+          final Object[] bindings = {index, resourcesToWriteSize, uri.fileExtension(), URI.decode(uri.lastSegment())};
           monitor.subTask(NLS.bind(Messages.MonitoredClusteringBuilderState_WRITE_ONE_DESCRIPTION, bindings));
           traceSet.started(ResourceIndexingEvent.class, uri);
 

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/RebuildingXtextBuilder.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/RebuildingXtextBuilder.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.builder;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
@@ -44,7 +45,6 @@ import org.eclipse.xtext.builder.impl.XtextBuilder;
 import org.eclipse.xtext.resource.IResourceDescription.Delta;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionsProvider;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -174,7 +174,7 @@ public class RebuildingXtextBuilder extends XtextBuilder {
         ((ResourceSetImpl) resourceSet).setURIResourceMap(Maps.<URI, Resource> newHashMap());
       }
       BuildData buildData = new BuildData(getProject().getName(), resourceSet, toBeBuilt, queuedBuildData);
-      ImmutableList<Delta> deltas = builderState.update(buildData, progress.newChild(1));
+      List<Delta> deltas = builderState.update(buildData, progress.newChild(1));
       if (participant != null) {
         final BuildContext buildContext = new BuildContext(this, resourceSet, deltas, type);
         // remember the current workspace tree

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/RegistryBuilderParticipant.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/RegistryBuilderParticipant.java
@@ -61,7 +61,7 @@ public class RegistryBuilderParticipant extends org.eclipse.xtext.builder.impl.R
   @Inject
   private ResourceServiceProviderLocator resourceServiceProviderLocator;
 
-  private ImmutableList<IXtextBuilderParticipant> immutableCommonParticipants;
+  private ImmutableList<IXtextBuilderParticipant> immutableCommonParticipants; // NOPMD LooseCoupling
 
   private final Map<String, IXtextBuilderParticipant> classToParticipant = Maps.newHashMap();
   private final Map<String, Set<ILanguageSpecificBuilderParticipant>> serviceProviderToParticipants = Maps.newHashMap();
@@ -163,7 +163,7 @@ public class RegistryBuilderParticipant extends org.eclipse.xtext.builder.impl.R
    *           caused by an {@link IXtextBuilderParticipant}
    */
   protected void buildOtherParticipants(final IBuildContext buildContext, final IProgressMonitor monitor) throws CoreException {
-    ImmutableList<IXtextBuilderParticipant> otherBuilderParticipants = getParticipants();
+    List<IXtextBuilderParticipant> otherBuilderParticipants = getParticipants();
     if (otherBuilderParticipants.isEmpty()) {
       return;
     }
@@ -238,7 +238,7 @@ public class RegistryBuilderParticipant extends org.eclipse.xtext.builder.impl.R
   }
 
   @Override
-  protected synchronized ImmutableList<IXtextBuilderParticipant> initParticipants() {
+  protected synchronized ImmutableList<IXtextBuilderParticipant> initParticipants() { // NOPMD LooseCoupling
     if (immutableCommonParticipants == null) {
       String pluginID = "org.eclipse.xtext.builder"; //$NON-NLS-1$ // Activator.getDefault().getBundle().getSymbolicName();
       String extensionPointID = EXTENSION_POINT_ID;
@@ -260,7 +260,7 @@ public class RegistryBuilderParticipant extends org.eclipse.xtext.builder.impl.R
       super(pluginRegistry, pluginID, extensionPointID);
     }
 
-    protected ImmutableList<IXtextBuilderParticipant> getCommonParticipants() {
+    protected ImmutableList<IXtextBuilderParticipant> getCommonParticipants() { // NOPMD LooseCoupling
       return ImmutableList.copyOf(commonParticipants);
     }
 
@@ -344,10 +344,7 @@ public class RegistryBuilderParticipant extends org.eclipse.xtext.builder.impl.R
      */
     private boolean unregisterLanguageSpecificBuilderParticipant(final String languageId, final ILanguageSpecificBuilderParticipant languageSpecificBuilderParticipant) {
       Set<ILanguageSpecificBuilderParticipant> languageSpecificBuilderParticipants = serviceProviderToParticipants.get(languageId);
-      if (languageSpecificBuilderParticipants != null) {
-        return languageSpecificBuilderParticipants.remove(languageSpecificBuilderParticipant);
-      }
-      return false;
+      return languageSpecificBuilderParticipants != null && languageSpecificBuilderParticipants.remove(languageSpecificBuilderParticipant);
     }
   }
 }

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
@@ -78,21 +78,24 @@ public class ParallelResourceLoader extends AbstractResourceLoader {
   private final int nThreads;
   private final int queueSize;
   private long timeout;
-  private long slowLoadingTime;
+  private final long slowLoadingTime;
 
   public ParallelResourceLoader(final IResourceSetProvider resourceSetProvider, final Sorter sorter, final int nThreads, final int queueSize) {
     super(resourceSetProvider, sorter);
     this.nThreads = nThreads;
     this.queueSize = queueSize;
     this.timeout = MAX_WAIT_TIME;
-    String slowLoadingTimeString = System.getProperty(SLOW_LOADING_TIME_PROPERTY);
+    this.slowLoadingTime = parseSlowLoadingTimeString(System.getProperty(SLOW_LOADING_TIME_PROPERTY));
+  }
+
+  private long parseSlowLoadingTimeString(final String slowLoadingTimeString) {
     try {
-      slowLoadingTime = Long.parseLong(slowLoadingTimeString);
+      return Long.parseLong(slowLoadingTimeString);
     } catch (NumberFormatException e) {
       if (slowLoadingTimeString != null) {
         LOGGER.warn(String.format("Slow loading timeout property '%s' is set to invalid value '%s'. Using default value of %d ms instead.", SLOW_LOADING_TIME_PROPERTY, slowLoadingTimeString, SLOW_LOADING_TIME_DEFAULT)); //$NON-NLS-1$
       }
-      slowLoadingTime = SLOW_LOADING_TIME_DEFAULT;
+      return SLOW_LOADING_TIME_DEFAULT;
     }
   }
 

--- a/com.avaloq.tools.ddk.xtext.expression/src/com/avaloq/tools/ddk/xtext/expression/generator/CompilationContext.java
+++ b/com.avaloq.tools.ddk.xtext.expression/src/com/avaloq/tools/ddk/xtext/expression/generator/CompilationContext.java
@@ -11,15 +11,13 @@
 package com.avaloq.tools.ddk.xtext.expression.generator;
 
 import java.lang.reflect.Field;
-import java.util.HashSet;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.internal.xtend.xtend.ast.Extension;
 import org.eclipse.internal.xtend.xtend.ast.JavaExtensionStatement;
 import org.eclipse.osgi.util.NLS;
-import org.eclipse.xtend.expression.AnalysationIssue;
 import org.eclipse.xtend.expression.ExecutionContext;
 import org.eclipse.xtend.expression.ExpressionFacade;
 import org.eclipse.xtend.expression.Variable;
@@ -70,8 +68,7 @@ public class CompilationContext {
    * @return type of expression
    */
   public Type analyze(final String expression) {
-    final HashSet<AnalysationIssue> issues = Sets.newHashSet();
-    return new ExpressionFacade(context).analyze(expression, issues);
+    return new ExpressionFacade(context).analyze(expression, Sets.newHashSet());
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/format/validation/FormatValidationTest.java
+++ b/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/format/validation/FormatValidationTest.java
@@ -104,7 +104,7 @@ public class FormatValidationTest extends AbstractValidationTest {
    */
   @Test
   public void testNegativeACF1000() {
-    setFormattingRules(new String[0], new String[] {"INT_EXP { \"e\" : no_space around;}"});
+    setFormattingRules(new String[0], "INT_EXP { \"e\" : no_space around;}");
     assertDiagnostic(parentFormat, FormatValidator.ILLEGAL_DIRECTIVE_CODE);
   }
 
@@ -113,7 +113,7 @@ public class FormatValidationTest extends AbstractValidationTest {
    */
   @Test
   public void testPositiveACF1000() {
-    setFormattingRules(new String[0], new String[] {"INT_EXP { rule : no_space around;}"});
+    setFormattingRules(new String[0], "INT_EXP { rule : no_space around;}");
     assertNoDiagnostic(parentFormat, FormatValidator.ILLEGAL_DIRECTIVE_CODE);
   }
 
@@ -122,7 +122,7 @@ public class FormatValidationTest extends AbstractValidationTest {
    */
   @Test
   public void illegalWildcardRuleOverride() {
-    setFormattingRules(new String[] {OVERRIDE_WILDCARD_RULE}, new String[] {});
+    setFormattingRules(new String[] {OVERRIDE_WILDCARD_RULE});
     assertDiagnostic(extendingFormat, FormatValidator.OVERRIDE_ILLEGAL_CODE);
   }
 
@@ -131,7 +131,7 @@ public class FormatValidationTest extends AbstractValidationTest {
    */
   @Test
   public void illegalGrammarRuleOverride() {
-    setFormattingRules(new String[] {OVERRIDE_INT_EXP_RULE}, new String[] {});
+    setFormattingRules(new String[] {OVERRIDE_INT_EXP_RULE});
     assertDiagnostic(extendingFormat, FormatValidator.OVERRIDE_ILLEGAL_CODE);
   }
 
@@ -140,7 +140,7 @@ public class FormatValidationTest extends AbstractValidationTest {
    */
   @Test
   public void missingWildcardRuleOverride() {
-    setFormattingRules(new String[] {WILDCARD_RULE}, new String[] {WILDCARD_RULE});
+    setFormattingRules(new String[] {WILDCARD_RULE}, WILDCARD_RULE);
 
     assertDiagnostic(extendingFormat, FormatValidator.OVERRIDE_MISSING_CODE);
   }
@@ -150,7 +150,7 @@ public class FormatValidationTest extends AbstractValidationTest {
    */
   @Test
   public void missingGrammarRuleOverride() {
-    setFormattingRules(new String[] {INT_EXP_RULE}, new String[] {INT_EXP_RULE});
+    setFormattingRules(new String[] {INT_EXP_RULE}, INT_EXP_RULE);
     assertDiagnostic(extendingFormat, FormatValidator.OVERRIDE_MISSING_CODE);
   }
 
@@ -159,7 +159,7 @@ public class FormatValidationTest extends AbstractValidationTest {
    */
   @Test
   public void wildcardRuleOverrideOK() {
-    setFormattingRules(new String[] {OVERRIDE_WILDCARD_RULE}, new String[] {WILDCARD_RULE});
+    setFormattingRules(new String[] {OVERRIDE_WILDCARD_RULE}, WILDCARD_RULE);
     assertNoDiagnostic(extendingFormat, FormatValidator.OVERRIDE_MISSING_CODE);
     assertNoDiagnostic(extendingFormat, FormatValidator.OVERRIDE_ILLEGAL_CODE);
   }
@@ -169,7 +169,7 @@ public class FormatValidationTest extends AbstractValidationTest {
    */
   @Test
   public void grammarRuleOverrideOK() {
-    setFormattingRules(new String[] {OVERRIDE_INT_EXP_RULE}, new String[] {INT_EXP_RULE});
+    setFormattingRules(new String[] {OVERRIDE_INT_EXP_RULE}, INT_EXP_RULE);
     assertNoDiagnostic(extendingFormat, FormatValidator.OVERRIDE_MISSING_CODE);
     assertNoDiagnostic(extendingFormat, FormatValidator.OVERRIDE_ILLEGAL_CODE);
   }
@@ -184,7 +184,7 @@ public class FormatValidationTest extends AbstractValidationTest {
     } catch (IOException e) {
       fail("Could not create MyDsl model: " + e.getMessage());
     }
-    FormatConfiguration myDslModel = createModel("MyDsl", PARENT_MODEL_NAME, new String[] {});
+    FormatConfiguration myDslModel = createModel("MyDsl", PARENT_MODEL_NAME);
     assertDiagnostic(myDslModel, FormatValidator.EXTENDED_GRAMMAR_INCOMPATIBLE_CODE);
   }
 
@@ -193,8 +193,8 @@ public class FormatValidationTest extends AbstractValidationTest {
    */
   @Test
   public void extendedGrammarCompatibleOK() {
-    createModel(PARENT_MODEL_NAME, null, new String[] {});
-    FormatConfiguration extendModel = createModel(EXTENDING_MODEL_NAME, PARENT_MODEL_NAME, new String[] {});
+    createModel(PARENT_MODEL_NAME, null);
+    FormatConfiguration extendModel = createModel(EXTENDING_MODEL_NAME, PARENT_MODEL_NAME);
     assertNoDiagnostic(extendModel, FormatValidator.EXTENDED_GRAMMAR_INCOMPATIBLE_CODE);
   }
 
@@ -204,7 +204,7 @@ public class FormatValidationTest extends AbstractValidationTest {
    */
   @Test
   public void requiredRulesImplemented() {
-    setFormattingRules(new String[0], new String[] {"Rule {}"});
+    setFormattingRules(new String[0], "Rule {}");
     assertDiagnostic(extendingFormat, FormatValidator.GRAMMAR_RULE_MISSING_CODE);
   }
 }

--- a/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/naming/FormatQualifiedNameConverter.java
+++ b/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/naming/FormatQualifiedNameConverter.java
@@ -32,7 +32,7 @@ public class FormatQualifiedNameConverter extends IQualifiedNameConverter.Defaul
 
   @Override
   public QualifiedName toQualifiedName(final String qualifiedNameAsString) {
-    if (qualifiedNameAsString == null || qualifiedNameAsString.equals("") || Strings.isEmpty(getDelimiter())) {
+    if (qualifiedNameAsString == null || "".equals(qualifiedNameAsString) || Strings.isEmpty(getDelimiter())) {
       return super.toQualifiedName(qualifiedNameAsString);
     }
     Matcher m = STRING_PATTERN.matcher(qualifiedNameAsString);

--- a/com.avaloq.tools.ddk.xtext.generator.test/src/com/avaloq/tools/ddk/xtext/generator/test/util/EClassComparatorTest.java
+++ b/com.avaloq.tools.ddk.xtext.generator.test/src/com/avaloq/tools/ddk/xtext/generator/test/util/EClassComparatorTest.java
@@ -71,7 +71,7 @@ public class EClassComparatorTest {
     sorted = EClassComparator.sortedEPackageGroups(Lists.newArrayList(XtextPackage.Literals.ABSTRACT_ELEMENT, XtextPackage.Literals.ACTION, ECLASS), mapping);
     assertEquals(3, sorted.size());
     assertEquals(2, sorted.keySet().size());
-    assertEquals(Lists.newArrayList(ECLASS), sorted.get(EcorePackage.eINSTANCE));
+    assertEquals(Lists.newArrayList(ECLASS), sorted.get(EcorePackage.eINSTANCE)); // NOPMD ConfusingArgumentToVarargsMethod
     assertEquals(Lists.newArrayList(XtextPackage.Literals.ACTION, XtextPackage.Literals.ABSTRACT_ELEMENT), sorted.get(XtextPackage.eINSTANCE));
   }
 

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/CombinedGrammarReportBuilder.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/CombinedGrammarReportBuilder.java
@@ -94,7 +94,7 @@ public class CombinedGrammarReportBuilder {
    */
 
   private void addRuleToDoc(final AbstractRule rule, final StringBuilder doc) {
-    doc.append("\n\n<h2><a name=\"" + rule.getName() + "\">" + rule.getName() + "</a> (" + GrammarUtil.getSimpleName(GrammarUtil.getGrammar(rule)) + ")</h2>");
+    doc.append("\n\n<h2><a name=\"").append(rule.getName()).append("\">").append(rule.getName()).append("</a> (").append(GrammarUtil.getSimpleName(GrammarUtil.getGrammar(rule))).append(")</h2>");
     doc.append("<pre>");
     doc.append(getText(rule));
     doc.append("\n</pre>");

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/AcfKeywordHelper.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/AcfKeywordHelper.java
@@ -189,7 +189,7 @@ public class AcfKeywordHelper implements Adapter {
     Iterator<EObject> iter = Iterators.concat(EcoreUtil.<EObject> getAllContents(parserRules), EcoreUtil.<EObject> getAllContents(enumRules));
     Iterator<Keyword> filtered = Iterators.filter(iter, Keyword.class);
     Iterator<String> transformed = Iterators.transform(filtered, Keyword::getValue);
-    TreeSet<String> treeSet = Sets.newTreeSet(new Comparator<String>() {
+    Set<String> treeSet = Sets.newTreeSet(new Comparator<String>() {
       @Override
       public int compare(final String o1, final String o2) {
         if (o1.length() == o2.length()) {

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/ParserSemanticPredicatesUtil.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/ParserSemanticPredicatesUtil.java
@@ -45,6 +45,7 @@ import com.google.common.collect.Sets;
 /**
  * Utility for semantic predicates in Xtext grammars.
  */
+// CHECKSTYLE:OFF MagicNumber
 public final class ParserSemanticPredicatesUtil {
 
   /**
@@ -141,7 +142,7 @@ public final class ParserSemanticPredicatesUtil {
         }
       }
       if (condition != null) {
-        StringBuilder predicate = new StringBuilder();
+        StringBuilder predicate = new StringBuilder(25);
         predicate.append('{');
         predicate.append(condition);
         if (!gated) { // This does not bring anything in gated predicates
@@ -224,7 +225,7 @@ public final class ParserSemanticPredicatesUtil {
     if (text != null) {
       Matcher matcher = KEYWORD_RULE_ANNOTATION_PATTERN.matcher(text);
       if (matcher.find()) {
-        StringBuilder predicate = new StringBuilder();
+        StringBuilder predicate = new StringBuilder(60);
         predicate.append("return \"Unexpected: \" + token.getText() + \". Expected: '"); //$NON-NLS-1$
         predicate.append(Joiner.on("', '").join(KEYWORDS_SPLITTER.split(matcher.group(1)))); //$NON-NLS-1$
         predicate.append("'\";\n"); //$NON-NLS-1$
@@ -251,7 +252,7 @@ public final class ParserSemanticPredicatesUtil {
     if (text != null) {
       Matcher matcher = KEYWORD_RULE_ANNOTATION_PATTERN.matcher(text);
       if (matcher.find()) {
-        StringBuilder predicate = new StringBuilder();
+        StringBuilder predicate = new StringBuilder(100);
         predicate.append("String text = parserContext.getInput().LT(1).getText();"); //$NON-NLS-1$
         predicate.append('\n');
         predicate.append("    return "); //$NON-NLS-1$
@@ -427,7 +428,7 @@ public final class ParserSemanticPredicatesUtil {
     if (text != null) {
       Matcher matcher = KEYWORD_RULE_ANNOTATION_PATTERN.matcher(text);
       if (matcher.find()) {
-        StringBuilder predicate = new StringBuilder();
+        StringBuilder predicate = new StringBuilder(60);
         boolean passedFirst = false;
         for (String kw : KEYWORDS_SPLITTER.split(matcher.group(1))) {
           if (passedFirst) {
@@ -488,10 +489,7 @@ public final class ParserSemanticPredicatesUtil {
 
   private static boolean matches(final AbstractRule rule, final Pattern pattern) {
     String text = getText(rule);
-    if (text != null) {
-      return pattern.matcher(text).find();
-    }
-    return false;
+    return text != null && pattern.matcher(text).find();
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext.ide/src/com/avaloq/tools/ddk/xtext/ide/findrefs/InferredModelReferenceFilter.java
+++ b/com.avaloq.tools.ddk.xtext.ide/src/com/avaloq/tools/ddk/xtext/ide/findrefs/InferredModelReferenceFilter.java
@@ -40,11 +40,9 @@ public class InferredModelReferenceFilter implements Predicate<IReferenceDescrip
    */
   protected boolean isInferredModelElement(final URI elementURI) {
     String fragment = elementURI.fragment();
-    if (fragment.length() > 1) {
-      // URI fragments of non-inferred elements look like: /0/x/y/z/
-      return fragment.charAt(1) != '0';
-    }
-    return false;
+    return fragment.length() > 1
+        // URI fragments of non-inferred elements look like: /0/x/y/z/
+        && fragment.charAt(1) != '0';
   }
 
 }

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/ScopeUtil.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/ScopeUtil.java
@@ -77,7 +77,9 @@ public final class ScopeUtil {
    * @return string signature
    */
   public static String getSignature(final ScopeRule rule) { // NOPMD NPathComplexity
-    StringBuffer result = new StringBuffer();
+    // CHECKSTYLE:OFF MagicNumber
+    StringBuffer result = new StringBuffer(60);
+    // CHECKSTYLE:ON
     final ScopeDefinition def = EcoreUtil2.getContainerOfType(rule, ScopeDefinition.class);
     result.append(def.getName()).append('_');
     final EClass type = def.getReference() != null ? def.getReference().getEReferenceType() : def.getTargetType();

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/linking/ScopeLinkingService.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/linking/ScopeLinkingService.java
@@ -13,8 +13,8 @@ package com.avaloq.tools.ddk.xtext.scope.linking;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
@@ -80,8 +80,7 @@ public class ScopeLinkingService extends DefaultLinkingService {
       if (scopeModelName != null) {
         final ResourceSet resourceSet = context.eResource().getResourceSet();
         List<Resource> resources = resourceSet.getResources();
-        for (int i = 0; i < resources.size(); i++) {
-          Resource resource = resources.get(i);
+        for (Resource resource : resources) {
           EObject rootElement = null;
           if (resource instanceof XtextResource && ((XtextResource) resource).getLanguageName().equals(languageName) && !resource.getContents().isEmpty()) {
             rootElement = resource.getContents().get(0);
@@ -105,10 +104,10 @@ public class ScopeLinkingService extends DefaultLinkingService {
       }
       return Collections.emptyList();
     } catch (ClasspathUriResolutionException e) {
-      LOG.warn("Cannot load included scope.", e);
+      LOG.warn("Cannot load included scope.", e); // NOPMD InvalidLogMessageFormat
       return Collections.emptyList();
     } catch (ValueConverterException e) {
-      LOG.warn("Cannot convert included scope name.", e);
+      LOG.warn("Cannot convert included scope name.", e); // NOPMD InvalidLogMessageFormat
       return Collections.emptyList();
     }
   }

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/validation/ScopeValidator.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/validation/ScopeValidator.java
@@ -219,7 +219,7 @@ public class ScopeValidator extends AbstractScopeValidator {
    * @return {@code true} if it is the default scope
    */
   private boolean isDefaultScope(final ScopeDefinition def) {
-    return def.getName() == null || def.getName().equals(DEFAULT_SCOPE_NAME);
+    return def.getName() == null || DEFAULT_SCOPE_NAME.equals(def.getName());
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/AbstractXtextMarkerBasedTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/AbstractXtextMarkerBasedTest.java
@@ -16,8 +16,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -388,7 +388,7 @@ public abstract class AbstractXtextMarkerBasedTest extends AbstractXtextTest {
     StringBuilder result = new StringBuilder();
     StringBuilder errorBuffer = new StringBuilder();
     // Sort positions
-    ArrayList<Integer> positions = Lists.newArrayList(errorsOnPosition.keySet());
+    List<Integer> positions = Lists.newArrayList(errorsOnPosition.keySet());
 
     int posIdx = 0;
     int sourceIdx = 0;

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/conversion/AbstractValueConverterServiceTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/conversion/AbstractValueConverterServiceTest.java
@@ -17,14 +17,15 @@ import static org.junit.Assert.fail;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.IGrammarAccess;
 import org.eclipse.xtext.conversion.IValueConverterService;
 import org.eclipse.xtext.conversion.ValueConverterException;
 
-import com.avaloq.tools.ddk.xtext.test.AbstractXtextTest;
 import com.avaloq.tools.ddk.xtext.grammar.KeywordCollector;
+import com.avaloq.tools.ddk.xtext.test.AbstractXtextTest;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -41,7 +42,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
   public static final String INVALID_ID_NONALPHANUM = "#";
   /** ID regular expression does not allow any '.'. */
   public static final String INVALID_ID_WITHDOT = "someValidIdentifier.something";
-  protected static final ImmutableSet<String> INVALID_IDENTIFIERS = ImmutableSet.of(
+  protected static final Set<String> INVALID_IDENTIFIERS = ImmutableSet.of(
 // @Format-Off
     INVALID_ID_NUMBER,
     INVALID_ID_NONALPHANUM,
@@ -53,7 +54,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
 
   /**
    * Returns the {@link IGrammarAccess}.
-   * 
+   *
    * @return the {@link IGrammarAccess}, never {@code null}
    */
   protected IGrammarAccess getGrammarAccess() {
@@ -67,7 +68,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
    * <p>
    * <em>Note</em>: The default is {@code true}, i.e. keyword case is ignored.
    * </p>
-   * 
+   *
    * @return whether keyword case is ignored
    */
   protected boolean isIgnoreCase() {
@@ -76,7 +77,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
 
   /**
    * Gets or creates the {@link KeywordCollector} instance for the given {@link AbstractRule}.
-   * 
+   *
    * @param rule
    *          the {@link AbstractRule}, must not be {@code null}
    * @return the {@link KeywordCollector} instance for the given {@link AbstractRule}, never {@code null}
@@ -92,7 +93,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
 
   /**
    * Returns the {@link IValueConverterService}.
-   * 
+   *
    * @return the {@link IValueConverterService}, never {@code null}
    */
   protected IValueConverterService getValueConverterService() {
@@ -103,7 +104,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
 
   /**
    * Asserts that the value-to-string conversion resulted in a string that is equal to the specified input value.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion, must not be {@code null}
    * @param value
@@ -116,7 +117,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
 
   /**
    * Asserts that the value-to-string conversion resulted in a string that is equal to the specified input value surrounded by double-quotes.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion, must not be {@code null}
    * @param value
@@ -130,7 +131,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
   /**
    * Asserts that the value-to-string conversion for all the specified values results in strings that are equal to the specified input values surrounded by
    * double-quotes.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion, must not be {@code null}
    * @param values
@@ -151,7 +152,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
 
   /**
    * Asserts that the value-to-string conversion for the keywords listed by the specified rule (or one of rules it calls) leaves them unchanged.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion and whose keywords are tested, must not be {@code null}
    */
@@ -161,7 +162,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
 
   /**
    * Asserts that the value-to-string conversion for the keywords listed by the specified rule (or one of rules it calls) leaves them unchanged.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion and whose keywords are tested, must not be {@code null}
    * @param exceptions
@@ -180,7 +181,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
   /**
    * Asserts that the value-to-string conversion for values that do not match the ID terminal rule regular expression results in the values surrounded by
    * double-quotes.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion, must not be {@code null}
    */
@@ -190,7 +191,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
 
   /**
    * Asserts that the value-to-string conversion for all of the specified values results in a {@link ValueConverterException} thrown.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion, must not be {@code null}
    * @param valueList
@@ -213,7 +214,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
   /**
    * Asserts that the value-to-string conversion for values that do not match the ID terminal rule regular expression results in a
    * {@link ValueConverterException} thrown.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion, must not be {@code null}
    */
@@ -224,7 +225,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
   /**
    * Asserts that the value-to-string conversion for values that are part of the rule language but are not listed by the rule results in a
    * {@link ValueConverterException} thrown.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion, must not be {@code null}
    */
@@ -234,7 +235,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
 
   /**
    * Asserts that the value-to-string conversion for values that are part of the rule language but are not listed by the rule results in quoted strings.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion, must not be {@code null}
    */
@@ -245,7 +246,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
   /**
    * Asserts that the value-to-string conversion for values that keywords listed by the rule leaves them unchanged while other language keywords or invalid IDs
    * result in a {@link ValueConverterException} thrown.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion, must not be {@code null}
    */
@@ -257,7 +258,7 @@ public abstract class AbstractValueConverterServiceTest extends AbstractXtextTes
 
   /**
    * Asserts that boolean values convert to "true" for {@link Boolean#TRUE} and "false" for {@link Boolean#FALSE}.
-   * 
+   *
    * @param rule
    *          the rule used for the value-to-string conversion, must not be {@code null}
    */

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/generator/AbstractGeneratorTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/generator/AbstractGeneratorTest.java
@@ -48,7 +48,6 @@ import org.junit.Assert;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.io.CharStreams;
@@ -111,7 +110,7 @@ public abstract class AbstractGeneratorTest {
    * @throws CoreException
    *           the {@link CoreException}
    */
-  public void initializeProject(final String projectName, final ImmutableMap<String, String> sourceFileNames) throws CoreException {
+  public void initializeProject(final String projectName, final Map<String, String> sourceFileNames) throws CoreException {
     initializeProject(projectName, null, REQUIRED_BUNDLES, null, null, sourceFileNames);
   }
 
@@ -134,7 +133,7 @@ public abstract class AbstractGeneratorTest {
    * @throws CoreException
    *           the {@link CoreException}
    */
-  public void initializeProject(final String projectName, final List<String> folders, final List<String> requiredBundles, final List<String> importedPackages, final List<String> exportedPackages, final ImmutableMap<String, String> sourceFileNames) throws CoreException {
+  public void initializeProject(final String projectName, final List<String> folders, final List<String> requiredBundles, final List<String> importedPackages, final List<String> exportedPackages, final Map<String, String> sourceFileNames) throws CoreException {
     // a project must be created
     createPluginProject(projectName, folders, requiredBundles, importedPackages, exportedPackages);
     // sources are copied into the project and then built by the Xtext builder
@@ -306,7 +305,7 @@ public abstract class AbstractGeneratorTest {
    * @param sourceFileNames
    *          the source file names, mapping input filename to output filename
    */
-  public void addSourcesToWorkspace(final String projectName, final ImmutableMap<String, String> sourceFileNames) {
+  public void addSourcesToWorkspace(final String projectName, final Map<String, String> sourceFileNames) {
     try {
       new WorkspaceModifyOperation() {
         @Override

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/junit/runners/XtextClassRunner.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/junit/runners/XtextClassRunner.java
@@ -251,7 +251,7 @@ public class XtextClassRunner extends XtextRunner {
           LOGGER.info(stringWriter.toString());
         }
       }
-    } catch (AssumptionViolatedException e) {
+    } catch (AssumptionViolatedException e) { // NOPMD ExceptionAsFlowControl
       eachNotifier.addFailedAssumption(e);
       // CHECKSTYLE:CHECK-OFF IllegalCatch // we want to catch all possible errors
     } catch (Throwable e) {

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/scoping/AbstractScopingTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/scoping/AbstractScopingTest.java
@@ -423,7 +423,7 @@ public abstract class AbstractScopingTest extends AbstractXtextMarkerBasedTest {
    * @return the expected uris for the given sources in the given context
    */
   private Set<URI> getExpectedURIs(final EObject context, final EClass modelElementClass, final String... sources) {
-    HashSet<URI> expectedURIs = new HashSet<URI>();
+    Set<URI> expectedURIs = new HashSet<URI>();
     for (String source : sources) {
       expectedURIs.add(Iterables.get(getExportedObjects(context, modelElementClass, source), 0).getEObjectURI());
     }

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/ui/hover/AbstractHoverTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/ui/hover/AbstractHoverTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractHoverTest extends AbstractXtextTest {
   @Override
   protected void beforeAllTests() {
     super.beforeAllTests();
-    getTestInformation().putTestObject(AbstractHoverTest.class, new HashMap<Object, ArrayList<String>>());
+    getTestInformation().putTestObject(AbstractHoverTest.class, new HashMap<Object, ArrayList<String>>()); // NOPMD LooseCoupling
     buildHoverMap(getSemanticModel());
   }
 
@@ -59,10 +59,10 @@ public abstract class AbstractHoverTest extends AbstractXtextTest {
    * @return directory of semantic nodes indexed by the class of the represented semantic model node, or {@code null} if none was set up
    */
   @SuppressWarnings("unchecked")
-  protected Map<Object, ArrayList<String>> getHoverMap() {
+  protected Map<Object, ArrayList<String>> getHoverMap() { // NOPMD LooseCoupling
     Object obj = getTestInformation().getTestObject(AbstractHoverTest.class);
     if (obj instanceof Map<?, ?>) {
-      return (Map<Object, ArrayList<String>>) obj;
+      return (Map<Object, ArrayList<String>>) obj; // NOPMD LooseCoupling
     } else {
       return null; // NOPMD ReturnEmptyCollectionRatherThanNull
     }
@@ -77,7 +77,7 @@ public abstract class AbstractHoverTest extends AbstractXtextTest {
    *          the hover string of the element, must not be {@code null}
    */
   private void addToHoverMap(final Object element, final String hover) {
-    Map<Object, ArrayList<String>> hoverMap = getHoverMap();
+    Map<Object, ArrayList<String>> hoverMap = getHoverMap(); // NOPMD LooseCoupling
 
     if (hoverMap == null) {
       return;

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/ui/labeling/AbstractLabelingTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/ui/labeling/AbstractLabelingTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractLabelingTest extends AbstractXtextTest {
   @Override
   protected void beforeAllTests() {
     super.beforeAllTests();
-    getTestInformation().putTestObject(AbstractLabelingTest.class, new HashMap<Object, ArrayList<String>>());
+    getTestInformation().putTestObject(AbstractLabelingTest.class, new HashMap<Object, ArrayList<String>>()); // NOPMD LooseCoupling
     buildLabelMap(getSemanticModel());
   }
 
@@ -88,10 +88,10 @@ public abstract class AbstractLabelingTest extends AbstractXtextTest {
    */
 
   @SuppressWarnings({"unchecked", "PMD.ReturnEmptyCollectionRatherThanNull"})
-  private Map<Object, ArrayList<String>> getLabelMap() {
+  private Map<Object, ArrayList<String>> getLabelMap() { // NOPMD LooseCoupling
     Object obj = getTestInformation().getTestObject(AbstractLabelingTest.class);
     if (obj instanceof Map<?, ?>) {
-      return (Map<Object, ArrayList<String>>) obj;
+      return (Map<Object, ArrayList<String>>) obj; // NOPMD LooseCoupling
     } else {
       return null;
     }

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/ui/outline/AbstractOutlineTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/ui/outline/AbstractOutlineTest.java
@@ -70,10 +70,10 @@ public abstract class AbstractOutlineTest extends AbstractXtextEditorTest {
    * @return directory of outline nodes indexed by the class of the represented semantic model node
    */
   @SuppressWarnings({"unchecked", "PMD.ReturnEmptyCollectionRatherThanNull"})
-  private Map<Object, ArrayList<IOutlineNode>> getOutlineMap() {
+  private Map<Object, ArrayList<IOutlineNode>> getOutlineMap() { // NOPMD LooseCoupling
     Object obj = getTestInformation().getTestObject(IOutlineNode.class);
     if (obj instanceof Map<?, ?>) {
-      return (Map<Object, ArrayList<IOutlineNode>>) obj;
+      return (Map<Object, ArrayList<IOutlineNode>>) obj; // NOPMD LooseCoupling
     } else {
       return null;
     }
@@ -86,7 +86,7 @@ public abstract class AbstractOutlineTest extends AbstractXtextEditorTest {
   protected final void beforeAllTests() {
     super.beforeAllTests();
     IOutlineTreeProvider provider = getXtextTestUtil().get(IOutlineTreeProvider.class);
-    getTestInformation().putTestObject(IOutlineNode.class, new HashMap<Object, ArrayList<IOutlineNode>>());
+    getTestInformation().putTestObject(IOutlineNode.class, new HashMap<Object, ArrayList<IOutlineNode>>()); // NOPMD LooseCoupling
     buildOutlineMap(provider.createRoot(getDocument()));
   }
 
@@ -214,7 +214,7 @@ public abstract class AbstractOutlineTest extends AbstractXtextEditorTest {
    *          the array of classes which constitute the entire outline tree.
    */
   protected void assertOutlineNodeTreeConsistsOf(final Object... classes) {
-    ArrayList<Object> outlineMapKeySet = new ArrayList<Object>(getOutlineMap().keySet());
+    List<Object> outlineMapKeySet = new ArrayList<Object>(getOutlineMap().keySet());
     outlineMapKeySet.removeAll(Arrays.asList(classes));
     // assert that only EStructuralFeatures remain
     for (Object object : outlineMapKeySet) {

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/validation/AbstractValidationTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/validation/AbstractValidationTest.java
@@ -57,6 +57,7 @@ import com.google.inject.Provider;
  */
 @SuppressWarnings({"nls", "PMD.ExcessiveClassLength"})
 // CHECKSTYLE:CHECK-OFF MultipleStringLiterals
+// CHECKSTYLE:OFF MagicNumber
 public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTest {
 
   public static final int NO_ERRORS = 0;
@@ -114,8 +115,6 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
    * Assertion testing for {@link AbstractValidationDiagnostic validation issues} at a given source position.
    */
   protected class XtextDiagnosticAssertion extends AbstractModelAssertion {
-
-    private static final int MINIMAL_STRINGBUILDER_CAPACITY = 100;
 
     /** Issue code of the diagnostic. */
     private final String issueCode;
@@ -205,19 +204,18 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
      *          actual message
      */
     private void createErrorMessage(final Integer pos, final BasicDiagnostic diagnosticsOnTargetPosition, final boolean issueFound, final boolean expectedSeverityMatches, final int actualSeverity, final boolean expectedMessageMatches, final String actualMessage) {
-      StringBuilder errorMessage = new StringBuilder(MINIMAL_STRINGBUILDER_CAPACITY);
+      StringBuilder errorMessage = new StringBuilder(180);
       if (issueMustBeFound && !issueFound) {
-        errorMessage.append("Expected issue not found. Code '" + issueCode + "'\n");
+        errorMessage.append("Expected issue not found. Code '").append(issueCode).append('\n');
       } else if (!issueMustBeFound && issueFound) {
-        errorMessage.append("There should be no issue with the code '" + issueCode + DOT_AND_LINEBREAK);
+        errorMessage.append("There should be no issue with the code '").append(issueCode).append(DOT_AND_LINEBREAK);
       }
       if (issueFound && !expectedMessageMatches) {
-        errorMessage.append("Expected message does not match. Expected: '" + message + "', Actual: '" + actualMessage + "'\n");
+        errorMessage.append("Expected message does not match. Expected: '").append(message).append("', Actual: '").append(actualMessage).append('\n');
       }
       // If the expected issue has been found, but the actual severity does not match with expected one
       if (issueMustBeFound && issueFound && !expectedSeverityMatches) {
-        errorMessage.append("Severity does not match. Expected: " + CODE_TO_NAME.get(expectedSeverity) + ". Actual: " + CODE_TO_NAME.get(actualSeverity)
-            + ".\n");
+        errorMessage.append("Severity does not match. Expected: ").append(CODE_TO_NAME.get(expectedSeverity)).append(". Actual: ").append(CODE_TO_NAME.get(actualSeverity)).append(".\n");
       }
       // Memorize error message
       if (errorMessage.length() > 0) {
@@ -284,8 +282,6 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
    * Assertion testing for {@link AbstractValidationDiagnostic validation issues} at a given source position.
    */
   private class ResourceDiagnosticAssertion extends AbstractModelAssertion {
-
-    private static final int MINIMAL_STRINGBUILDER_CAPACITY = 100;
 
     /** Issue code of the diagnostic. */
     private final String issueCode;
@@ -382,19 +378,18 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
      *          actual message
      */
     private void createErrorMessage(final Integer pos, final List<Resource.Diagnostic> diagnosticsOnTargetPosition, final boolean issueFound, final boolean expectedSeverityMatches, final int actualSeverity, final boolean expectedMessageMatches, final String actualMessage) {
-      StringBuilder errorMessage = new StringBuilder(MINIMAL_STRINGBUILDER_CAPACITY);
+      StringBuilder errorMessage = new StringBuilder(175);
       if (issueMustBeFound && !issueFound) {
-        errorMessage.append("Expected issue not found. Code '" + issueCode + "'\n");
+        errorMessage.append("Expected issue not found. Code '").append(issueCode).append('\n');
       } else if (!issueMustBeFound && issueFound) {
-        errorMessage.append("There should be no issue with the code '" + issueCode + DOT_AND_LINEBREAK);
+        errorMessage.append("There should be no issue with the code '").append(issueCode).append(DOT_AND_LINEBREAK);
       }
       if (issueFound && !expectedMessageMatches) {
-        errorMessage.append("Expected message does not match. Expected: '" + message + "', Actual: '" + actualMessage + "'\n");
+        errorMessage.append("Expected message does not match. Expected: '").append(message).append("', Actual: '").append(actualMessage).append('\n');
       }
       // If the expected issue has been found, but the actual severity does not match with expected one
       if (issueMustBeFound && issueFound && !expectedSeverityMatches) {
-        errorMessage.append("Severity does not match. Expected: " + CODE_TO_NAME.get(expectedSeverity) + ". Actual: " + CODE_TO_NAME.get(actualSeverity)
-            + ".\n");
+        errorMessage.append("Severity does not match. Expected: ").append(CODE_TO_NAME.get(expectedSeverity)).append(". Actual: ").append(CODE_TO_NAME.get(actualSeverity)).append(".\n");
       }
       // Memorize error message
       if (errorMessage.length() > 0) {
@@ -417,7 +412,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
      *         {@code true} if diagnostic has the same position as the given one, {@code false} otherwise.
      */
     private boolean diagnosticPositionEquals(final Integer pos, final AbstractDiagnostic diagnostic) {
-      return diagnostic.getOffset() == pos.intValue();
+      return diagnostic.getOffset() == pos;
     }
   }
 
@@ -521,7 +516,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
    */
   // TODO (ACF-4153) generalize for all kinds of errors and move to AbstractXtextTest
   private String diagnosticsToString(final List<Resource.Diagnostic> diagnostics, final boolean displayPathToTargetObject) {
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder(25);
     for (Resource.Diagnostic diagnostic : diagnostics) {
       if (diagnostic instanceof AbstractDiagnostic) {
         AbstractDiagnostic diag = (AbstractDiagnostic) diagnostic;
@@ -1097,7 +1092,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
       if (diagnostic instanceof AbstractDiagnostic) {
         AbstractDiagnostic diag = (AbstractDiagnostic) diagnostic;
         // Create error message
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(35);
         sb.append("Unexpected diagnostic found. Code '");
         sb.append(diag.getCode());
         sb.append(DOT_AND_LINEBREAK);
@@ -1105,7 +1100,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
         memorizeErrorOnPosition(diag.getOffset(), sb.toString());
       } else {
         // Create error message
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(30);
         sb.append("Unexpected diagnostic found. '");
         sb.append(diagnostic.toString());
         sb.append(DOT_AND_LINEBREAK);
@@ -1124,7 +1119,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
       if (diagnostic instanceof AbstractValidationDiagnostic) {
         AbstractValidationDiagnostic avd = (AbstractValidationDiagnostic) diagnostic;
         // Create error message
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(30);
         sb.append("Unexpected issue found. Code '");
         sb.append(avd.getIssueCode());
         sb.append(DOT_AND_LINEBREAK);
@@ -1146,7 +1141,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
         }
       } else {
         // Create error message
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(30);
         sb.append("Unexpected diagnostic found. '");
         sb.append(diagnostic.toString());
         sb.append(DOT_AND_LINEBREAK);

--- a/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/util/RuntimeProjectUtilTest.java
+++ b/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/util/RuntimeProjectUtilTest.java
@@ -43,7 +43,7 @@ public class RuntimeProjectUtilTest extends AbstractUtilTest {
 
   private static final String WORKSPACE_PATH = ResourcesPlugin.getWorkspace().getRoot().getLocationURI().getPath();
 
-  public static final ImmutableList<String> SOURCE_NAMES = ImmutableList.of("FormatBuilderParticipantInput.format", "FormatBuilderParticipantOutput.format");
+  public static final List<String> SOURCE_NAMES = ImmutableList.of("FormatBuilderParticipantInput.format", "FormatBuilderParticipantOutput.format");
 
   private static URI uriInCorrect;
   private static IStorage2UriMapper mapperInCorrect;

--- a/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/templates/ResourceNameTemplateVariableResolverTest.java
+++ b/com.avaloq.tools.ddk.xtext.ui.test/src/com/avaloq/tools/ddk/xtext/ui/templates/ResourceNameTemplateVariableResolverTest.java
@@ -36,7 +36,6 @@ public class ResourceNameTemplateVariableResolverTest {
   private static final String FILENAME = "filename"; //$NON-NLS-1$
 
   private static XtextTemplateContext mockContext;
-  private static IXtextDocument mockDocument;
   private static IFile mockFile;
 
   private static TemplateVariableResolverTestHelper helper;
@@ -46,13 +45,13 @@ public class ResourceNameTemplateVariableResolverTest {
   @BeforeAll
   public void beforeAll() {
     mockContext = Mockito.mock(XtextTemplateContext.class);
-    mockDocument = Mockito.mock(IXtextDocument.class);
     mockFile = Mockito.mock(IFile.class);
 
     helper = Guice.createInjector(new XtextRuntimeModule()).getInstance(TemplateVariableResolverTestHelper.class);
 
     resolver = new ResourceNameTemplateVariableResolver();
 
+    IXtextDocument mockDocument = Mockito.mock(IXtextDocument.class);
     Mockito.when(mockContext.getDocument()).thenReturn(mockDocument);
     Mockito.when(mockDocument.getAdapter(IFile.class)).thenReturn(mockFile);
   }
@@ -60,7 +59,6 @@ public class ResourceNameTemplateVariableResolverTest {
   @AfterAll
   public void afterAll() {
     mockContext = null;
-    mockDocument = null;
     mockFile = null;
 
     helper = null;

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/AbstractValidElementBase.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/AbstractValidElementBase.java
@@ -12,16 +12,17 @@ package com.avaloq.tools.ddk.xtext.ui.validation;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.List;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.core.runtime.IConfigurationElement;
 
 
 /**
  * This class serves as the implementation base for the element classes of the
  * plug-in extension point <code>ch.paranor.au.xtext.valid.core.valid</code>.
- * 
+ *
  * @see ValidExtensionPointManager
  */
 public abstract class AbstractValidElementBase {
@@ -52,14 +53,14 @@ public abstract class AbstractValidElementBase {
    * Return all child elements of this element that conform to the hierarchy of the
    * XML schema that goes with this extension point. The order the returned elements
    * is not specified here.
-   * 
+   *
    * @return the child elements of this element
    */
   public AbstractValidElementBase[] getChildElements() {
     AbstractValidElementBase[] childElements = null;
     if (childElements == null) {
       IConfigurationElement[] ce = getConfigurationElement().getChildren();
-      ArrayList<AbstractValidElementBase> elements = new ArrayList<AbstractValidElementBase>();
+      List<AbstractValidElementBase> elements = new ArrayList<AbstractValidElementBase>();
       for (IConfigurationElement element : ce) {
         AbstractValidElementBase e = createChildElement(element);
         if (e != null) {
@@ -90,7 +91,7 @@ public abstract class AbstractValidElementBase {
    * represents. All attributes of this element are provided
    * via getters of this class. Child elements of this
    * element can be obtained via {@link #getChildElements}.
-   * 
+   *
    * @return never null
    */
   public IConfigurationElement getConfigurationElement() {
@@ -99,7 +100,7 @@ public abstract class AbstractValidElementBase {
 
   /**
    * Creates a child element inside the container (configuration element).
-   * 
+   *
    * @param container
    *          the parent of the newly created element
    * @return the created element
@@ -117,7 +118,7 @@ public abstract class AbstractValidElementBase {
 
   /**
    * Log a problem.
-   * 
+   *
    * @param ex
    *          exception manifesting the problem
    * @param msg
@@ -130,7 +131,7 @@ public abstract class AbstractValidElementBase {
   /**
    * Reads the named attribute value from the configuration element. Throws IllegalArgumentException
    * if the name of the attribute is not known
-   * 
+   *
    * @param configurationElement
    *          the container (configuration element)
    * @param name

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/ValidExtension.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/ValidExtension.java
@@ -12,6 +12,7 @@ package com.avaloq.tools.ddk.xtext.ui.validation;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
@@ -53,7 +54,7 @@ public final class ValidExtension {
     ValidElement[] topLevelElements = null;
     if (topLevelElements == null) {
       IConfigurationElement[] configurationElements = extension.getConfigurationElements();
-      ArrayList<ValidElement> elements = new ArrayList<ValidElement>();
+      List<ValidElement> elements = new ArrayList<ValidElement>();
       for (IConfigurationElement ce : configurationElements) {
         if (XML_TOP_ELEMENT_NAME.equals(ce.getName())) {
           ValidElement e = new ValidElement(ce);
@@ -84,8 +85,7 @@ public final class ValidExtension {
       // CHECKSTYLE:OFF
     } catch (Exception e) {
       // CHECKSTYLE:ON
-      final String message = MessageFormat.format(FAILED_TO_LOAD_EXTENSION, new Object[] {ValidExtension.class.getSimpleName(), id,
-          extension.getNamespaceIdentifier()});
+      final String message = MessageFormat.format(FAILED_TO_LOAD_EXTENSION, ValidExtension.class.getSimpleName(), id, extension.getNamespaceIdentifier());
       AbstractValidElementBase.logException(e, message);
       return null;
     }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/formatting/ExtendedFormattingConfigBasedStream.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/formatting/ExtendedFormattingConfigBasedStream.java
@@ -70,8 +70,8 @@ import com.google.common.collect.Sets;
 public class ExtendedFormattingConfigBasedStream extends FormattingConfigBasedStream implements IDelegatingTokenStream {
 
   private static final Logger LOGGER = LogManager.getLogger(ExtendedFormattingConfigBasedStream.class);
-  private final Stack<Integer> columnIndents = new Stack<Integer>();
-  private final Stack<Integer> initialIndents = new Stack<Integer>();
+  private final Stack<Integer> columnIndents = new Stack<Integer>(); // NOPMD LooseCoupling, ReplaceVectorWithList
+  private final Stack<Integer> initialIndents = new Stack<Integer>(); // NOPMD LooseCoupling, ReplaceVectorWithList
   private final Set<NoFormatLocator> noFormatLocators = new HashSet<NoFormatLocator>();
 
   private INode currentNode;
@@ -197,7 +197,7 @@ public class ExtendedFormattingConfigBasedStream extends FormattingConfigBasedSt
    * @return
    *         top element or 0 if stack empty
    */
-  private int emptySafeStackPeek(final Stack<Integer> stack) {
+  private int emptySafeStackPeek(final Stack<Integer> stack) { // NOPMD LooseCoupling
     if (!stack.empty()) {
       return stack.peek();
     }
@@ -210,7 +210,7 @@ public class ExtendedFormattingConfigBasedStream extends FormattingConfigBasedSt
    * @param stack
    *          stack of integers
    */
-  private void emptySafeStackPop(final Stack<Integer> stack) {
+  private void emptySafeStackPop(final Stack<Integer> stack) { // NOPMD LooseCoupling
     if (!stack.empty()) {
       stack.pop();
     }
@@ -295,7 +295,7 @@ public class ExtendedFormattingConfigBasedStream extends FormattingConfigBasedSt
       }
     }
 
-    List<ElementLocator> result = Lists.newArrayList(activeRangeLocators);
+    List<ElementLocator> result = Lists.newArrayList(activeRangeLocators); // NOPMD ConfusingArgumentToVarargsMethod
     last = grammarElement;
     for (ElementLocator locator : locators) {
       if (locator.getType() == LocatorType.RANGE && !activeRangeLocators.add(locator)) {
@@ -354,10 +354,10 @@ public class ExtendedFormattingConfigBasedStream extends FormattingConfigBasedSt
           }
           Integer parameter = (Integer) calculateParameterMethod.invoke(parameterCalculator, semanticNode, columnMap.get(semanticNode));
           if (locator instanceof ColumnLocator) {
-            ((ColumnLocator) locator).setColumn(parameter.intValue());
+            ((ColumnLocator) locator).setColumn(parameter);
             parameterizedLocators.add(locator);
           } else if (locator instanceof FixedLocator) {
-            ((FixedLocator) locator).setColumn(parameter.intValue());
+            ((FixedLocator) locator).setColumn(parameter);
             parameterizedLocators.add(locator);
           } else if (locator instanceof IIndentationLocator) {
             ((IIndentationLocator) locator).setIndentation(parameter);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/AbstractFragmentProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/AbstractFragmentProvider.java
@@ -44,7 +44,6 @@ public abstract class AbstractFragmentProvider implements IFragmentProvider {
   protected class FragmentSegmentIterator implements Iterator<String> {
     private final String fragment;
     private final int length;
-    private int startIdx;
     private int endIdx;
     private int reps;
 
@@ -80,7 +79,7 @@ public abstract class AbstractFragmentProvider implements IFragmentProvider {
      */
     @Override
     public String next() { // NOPMD - this isn't actually complex, and I much prefer a ternary to a if-else
-      startIdx = endIdx + 1;
+      int startIdx = endIdx + 1;
       int idx = indexOfUnescapedChar(fragment, END_MATCHER, startIdx);
       int repIdx = idx < length && fragment.charAt(idx) == REP_SEPARATOR ? idx : -1;
       endIdx = repIdx == -1 ? idx : indexOfUnescapedChar(fragment, SEGMENT_SEPARATOR_MATCHER, repIdx);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/FastLazyURIEncoder.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/FastLazyURIEncoder.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.linking;
 
+import java.util.Objects;
+
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -41,9 +43,7 @@ public class FastLazyURIEncoder extends LazyURIEncoder {
       idx = idx2 + 2;
       idx2 = uriFragment.indexOf(SEP, idx);
       INode node = NodeModelUtils.getNode(source);
-      if (node == null) {
-        throw new IllegalStateException("Couldn't resolve lazy link, because no node model is attached."); //$NON-NLS-1$
-      }
+      Objects.requireNonNull(node, "Couldn't resolve lazy link, because no node model is attached."); //$NON-NLS-1$
 
       EReference ref = fromShortExternalForm(source.eClass(), uriFragment.substring(idx, idx2));
       idx = idx2 + 2;

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
@@ -269,9 +269,7 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
     if (isValidationDisabled()) {
       return;
     }
-    if (diagnosticFilter.suppressDiagnostic(triple)) {
-      return;
-    } else {
+    if (!diagnosticFilter.suppressDiagnostic(triple)) {
       super.createAndAddDiagnostic(triple);
       if (LOGGER.isDebugEnabled()) {
         // call to super does not return the new diagnostic so create a temporary one
@@ -437,13 +435,9 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
 
   @Override
   protected Set<String> getUnresolvableURIFragments() {
-    Set<String> unresolveableProxies = getCache().get(UNRESOLVEABLE_PROXIES_KEY, this, new Provider<Set<String>>() {
-      @Override
-      public Set<String> get() {
-        return isLoadedFromStorage() ? Sets.newHashSet(StorageAwareResource.UNRESOLVABLE_FRAGMENT) : Sets.newHashSet();
-      }
-    });
-    return unresolveableProxies;
+    return getCache().get(UNRESOLVEABLE_PROXIES_KEY, this, () -> //
+    isLoadedFromStorage() ? Sets.newHashSet(StorageAwareResource.UNRESOLVABLE_FRAGMENT) : Sets.newHashSet()// NOPMD ConfusingArgumentToVarargsMethod
+    );
   }
 
   @Override

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/AbstractExportedNameProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/AbstractExportedNameProvider.java
@@ -29,7 +29,7 @@ import com.google.inject.Inject;
 public abstract class AbstractExportedNameProvider extends IQualifiedNameProvider.AbstractImpl {
 
   @Inject
-  private final IResourceScopeCache cache = IResourceScopeCache.NullImpl.INSTANCE;
+  private static final IResourceScopeCache CACHE = IResourceScopeCache.NullImpl.INSTANCE;
 
   @Inject
   private final IQualifiedNameConverter converter = new IQualifiedNameConverter.DefaultImpl();
@@ -39,7 +39,7 @@ public abstract class AbstractExportedNameProvider extends IQualifiedNameProvide
    */
   @Override
   public QualifiedName getFullyQualifiedName(final EObject obj) {
-    return cache.get(Tuples.pair(obj, this.getClass()), obj.eResource(), () -> qualifiedName(obj));
+    return CACHE.get(Tuples.pair(obj, this.getClass()), obj.eResource(), () -> qualifiedName(obj));
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNamePattern.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNamePattern.java
@@ -415,9 +415,7 @@ public class QualifiedNamePattern extends QualifiedName {
       }
     } else {
       for (T[] values : lookupMap.subMap(lowerInclusive(), upperExclusive()).values()) {
-        for (T element : values) {
-          candidates.add(element);
-        }
+        candidates.addAll(Arrays.asList(values));
       }
     }
     return candidates;

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractCachingResourceDescriptionManager.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractCachingResourceDescriptionManager.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.function.Predicate;
@@ -76,7 +77,7 @@ public abstract class AbstractCachingResourceDescriptionManager extends DerivedS
   private IFileExtensionResolver fileExtensionResolver;
 
   /** The file extensions of the DSL this resource description manager is for. */
-  private ImmutableSet<String> fileExtensions;
+  private Set<String> fileExtensions;
 
   /**
    * Set the file extensions of our own language.
@@ -359,8 +360,8 @@ public abstract class AbstractCachingResourceDescriptionManager extends DerivedS
   }
 
   /** Cache for the exported names from a delta. */
-  private static final WeakHashMap<Delta, Set<QualifiedName>> RESOLVED_EXPORTED_NAMES = new WeakHashMap<Delta, Set<QualifiedName>>();
-  private static final WeakHashMap<Delta, Set<QualifiedName>> UNRESOLVED_EXPORTED_NAMES = new WeakHashMap<Delta, Set<QualifiedName>>();
+  private static final Map<Delta, Set<QualifiedName>> RESOLVED_EXPORTED_NAMES = new WeakHashMap<Delta, Set<QualifiedName>>();
+  private static final Map<Delta, Set<QualifiedName>> UNRESOLVED_EXPORTED_NAMES = new WeakHashMap<Delta, Set<QualifiedName>>();
 
   @Override
   // PMD : readability ok, nesting level of "returns" is always one
@@ -467,7 +468,7 @@ public abstract class AbstractCachingResourceDescriptionManager extends DerivedS
    *
    * @return all extensions ({@code null})
    */
-  protected static ImmutableSet<String> all() {
+  protected static ImmutableSet<String> all() { // NOPMD LooseCoupling
     return null; // NOPMD ReturnEmptyCollectionRatherThanNull
   }
 

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractResourceDescriptionStrategy.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractResourceDescriptionStrategy.java
@@ -131,10 +131,7 @@ public abstract class AbstractResourceDescriptionStrategy extends DefaultResourc
    * @return true if object fingerprints can be computed
    */
   protected boolean doComputeObjectFingerprint(final EObject object) {
-    if (fingerprintComputer == null) {
-      return false;
-    }
-    return !BuildPhases.isIndexing(object);
+    return fingerprintComputer != null && !BuildPhases.isIndexing(object);
   }
 
   @Override

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescriptionDelta.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescriptionDelta.java
@@ -15,8 +15,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.IResourceDescription;
@@ -229,11 +229,7 @@ public class ResourceDescriptionDelta extends AbstractResourceDescriptionDelta {
     IResourceDescription desc = newDesc == null ? oldDesc : getNew();
     final Iterator<IEObjectDescription> objectIter = desc.getExportedObjects().iterator();
 
-    if (!objectIter.hasNext()) {
-      return false;
-    } else {
-      return objectIter.next().getUserData(IFingerprintComputer.OBJECT_FINGERPRINT) != null;
-    }
+    return objectIter.hasNext() && objectIter.next().getUserData(IFingerprintComputer.OBJECT_FINGERPRINT) != null;
   }
 
   public Collection<IEObjectDescription> getDeletedObjects() {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceServiceProviderLocator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceServiceProviderLocator.java
@@ -52,8 +52,7 @@ public class ResourceServiceProviderLocator {
    * @return the {@link IResourceServiceProvider} for the given language id
    */
   public IResourceServiceProvider getResourceServiceProviderById(final String languageId) {
-    ImmutableMap<Map<String, Object>, ? extends Function<String, IResourceServiceProvider>> resourceProvidersMap = getProviderMaps();
-    for (Map.Entry<Map<String, Object>, ? extends Function<String, IResourceServiceProvider>> mapEntry : resourceProvidersMap.entrySet()) {
+    for (Map.Entry<Map<String, Object>, ? extends Function<String, IResourceServiceProvider>> mapEntry : getProviderMaps().entrySet()) {
       Map<String, Object> map = mapEntry.getKey();
       for (Map.Entry<String, Object> entry : map.entrySet()) {
         try {
@@ -80,28 +79,27 @@ public class ResourceServiceProviderLocator {
    *
    * @return the resource service provider's maps
    */
-  private ImmutableMap<Map<String, Object>, ? extends Function<String, IResourceServiceProvider>> getProviderMaps() {
-    ImmutableMap<Map<String, Object>, ? extends Function<String, IResourceServiceProvider>> resourceProvidersMap = //
-        ImmutableMap.of(IResourceServiceProvider.Registry.INSTANCE.getExtensionToFactoryMap(), new Function<String, IResourceServiceProvider>() {
-          @Override
-          public IResourceServiceProvider apply(final String input) {
-            URI fake = URI.createURI("fake:/foo." + input); //$NON-NLS-1$
-            return IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(fake, ContentHandler.UNSPECIFIED_CONTENT_TYPE);
-          }
-        }, IResourceServiceProvider.Registry.INSTANCE.getContentTypeToFactoryMap(), new Function<String, IResourceServiceProvider>() {
-          @Override
-          public IResourceServiceProvider apply(final String input) {
-            URI fake = URI.createURI("fake:/foo"); //$NON-NLS-1$
-            return IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(fake, input);
-          }
-        }, IResourceServiceProvider.Registry.INSTANCE.getProtocolToFactoryMap(), new Function<String, IResourceServiceProvider>() {
-          @Override
-          public IResourceServiceProvider apply(final String input) {
-            URI fake = URI.createURI(input + ":/foo"); //$NON-NLS-1$
-            return IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(fake, ContentHandler.UNSPECIFIED_CONTENT_TYPE);
-          }
-        });
-    return resourceProvidersMap;
+  private Map<Map<String, Object>, ? extends Function<String, IResourceServiceProvider>> getProviderMaps() {
+    return //
+    ImmutableMap.of(IResourceServiceProvider.Registry.INSTANCE.getExtensionToFactoryMap(), new Function<String, IResourceServiceProvider>() {
+      @Override
+      public IResourceServiceProvider apply(final String input) {
+        URI fake = URI.createURI("fake:/foo." + input); //$NON-NLS-1$
+        return IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(fake, ContentHandler.UNSPECIFIED_CONTENT_TYPE);
+      }
+    }, IResourceServiceProvider.Registry.INSTANCE.getContentTypeToFactoryMap(), new Function<String, IResourceServiceProvider>() {
+      @Override
+      public IResourceServiceProvider apply(final String input) {
+        URI fake = URI.createURI("fake:/foo"); //$NON-NLS-1$
+        return IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(fake, input);
+      }
+    }, IResourceServiceProvider.Registry.INSTANCE.getProtocolToFactoryMap(), new Function<String, IResourceServiceProvider>() {
+      @Override
+      public IResourceServiceProvider apply(final String input) {
+        URI fake = URI.createURI(input + ":/foo"); //$NON-NLS-1$
+        return IResourceServiceProvider.Registry.INSTANCE.getResourceServiceProvider(fake, ContentHandler.UNSPECIFIED_CONTENT_TYPE);
+      }
+    });
   }
 
 }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageFacade.java
@@ -39,7 +39,7 @@ public class DirectLinkingResourceStorageFacade extends ResourceStorageFacade {
 
   @Inject(optional = true)
   @Named(value = STORE_NODE_MODEL)
-  private boolean storeNodeModel = true; // NOPMD ImmutableField
+  private final boolean storeNodeModel = true; // NOPMD ImmutableField
 
   @Inject
   private ITraceSet traceSet;
@@ -51,7 +51,7 @@ public class DirectLinkingResourceStorageFacade extends ResourceStorageFacade {
 
   @Override
   public boolean shouldLoadFromStorage(final StorageAwareResource resource) {
-    if (ResourceLoadMode.get(resource).instruction(Constituent.RESOURCE) == Instruction.SKIP) {
+    if (ResourceLoadMode.get(resource).instruction(Constituent.RESOURCE) == Instruction.SKIP) { // NOPMD SimplifyBooleanReturns
       return false;
     }
     return super.shouldLoadFromStorage(resource);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyAwareSerializationConversionContext.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyAwareSerializationConversionContext.java
@@ -37,7 +37,7 @@ class ProxyAwareSerializationConversionContext extends SerializationConversionCo
   @SuppressWarnings("unchecked")
   @Override
   protected void fillEObjectToIdMap(final Resource resource) {
-    ArrayList<EObject> idToEObjectMap = new ArrayList<EObject>();
+    List<EObject> idToEObjectMap = new ArrayList<EObject>();
 
     fillIdToEObjectMap(resource, idToEObjectMap);
 

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
@@ -74,7 +74,7 @@ class ProxyCompositeNode implements ICompositeNode, BidiTreeIterable<INode>, Ada
       return;
     }
 
-    ArrayList<EObject> idToEObjectMap = Lists.newArrayList();
+    ArrayList<EObject> idToEObjectMap = Lists.newArrayList(); // NOPMD LooseCoupling
     EObject root = resource.getContents().get(0);
 
     ProxyCompositeNode rootNode = installProxyNodeModel(root, idToEObjectMap);

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/serializer/sequencer/ReorderingHiddenTokenSequencer.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/serializer/sequencer/ReorderingHiddenTokenSequencer.java
@@ -691,7 +691,7 @@ public class ReorderingHiddenTokenSequencer implements IHiddenTokenSequencer, IS
     if (!tokenUtil.isCommentNode(comment)) {
       return false;
     }
-    if (node.getText().endsWith(NEW_LINE)) {
+    if (node.getText().endsWith(NEW_LINE)) { // NOPMD SimplifyBooleanReturns
       return false;
     }
     return comment.getStartLine() == node.getEndLine();

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/ResourceValidationRuleSummaryEvent.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/tracing/ResourceValidationRuleSummaryEvent.java
@@ -109,7 +109,7 @@ public class ResourceValidationRuleSummaryEvent extends ResourceEvent {
      */
     public void postEvents(final URI uri, final ITraceSet traceSet) {
       for (Map.Entry<String, long[]> entry : ruleExecutionData.entrySet()) {
-        traceSet.post(new ResourceValidationRuleSummaryEvent(Trigger.TRACE, new Object[] {uri, entry.getKey(), entry.getValue()[0], entry.getValue()[1]}));
+        traceSet.post(new ResourceValidationRuleSummaryEvent(Trigger.TRACE, uri, entry.getKey(), entry.getValue()[0], entry.getValue()[1]));
       }
     }
 

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/validation/ValidPreferenceStore.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/validation/ValidPreferenceStore.java
@@ -89,7 +89,7 @@ public class ValidPreferenceStore {
    * The default context is the context where getDefault and setDefault
    * methods will search. This context is also used in the search.
    */
-  private final IScopeContext defaultContext = DefaultScope.INSTANCE;
+  private static final IScopeContext DEFAULT_CONTEXT = DefaultScope.INSTANCE;
 
   /**
    * The nodeQualifer is the string used to look up the node in the contexts.
@@ -178,7 +178,7 @@ public class ValidPreferenceStore {
    * @return this store's default preference node
    */
   private IEclipsePreferences getDefaultPreferences() {
-    return defaultContext.getNode(defaultQualifier);
+    return DEFAULT_CONTEXT.getNode(defaultQualifier);
   }
 
   /**
@@ -244,7 +244,7 @@ public class ValidPreferenceStore {
     // Assert that the default was not included (we automatically add it to
     // the end)
     for (final IScopeContext scope : scopes) {
-      if (scope.equals(defaultContext)) {
+      if (scope.equals(DEFAULT_CONTEXT)) {
         Assert.isTrue(false, "Do not add the default to the search contexts"); //$NON-NLS-1$
       }
     }
@@ -257,10 +257,7 @@ public class ValidPreferenceStore {
    * @return <code>true</code> if either a current value or a default
    */
   public boolean contains(final String name) {
-    if (name == null) {
-      return false;
-    }
-    return (Platform.getPreferencesService().get(name, null, getPreferenceNodes(true))) != null;
+    return name != null && Platform.getPreferencesService().get(name, null, getPreferenceNodes(true)) != null;
   }
 
   /**
@@ -440,10 +437,7 @@ public class ValidPreferenceStore {
    *         (including the case where the preference is unknown to this store)
    */
   public boolean isDefault(final String name) {
-    if (name == null) {
-      return false;
-    }
-    return (Platform.getPreferencesService().get(name, null, getPreferenceNodes(false))) == null;
+    return name != null && Platform.getPreferencesService().get(name, null, getPreferenceNodes(false)) == null;
   }
 
 }

--- a/com.avaloq.tools.ddk.xtextspy.test/src/com/avaloq/tools/ddk/xtextspy/test/EObjectContentProviderTest.java
+++ b/com.avaloq.tools.ddk.xtextspy.test/src/com/avaloq/tools/ddk/xtextspy/test/EObjectContentProviderTest.java
@@ -112,7 +112,7 @@ public class EObjectContentProviderTest extends AbstractXtextTests {
     when(mockSelectionListener.getEditor()).thenReturn(mockEditor);
     IXtextDocument mockDocument = mock(IXtextDocument.class);
     when(mockEditor.getDocument()).thenReturn(mockDocument);
-    when(mockDocument.<ArrayList<AttributeValuePair>> readOnly(any(IUnitOfWork.class))).thenReturn(newArrayList(attributeValuePair));
+    when(mockDocument.<ArrayList<AttributeValuePair>> readOnly(any(IUnitOfWork.class))).thenReturn(newArrayList(attributeValuePair)); // NOPMD LooseCoupling
     // Mockups for returning EOperation
     BasicEList<EOperation> mockEOperationsList = new BasicEList<EOperation>();
     mockEOperationsList.add(operation);

--- a/ddk-configuration/pmd/ruleset.xml
+++ b/ddk-configuration/pmd/ruleset.xml
@@ -24,21 +24,11 @@
     <exclude name="CloseResource"/>
     <exclude name="CompareObjectsWithEquals"/>
     <exclude name="ConstructorCallsOverridableMethod"/>
-    <exclude name="DataflowAnomalyAnalysis"/>
     <exclude name="DetachedTestCase"/>
     <exclude name="DontImportSun"/><!--Checkstyle-->
     <exclude name="DoNotTerminateVM"/>
-    <exclude name="EmptyCatchBlock"/><!--Checkstyle-->
-    <exclude name="EmptyFinallyBlock"/><!--Checkstyle-->
-    <exclude name="EmptyIfStmt"/><!--Checkstyle-->
-    <exclude name="EmptyInitializer"/><!--Checkstyle-->
-    <exclude name="EmptyStatementNotInLoop"/><!--Checkstyle-->
-    <exclude name="EmptyInitializer"/><!--Checkstyle-->
-    <exclude name="EmptySwitchStatements"/><!--Checkstyle-->
-    <exclude name="EmptyTryBlock"/><!--Checkstyle-->
-    <exclude name="EmptyWhileStmt"/><!--Checkstyle-->
-    <exclude name="ImportFromSamePackage"/><!--Eclipse-->
     <exclude name="JumbledIncrementer"/><!--Checkstyle-->
+    <exclude name="EmptyCatchBlock"/><!--Checkstyle-->
     <exclude name="NullAssignment"/>
     <exclude name="SingleMethodSingleton"/>
     <exclude name="UseEqualsToCompareStrings"/><!--Checkstyle-->
@@ -60,19 +50,17 @@
     <exclude name="DataClass"/>
     <exclude name="DoNotExtendJavaLangError"/>
     <exclude name="ExcessiveImports"/>
-    <exclude name="ExcessiveMethodLength"/>
+    <exclude name="ExcessivePublicCount"/>
     <exclude name="ClassWithOnlyPrivateConstructorsShouldBeFinal"/><!--Checkstyle-->
     <exclude name="CognitiveComplexity"/>
+    <exclude name="CouplingBetweenObjects"/>
     <exclude name="CyclomaticComplexity"/>
     <exclude name="GodClass"/><!--New after PMD 5.3 upgrade, not to be activated by default-->
     <exclude name="LawOfDemeter"/><!--New after PMD 5.3 upgrade, too many markers (50'000+), too late to change-->
     <exclude name="LoosePackageCoupling"/>
-    <exclude name="ModifiedCyclomaticComplexity"/><!--New after PMD 5.3 upgrade, see CyclomaticComplexity-->
     <exclude name="MutableStaticState"/>
     <exclude name="NcssCount"/>
-    <exclude name="NcssMethodCount"/>
     <exclude name="NPathComplexity"/><!--Checkstyle-->
-    <exclude name="StdCyclomaticComplexity"/><!--New after PMD 5.3 upgrade, see CyclomaticComplexity-->
     <exclude name="SimplifyBooleanExpressions"/><!--Checkstyle-->
     <exclude name="TooManyFields"/>
     <exclude name="TooManyMethods"/>
@@ -98,23 +86,18 @@
     <exclude name="UseTryWithResources"/><!--TODO-->
   </rule>
   <rule ref="category/java/codestyle.xml">
-    <exclude name="AbstractNaming"/><!--Checkstyle-->
     <exclude name="AtLeastOneConstructor"/>
-    <exclude name="AvoidFinalLocalVariable"/>
-    <exclude name="AvoidPrefixingMethodParameters"/><!--New after PMD 5.3 upgrade, only false positives-->
     <exclude name="CallSuperInConstructor"/>
     <exclude name="ClassNamingConventions"/>
     <exclude name="CommentDefaultAccessModifier"/>
     <exclude name="ConfusingTernary"/>
     <exclude name="ControlStatementBraces"/><!--Checkstyle-->
-    <exclude name="DefaultPackage"/>
-    <exclude name="DontImportJavaLang"/><!--Eclipse-->
-    <exclude name="DuplicateImports"/><!--Eclipse-->
     <exclude name="EmptyMethodInAbstractClassShouldBeAbstract"/>
     <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
     <exclude name="FieldNamingConventions"/>
     <exclude name="IdenticalCatchBranches"/>
     <exclude name="LinguisticNaming"/>
+    <exclude name="LambdaCanBeMethodReference"/>
     <exclude name="LocalVariableCouldBeFinal"/> <!--  not sensible -->
     <exclude name="LongVariable"/> <!--  not sensible -->
     <exclude name="MethodNamingConventions"/>
@@ -122,9 +105,9 @@
     <exclude name="OnlyOneReturn"/>
     <exclude name="ShortClassName"/><!--New after PMD 5.3 upgrade, not sensible/only false positives-->
     <exclude name="ShortVariable"/> <!--  not sensible -->
-    <exclude name="SuspiciousConstantFieldName"/><!--Checkstyle-->
     <exclude name="TooManyStaticImports"/>
     <exclude name="UnnecessaryAnnotationValueElement"/>
+    <exclude name="UnnecessaryImport"/><!--Too many false positives after PMD 7 -->
     <exclude name="UnnecessaryModifier"/><!--Checkstyle-->
     <exclude name="UnnecessaryFullyQualifiedName"/>
     <exclude name="UnnecessaryLocalBeforeReturn"/>
@@ -142,95 +125,6 @@
     <exclude name="OptimizableToArrayCall"/>
     <exclude name="RedundantFieldInitializer"/><!--Checkstyle-->
     <exclude name="TooFewBranchesForASwitchStatement"/>
-  </rule>
-
-  <rule
-      language="java"
-      name="MissingBreakOrReturnInSwitch"
-      message="A switch statement does not contain a break or return statement"
-      class="net.sourceforge.pmd.lang.rule.XPathRule"
-      dfa="false"
-      typeResolution="true">
-    <description>A switch statement without an enclosed break or return statement may be a bug.</description>
-    <priority>3</priority>
-    <properties>
-      <property name="xpath">
-        <value>
-          <![CDATA[
-//SwitchStatement
-[count(SwitchLabel) > 0]
-[count(.//BreakStatement)+count(.//ReturnStatement)=0]
-[count(BlockStatement/Statement/ReturnStatement)
- + count(BlockStatement/Statement/ThrowStatement)
-     < count (SwitchLabel)]
-]]>
-        </value>
-      </property>
-    </properties>
-    <example><![CDATA[
-public class Foo {
-  public void bar(int status) {
-    switch(status) {
-      case CANCELLED:
-        doCancelled();
-        // break; hm, should this be commented out?
-      case NEW:
-        doNew();
-      case REMOVED:
-        doRemoved();
-    }
-  }
-}
-]]>
-    </example>
-  </rule>
-
-  <rule
-      language="java"
-      name="BeforeAfterClassStatic"
-      message="Methods annotated with @BeforeClass or @AfterClass need to be static."
-      class="net.sourceforge.pmd.lang.rule.XPathRule"
-      dfa="false"
-      typeResolution="true">
-    <description>Test methods annotated with @BeforeClass or @AfterClass need to be static.</description>
-    <priority>3</priority>
-    <properties>
-      <property name="xpath">
-        <value>
-          <![CDATA[
-//ClassOrInterfaceBodyDeclaration[Annotation/MarkerAnnotation/Name[@Image='BeforeClass' or @Image='AfterClass']]
-[count(MethodDeclaration[@Static='true'])=0]]]>
-        </value>
-      </property>
-    </properties>
-    <example>
-      <![CDATA[
-]]>
-    </example>
-  </rule>
-
-  <rule
-      language="java"
-      name="BeforeAfterNotStatic"
-      message="Methods annotated with @Before or @After must not be static."
-      class="net.sourceforge.pmd.lang.rule.XPathRule"
-      dfa="false"
-      typeResolution="true">
-    <description>Test methods annotated with @Before or @After must not be static.</description>
-    <priority>3</priority>
-    <properties>
-      <property name="xpath">
-        <value>
-          <![CDATA[
-//ClassOrInterfaceBodyDeclaration[Annotation/MarkerAnnotation/Name[@Image='Before' or @Image='After']]
-[count(MethodDeclaration[@Static='false'])=0]]]>
-        </value>
-      </property>
-    </properties>
-    <example>
-      <![CDATA[
-]]>
-    </example>
   </rule>
 
 </ruleset>

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -52,8 +52,8 @@
     <deploy.version>3.1.2</deploy.version>
     <spotbugs.plugin.version>4.8.5.0</spotbugs.plugin.version>
     <spotbugs.version>4.8.5</spotbugs.version>
-    <pmd.plugin.version>3.21.2</pmd.plugin.version>
-    <pmd.version>6.55.0</pmd.version>
+    <pmd.plugin.version>3.22.0</pmd.plugin.version>
+    <pmd.version>7.1.0</pmd.version>
     <tycho.version>4.0.7</tycho.version>
     <xtend.version>2.34.0</xtend.version>
   </properties>


### PR DESCRIPTION
The custom rule for detecting fall through in switch statements is deleted, as PMD has now a rule ImplicitSwitchFallThrough.