### PR TITLE
Remove the check.runtime.ui and checkcfg.ui from the runtime feature

### DIFF
--- a/com.avaloq.tools.ddk.runtime.feature/feature.xml
+++ b/com.avaloq.tools.ddk.runtime.feature/feature.xml
@@ -59,13 +59,6 @@
          unpack="false"/>
 
    <plugin
-         id="com.avaloq.tools.ddk.check.runtime.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="com.avaloq.tools.ddk.checkcfg.core"
          download-size="0"
          install-size="0"
@@ -74,13 +67,6 @@
 
    <plugin
          id="com.avaloq.tools.ddk.checkcfg.ide"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="com.avaloq.tools.ddk.checkcfg.ui"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
as they are not needed unless UI components are used.