### PR TITLE
fix: Resolve ProxyCompositeNode before use by NodeModelUtils.

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
@@ -382,6 +382,10 @@ class ProxyCompositeNode implements ICompositeNode, BidiTreeIterable<INode>, Ada
     }
   }
 
+  @Override
+  public NodeModelUtils.Implementation utils() {
+    return delegate().utils();
+  }
 }
 
 /* Copyright (c) Avaloq Licence AG */


### PR DESCRIPTION
ProxyCompositeNode now loads delegate for calls to INode.utils() to preempt the utilities needing the node model.