### PR TITLE
feat: add AbstractDispatchingCheckImpl base class

### DIFF
--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/AbstractCheckImpl.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/AbstractCheckImpl.java
@@ -12,21 +12,11 @@
 package com.avaloq.tools.ddk.check.runtime.issue;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.emf.common.util.Diagnostic;
-import org.eclipse.emf.common.util.DiagnosticChain;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.xtext.diagnostics.Severity;
-import org.eclipse.xtext.validation.CheckMode;
-import org.eclipse.xtext.validation.CheckType;
-import org.eclipse.xtext.validation.FeatureBasedDiagnostic;
-import org.eclipse.xtext.validation.ValidationMessageAcceptor;
 
 import com.avaloq.tools.ddk.xtext.tracing.ResourceValidationRuleSummaryEvent.Collector;
 
@@ -34,25 +24,8 @@ import com.avaloq.tools.ddk.xtext.tracing.ResourceValidationRuleSummaryEvent.Col
 /**
  * An abstract base class for check catalog implementations.
  */
-public abstract class AbstractCheckImpl implements ICheckValidatorImpl, ValidationMessageAcceptor {
+public abstract class AbstractCheckImpl implements ICheckValidatorImpl {
   private static final Logger LOGGER = LogManager.getLogger(AbstractCheckImpl.class);
-
-  private final ThreadLocal<State> threadLocalState;
-
-  private final ValidationMessageAcceptor messageAcceptor;
-
-  public AbstractCheckImpl() {
-    this.threadLocalState = new ThreadLocal<State>();
-    this.messageAcceptor = this;
-  }
-
-  protected ThreadLocal<State> getThreadLocalState() {
-    return threadLocalState;
-  }
-
-  public ValidationMessageAcceptor getMessageAcceptor() {
-    return messageAcceptor;
-  }
 
   /**
    * Logs a check method failure.
@@ -103,155 +76,6 @@ public abstract class AbstractCheckImpl implements ICheckValidatorImpl, Validati
     if (collector != null) {
       collector.ruleEnded(rule, object);
     }
-  }
-
-  // ////////////////////////////////////////////////
-  // Copied and adapted from AbstractDeclarativeValidator below
-  // ////////////////////////////////////////////////
-
-  /**
-   * The holding the current state for a validation method being executed.
-   */
-  protected static class State {
-    // CHECKSTYLE:OFF
-    public DiagnosticChain chain = null;
-    public EObject currentObject = null;
-    public Method currentMethod = null;
-    public CheckMode checkMode = null;
-    public CheckType currentCheckType = null;
-    public boolean hasErrors = false;
-    public Map<Object, Object> context;
-
-    // CHECKSTYLE:ON
-    public State() {
-    }
-  }
-
-  protected EObject getCurrentObject() {
-    return threadLocalState.get().currentObject;
-  }
-
-  protected Method getCurrentMethod() {
-    return threadLocalState.get().currentMethod;
-  }
-
-  protected DiagnosticChain getChain() {
-    return threadLocalState.get().chain;
-  }
-
-  protected CheckMode getCheckMode() {
-    return threadLocalState.get().checkMode;
-  }
-
-  protected Map<Object, Object> getContext() {
-    return threadLocalState.get().context;
-  }
-
-  // ////////////////////////////////////////////////////////
-  // Implementation of the Validation message acceptor below
-  // ////////////////////////////////////////////////////////
-
-  @Override
-  public void acceptError(final String message, final EObject object, final EStructuralFeature feature, final int index, final String code, final String... issueData) {
-    State localState = threadLocalState.get();
-    localState.hasErrors = true;
-    localState.chain.add(createDiagnostic(Severity.ERROR, message, object, feature, index, code, issueData));
-  }
-
-  @Override
-  public void acceptWarning(final String message, final EObject object, final EStructuralFeature feature, final int index, final String code, final String... issueData) {
-    threadLocalState.get().chain.add(createDiagnostic(Severity.WARNING, message, object, feature, index, code, issueData));
-  }
-
-  @Override
-  public void acceptInfo(final String message, final EObject object, final EStructuralFeature feature, final int index, final String code, final String... issueData) {
-    threadLocalState.get().chain.add(createDiagnostic(Severity.INFO, message, object, feature, index, code, issueData));
-  }
-
-  @Override
-  public void acceptError(final String message, final EObject object, final int offset, final int length, final String code, final String... issueData) {
-    State localState = threadLocalState.get();
-    localState.hasErrors = true;
-    localState.chain.add(createDiagnostic(Severity.ERROR, message, object, offset, length, code, issueData));
-  }
-
-  @Override
-  public void acceptWarning(final String message, final EObject object, final int offset, final int length, final String code, final String... issueData) {
-    threadLocalState.get().chain.add(createDiagnostic(Severity.WARNING, message, object, offset, length, code, issueData));
-  }
-
-  @Override
-  public void acceptInfo(final String message, final EObject object, final int offset, final int length, final String code, final String... issueData) {
-    threadLocalState.get().chain.add(createDiagnostic(Severity.INFO, message, object, offset, length, code, issueData));
-  }
-
-  /**
-   * Creates a diagnostic for given parameters.
-   *
-   * @param severity
-   *          the issue severity
-   * @param message
-   *          the issue message
-   * @param object
-   *          the context object
-   * @param feature
-   *          the structural feature on which to create a marker
-   * @param index
-   *          the index at which to create a marker
-   * @param code
-   *          the issue code
-   * @param issueData
-   *          the issue data
-   * @return the diagnostic
-   */
-  protected Diagnostic createDiagnostic(final Severity severity, final String message, final EObject object, final EStructuralFeature feature, final int index, final String code, final String... issueData) {
-    int diagnosticSeverity = toDiagnosticSeverity(severity);
-    return new FeatureBasedDiagnostic(diagnosticSeverity, message, object, feature, index, threadLocalState.get().currentCheckType, code, issueData);
-  }
-
-  /**
-   * Creates a diagnostic for given parameters.
-   *
-   * @param severity
-   *          the issue severity
-   * @param message
-   *          the issue message
-   * @param object
-   *          the context object
-   * @param offset
-   *          the offset of the marker
-   * @param length
-   *          the length of tokens to be marked by the issue
-   * @param code
-   *          the issue code
-   * @param issueData
-   *          the issue data
-   * @return the diagnostic
-   */
-  protected Diagnostic createDiagnostic(final Severity severity, final String message, final EObject object, final int offset, final int length, final String code, final String... issueData) {
-    int diagnosticSeverity = toDiagnosticSeverity(severity);
-    return new CheckRangeBasedDiagnostic(diagnosticSeverity, message, object, offset, length, threadLocalState.get().currentCheckType, code, issueData);
-  }
-
-  /**
-   * Gets a numeric value mapped to a given {@link Severity}. Severities are mapped to
-   * <ul>
-   * <li>{@link Diagnostic#ERROR}
-   * <li>{@link Diagnostic#WARNING}
-   * <li>{@link Diagnostic#INFO}
-   * </ul>
-   *
-   * @param severity
-   *          the issue severity
-   * @return the numeric value representing a severity
-   */
-  protected static int toDiagnosticSeverity(final Severity severity) {
-    return switch (severity) {
-    case ERROR -> Diagnostic.ERROR;
-    case WARNING -> Diagnostic.WARNING;
-    case INFO -> Diagnostic.INFO;
-    default -> throw new IllegalArgumentException("Unknown severity " + severity); //$NON-NLS-1$
-    };
   }
 
 }

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/AbstractStatefulCheckImpl.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/AbstractStatefulCheckImpl.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.check.runtime.issue;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.DiagnosticChain;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.validation.CheckMode;
+import org.eclipse.xtext.validation.CheckType;
+import org.eclipse.xtext.validation.ValidationMessageAcceptor;
+
+
+/**
+ * A check catalog implementations that keeps track of validation state internally.
+ */
+public abstract class AbstractStatefulCheckImpl extends AbstractCheckImpl implements ValidationMessageAcceptorMixin {
+
+  private final ThreadLocal<State> threadLocalState;
+
+  private final ValidationMessageAcceptor messageAcceptor;
+
+  public AbstractStatefulCheckImpl() {
+    this.threadLocalState = new ThreadLocal<State>();
+    this.messageAcceptor = this;
+  }
+
+  protected ThreadLocal<State> getThreadLocalState() {
+    return threadLocalState;
+  }
+
+  public ValidationMessageAcceptor getMessageAcceptor() {
+    return messageAcceptor;
+  }
+
+  // ////////////////////////////////////////////////
+  // Copied and adapted from AbstractDeclarativeValidator below
+  // ////////////////////////////////////////////////
+
+  /**
+   * The class holding the current state for a validation method being executed.
+   */
+  protected static class State {
+    // CHECKSTYLE:OFF
+    public DiagnosticChain chain = null;
+    public EObject currentObject = null;
+    public Method currentMethod = null;
+    public CheckMode checkMode = null;
+    public CheckType currentCheckType = null;
+    public boolean hasErrors = false;
+    public Map<Object, Object> context;
+    // CHECKSTYLE:ON
+  }
+
+  @Override
+  public DiagnosticChain getChain() {
+    return threadLocalState.get().chain;
+  }
+
+  @Override
+  public CheckType getCurrentCheckType() {
+    return threadLocalState.get().currentCheckType;
+  }
+
+  @Override
+  public void setHasErrors() {
+    threadLocalState.get().hasErrors = true;
+  }
+
+  protected EObject getCurrentObject() {
+    return threadLocalState.get().currentObject;
+  }
+
+  protected Method getCurrentMethod() {
+    return threadLocalState.get().currentMethod;
+  }
+
+  protected CheckMode getCheckMode() {
+    return threadLocalState.get().checkMode;
+  }
+
+  protected Map<Object, Object> getContext() {
+    return threadLocalState.get().context;
+  }
+
+}

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/DefaultCheckImpl.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/DefaultCheckImpl.java
@@ -39,9 +39,8 @@ import com.google.inject.Inject;
  * The class DefaultCheckImpl serves as the default parent implementation for generated
  * issue classes.
  */
-// CHECKSTYLE:OFF
-public abstract class DefaultCheckImpl extends AbstractCheckImpl {
-  // CHECKSTYLE:ON
+@SuppressWarnings({"checkstyle:AbstractClassName"})
+public abstract class DefaultCheckImpl extends AbstractStatefulCheckImpl {
 
   private static final int VISITED_CLASSES_INIT_CAPACITY = 4;
 

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/ValidationMessageAcceptorMixin.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/ValidationMessageAcceptorMixin.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Evolution AG - initial API and implementation
+ *******************************************************************************/
+
+package com.avaloq.tools.ddk.check.runtime.issue;
+
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.common.util.DiagnosticChain;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.xtext.diagnostics.Severity;
+import org.eclipse.xtext.validation.CheckType;
+import org.eclipse.xtext.validation.FeatureBasedDiagnostic;
+import org.eclipse.xtext.validation.ValidationMessageAcceptor;
+
+
+/**
+ * A validation message acceptor implemented in terms of a small set of operations
+ * to access current validation state.
+ */
+public interface ValidationMessageAcceptorMixin extends ValidationMessageAcceptor {
+
+  /**
+   * Gets the current diagnostics accumulator.
+   *
+   * @return the accumulator, never {@code null}
+   */
+  DiagnosticChain getChain();
+
+  /**
+   * Gets the current check type.
+   *
+   * @return the type
+   */
+  CheckType getCurrentCheckType();
+
+  /**
+   * Flags the current context object as having had errors.
+   */
+  void setHasErrors();
+
+  // ////////////////////////////////////////////////
+  // Copied and adapted from AbstractDeclarativeValidator below
+  // ////////////////////////////////////////////////
+
+  // ////////////////////////////////////////////////////////
+  // Implementation of the Validation message acceptor below
+  // ////////////////////////////////////////////////////////
+
+  @Override
+  default void acceptError(final String message, final EObject object, final EStructuralFeature feature, final int index, final String code, final String... issueData) {
+    setHasErrors();
+    getChain().add(createDiagnostic(Severity.ERROR, message, object, feature, index, code, issueData));
+  }
+
+  @Override
+  default void acceptWarning(final String message, final EObject object, final EStructuralFeature feature, final int index, final String code, final String... issueData) {
+    getChain().add(createDiagnostic(Severity.WARNING, message, object, feature, index, code, issueData));
+  }
+
+  @Override
+  default void acceptInfo(final String message, final EObject object, final EStructuralFeature feature, final int index, final String code, final String... issueData) {
+    getChain().add(createDiagnostic(Severity.INFO, message, object, feature, index, code, issueData));
+  }
+
+  @Override
+  default void acceptError(final String message, final EObject object, final int offset, final int length, final String code, final String... issueData) {
+    setHasErrors();
+    getChain().add(createDiagnostic(Severity.ERROR, message, object, offset, length, code, issueData));
+  }
+
+  @Override
+  default void acceptWarning(final String message, final EObject object, final int offset, final int length, final String code, final String... issueData) {
+    getChain().add(createDiagnostic(Severity.WARNING, message, object, offset, length, code, issueData));
+  }
+
+  @Override
+  default void acceptInfo(final String message, final EObject object, final int offset, final int length, final String code, final String... issueData) {
+    getChain().add(createDiagnostic(Severity.INFO, message, object, offset, length, code, issueData));
+  }
+
+  /**
+   * Creates a diagnostic for given parameters.
+   *
+   * @param severity
+   *          the issue severity
+   * @param message
+   *          the issue message
+   * @param object
+   *          the context object
+   * @param feature
+   *          the structural feature on which to create a marker
+   * @param index
+   *          the index at which to create a marker
+   * @param code
+   *          the issue code
+   * @param issueData
+   *          the issue data
+   * @return the diagnostic
+   */
+  default Diagnostic createDiagnostic(final Severity severity, final String message, final EObject object, final EStructuralFeature feature, final int index, final String code, final String... issueData) {
+    int diagnosticSeverity = toDiagnosticSeverity(severity);
+    return new FeatureBasedDiagnostic(diagnosticSeverity, message, object, feature, index, getCurrentCheckType(), code, issueData);
+  }
+
+  /**
+   * Creates a diagnostic for given parameters.
+   *
+   * @param severity
+   *          the issue severity
+   * @param message
+   *          the issue message
+   * @param object
+   *          the context object
+   * @param offset
+   *          the offset of the marker
+   * @param length
+   *          the length of tokens to be marked by the issue
+   * @param code
+   *          the issue code
+   * @param issueData
+   *          the issue data
+   * @return the diagnostic
+   */
+  default Diagnostic createDiagnostic(final Severity severity, final String message, final EObject object, final int offset, final int length, final String code, final String... issueData) {
+    int diagnosticSeverity = toDiagnosticSeverity(severity);
+    return new CheckRangeBasedDiagnostic(diagnosticSeverity, message, object, offset, length, getCurrentCheckType(), code, issueData);
+  }
+
+  /**
+   * Gets a numeric value mapped to a given {@link Severity}. Severities are mapped to
+   * <ul>
+   * <li>{@link Diagnostic#ERROR}
+   * <li>{@link Diagnostic#WARNING}
+   * <li>{@link Diagnostic#INFO}
+   * </ul>
+   *
+   * @param severity
+   *          the issue severity
+   * @return the numeric value representing a severity
+   */
+  static int toDiagnosticSeverity(final Severity severity) {
+    return switch (severity) {
+    case ERROR -> Diagnostic.ERROR;
+    case WARNING -> Diagnostic.WARNING;
+    case INFO -> Diagnostic.INFO;
+    default -> throw new IllegalArgumentException("Unknown severity " + severity); //$NON-NLS-1$
+    };
+  }
+
+}


### PR DESCRIPTION
That is, create a variant of DispatchingCheckImpl as a slightly different check catalog implementation base class, one that assumes that the necessary validation state is passed around across 'validate' and context method calls as a reference to a DiagnosticCollector. Assume that instead of using a thread-local variable to track State, as is done by DispatchingCheckImpl.

To support implementation of the new CheckImpl base class do further refactoring of the existing ones.

A notable difference of AbstractDispatchingCheckImpl is that it no longer implements the ValidationMessageAcceptor interface, and it is instead the DiagnosticCollector that does.