### PR TITLE
Revert "Upgrade to PDM 7"

### DIFF
--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -52,8 +52,8 @@
     <deploy.version>3.1.1</deploy.version>
     <spotbugs.plugin.version>4.8.4.0</spotbugs.plugin.version>
     <spotbugs.version>4.8.4</spotbugs.version>
-    <pmd.plugin.version>3.22.0</pmd.plugin.version>
-    <pmd.version>7.0.0</pmd.version>
+    <pmd.plugin.version>3.21.2</pmd.plugin.version>
+    <pmd.version>6.55.0</pmd.version>
     <tycho.version>4.0.7</tycho.version>
     <xtend.version>2.34.0</xtend.version>
   </properties>


### PR DESCRIPTION
Reverts dsldevkit/dsl-devkit#916, it did not include the necessary changes to the GitHub Actions to upgrade those as well to PMD 7.

Upgrading GitHub Actions to use PMD 7 shows many PMD violations, and thus, needs to be better prepared.
