### PR TITLE
feat: generate check catalog dispatch methods

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorExtensions.xtend
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorExtensions.xtend
@@ -134,21 +134,30 @@ class CheckGeneratorExtensions {
     )
   }
 
-  def checkType(Context context) {
-    var TriggerKind kind;
-    if (context.eContainer instanceof Check) {
-      kind = (context.eContainer as Check).kind
-    }
+  def CheckType checkType(Check check) {
+    /* TODO handle the case of independent check implementations
+     * An Implementation is not a Check and has no kind,
+     * but it may execute checks of various types.
+     * As it is we treat them all as FAST regardless of declared kind.
+     */
+    val TriggerKind kind = check?.kind ?: TriggerKind::FAST;
 
-    if (kind === null) {
-      kind = TriggerKind::FAST // TODO handle the case of independent check implementations
-    }
-
-    return "CheckType." + switch (kind) {
+    return switch (kind) {
       case TriggerKind::EXPENSIVE: CheckType::EXPENSIVE
       case TriggerKind::NORMAL: CheckType::NORMAL
       case TriggerKind::FAST: CheckType::FAST
-    }.toString
+    };
+  }
+
+  /* Returns a default CheckType for a non-Check context. */
+  def CheckType checkType(Context context) {
+    val container = context.eContainer();
+    val Check check = if (container instanceof Check) container else null;
+    return checkType(check);
+  }
+
+  def String checkTypeQName(Context context) {
+    return "CheckType." + checkType(context);
   }
 
   def issues(EObject object) {

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorNaming.xtend
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorNaming.xtend
@@ -146,7 +146,7 @@ class CheckGeneratorNaming {
 
   /* Gets the name of the default validator class. */
   def String defaultValidatorClassName() {
-    "DefaultCheckImpl"
+    "DispatchingCheckImpl"
   }
 
   /* Gets the fully qualified name of the default validator class. */

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/PluginTestProjectManager.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/PluginTestProjectManager.java
@@ -39,18 +39,17 @@ import com.google.inject.Injector;
 /**
  * The Test Project Manager for Plugins.
  */
+@SuppressWarnings("nls")
 public class PluginTestProjectManager extends XtextTestProjectManager {
   private static final Logger LOGGER = LogManager.getLogger(PluginTestProjectManager.class);
 
-  public static final String DEFAULT_SOURCE_FOLDER = "src"; //$NON-NLS-1$
-  public static final String DEFAULT_SOURCE_GEN_FOLDER = "src-gen"; //$NON-NLS-1$
-  public static final String TEST_PROJECT_NAME = "test.project"; //$NON-NLS-1$
+  public static final String DEFAULT_SOURCE_FOLDER = "src";
+  public static final String DEFAULT_SOURCE_GEN_FOLDER = "src-gen";
+  public static final String TEST_PROJECT_NAME = "test.project";
 
   // org.eclipse.osgi needed for NLS
   // org.apache.logging.log4j needed for logging in generated StandaloneSetup
-  private static final List<String> REQUIRED_BUNDLES = newArrayList("org.eclipse.xtext.xbase.lib", "org.eclipse.xtend.lib", // //$NON-NLS-1$ //$NON-NLS-2$
-      "org.eclipse.emf.ecore", "com.avaloq.tools.ddk.check.core", "com.avaloq.tools.ddk.check.runtime.core", "com.avaloq.tools.ddk.check.lib", // //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-      "org.eclipse.xtext", "org.eclipse.osgi", "org.eclipse.xtend", "org.eclipse.core.runtime", "org.eclipse.xtext.xbase", "org.apache.logging.log4j"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+  private static final List<String> REQUIRED_BUNDLES = newArrayList("org.eclipse.xtext.xbase.lib", "org.eclipse.xtend.lib", "org.eclipse.emf.ecore", "com.avaloq.tools.ddk.check.core", "com.avaloq.tools.ddk.check.runtime.core", "com.avaloq.tools.ddk.check.lib", "com.avaloq.tools.ddk.xtext", "org.eclipse.xtext", "org.eclipse.osgi", "org.eclipse.xtend", "org.eclipse.core.runtime", "org.eclipse.xtext.xbase", "org.apache.logging.log4j");
 
   private final Injector injector;
 
@@ -73,14 +72,14 @@ public class PluginTestProjectManager extends XtextTestProjectManager {
     final PluginProjectFactory projectFactory = injector.getInstance(PluginProjectFactory.class);
     projectFactory.setProjectName(name);
     projectFactory.addFolders(newArrayList(DEFAULT_SOURCE_FOLDER, DEFAULT_SOURCE_GEN_FOLDER));
-    projectFactory.addBuilderIds(JavaCore.BUILDER_ID, "org.eclipse.pde.ManifestBuilder", "org.eclipse.pde.SchemaBuilder", XtextProjectHelper.BUILDER_ID); //$NON-NLS-1$ //$NON-NLS-2$
-    projectFactory.addProjectNatures(JavaCore.NATURE_ID, "org.eclipse.pde.PluginNature", XtextProjectHelper.NATURE_ID); //$NON-NLS-1$
+    projectFactory.addBuilderIds(JavaCore.BUILDER_ID, "org.eclipse.pde.ManifestBuilder", "org.eclipse.pde.SchemaBuilder", XtextProjectHelper.BUILDER_ID);
+    projectFactory.addProjectNatures(JavaCore.NATURE_ID, "org.eclipse.pde.PluginNature", XtextProjectHelper.NATURE_ID);
     projectFactory.addRequiredBundles(REQUIRED_BUNDLES);
     projectFactory.addContributor(new IProjectFactoryContributor() {
       @Override
       public void contributeFiles(final IProject project, final IFileCreator fileWriter) {
         // Generate a plugin.xml file
-        fileWriter.writeToFile("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<?eclipse version=\"3.4\"?>\n<plugin>\n</plugin>\n", "plugin.xml"); //$NON-NLS-1$ //$NON-NLS-2$
+        fileWriter.writeToFile("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<?eclipse version=\"3.4\"?>\n<plugin>\n</plugin>\n", "plugin.xml");
       }
     });
     final IProject[] result = new IProject[1];
@@ -92,7 +91,7 @@ public class PluginTestProjectManager extends XtextTestProjectManager {
         if (javaProject != null) {
           JavaProjectSetupUtil.addJreClasspathEntry(javaProject);
         } else {
-          LOGGER.warn("Could not create a new Check project, attempting to reuse the existing project."); //$NON-NLS-1$
+          LOGGER.warn("Could not create a new Check project, attempting to reuse the existing project.");
         }
       }
     };
@@ -112,7 +111,7 @@ public class PluginTestProjectManager extends XtextTestProjectManager {
       IResourcesSetupUtil.waitForBuild();
       createPluginProject(injector, TEST_PROJECT_NAME);
     } catch (CoreException e) {
-      throw new IllegalStateException("Failed to create plugin project"); //$NON-NLS-1$
+      throw new IllegalStateException("Failed to create plugin project");
     }
   }
 
@@ -146,12 +145,12 @@ public class PluginTestProjectManager extends XtextTestProjectManager {
     } catch (InvocationTargetException e) {
       LOGGER.error(e.getCause().getMessage());
     } catch (InterruptedException e) {
-      throw new AssertionError("Interrupted"); //$NON-NLS-1$
+      throw new AssertionError("Interrupted");
     }
   }
 
   @Override
   public URI createPlatformUri(final String encodedFileName) {
-    return URI.createPlatformResourceURI('/' + TEST_PROJECT_NAME + "/" + DEFAULT_SOURCE_FOLDER + "/" + encodedFileName, true); //$NON-NLS-1$ //$NON-NLS-2$
+    return URI.createPlatformResourceURI('/' + TEST_PROJECT_NAME + "/" + DEFAULT_SOURCE_FOLDER + "/" + encodedFileName, true);
   }
 }


### PR DESCRIPTION
That is, modify the Check language generator so that for each check catalog a dispatch method gets generated for calling all the applicable check methods for a given check mode and context object.

The motivation for this is to avoid the need to use runtime introspection to determine what methods are available, and also to avoid the need to deal with reified Method objects for invocation.

Retain DefaultCheckImpl to avoid breakage, but switch to DispatchingCheckImpl class as the new default check catalog base class used by the modified generator.