### PR TITLE
feat: pass DiagnosticCollector to generated methods

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckCompiler.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckCompiler.java
@@ -272,7 +272,7 @@ public class CheckCompiler extends XbaseCompiler {
 
     // acceptor
     b.append("// Issue diagnostic").newLine();
-    b.append(generatorNaming.catalogInstanceName(expr)).append(".accept(").append("getMessageAcceptor()");
+    b.append(generatorNaming.catalogInstanceName(expr)).append(".accept(").append("diagnosticCollector");
 
     // context object
     b.append(", //").increaseIndentation().newLine();

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorNaming.xtend
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/generator/CheckGeneratorNaming.xtend
@@ -146,7 +146,7 @@ class CheckGeneratorNaming {
 
   /* Gets the name of the default validator class. */
   def String defaultValidatorClassName() {
-    "DispatchingCheckImpl"
+    "AbstractDispatchingCheckImpl"
   }
 
   /* Gets the fully qualified name of the default validator class. */


### PR DESCRIPTION
That is, instead of using getMessageAcceptor() to access the object for recording diagnostics, pass a DiagnosticCollector object as an argument to generated context methods.

Additionally, have the generated calls to 'validate' also specify the CheckType of the performed check, so that the type can also be included in any constructed diagnostics. This is something that is missing from DispatchingCheckImpl based check execution, which always leaves CheckType as null.