### PR TITLE
fix StackOverflowError while replacing the ProxyCompositeNode delegate

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
@@ -19,11 +19,13 @@ import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.Notifier;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EContentsEList.FeatureIterator;
 import org.eclipse.emf.ecore.util.EContentsEList.Filterable;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.nodemodel.BidiIterable;
 import org.eclipse.xtext.nodemodel.BidiTreeIterable;
 import org.eclipse.xtext.nodemodel.BidiTreeIterator;
@@ -43,7 +45,6 @@ import org.eclipse.xtext.util.ITextRegion;
 import org.eclipse.xtext.util.ITextRegionWithLineInformation;
 
 import com.avaloq.tools.ddk.annotations.SuppressFBWarnings;
-import com.avaloq.tools.ddk.xtext.util.EObjectUtil;
 import com.google.common.collect.Lists;
 
 
@@ -172,7 +173,8 @@ class ProxyCompositeNode implements ICompositeNode, BidiTreeIterable<INode>, Ada
         }
         ICompositeNode compositeNode = NodeModelUtils.getNode(semanticElement);
         if (!(compositeNode instanceof CompositeNode)) {
-          throw new IllegalStateException("No composite node found for " + EObjectUtil.getLocationString(semanticElement) + ". Found " + compositeNode); //$NON-NLS-1$ //$NON-NLS-2$
+          URI uri = EcoreUtil.getURI(semanticElement);
+          throw new IllegalStateException("No composite node found for " + uri.toString() + " (" + semanticElement + "). Found " + compositeNode); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         }
         delegate = (CompositeNode) compositeNode;
       }


### PR DESCRIPTION
fix StackOverflowError such as:
	at com.avaloq.tools.ddk.xtext.resource.persistence.DirectLinkingResourceStorageLoadable.loadIntoResource(DirectLinkingResourceStorageLoadable.java:104)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.delegate(ProxyCompositeNode.java:169)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.utils(ProxyCompositeNode.java:397)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at org.eclipse.xtext.nodemodel.util.NodeModelUtils.findActualNodeFor(NodeModelUtils.java:160)
~[org.eclipse.xtext_2.37.0.v20241119-0857.jar:?]
	at com.avaloq.tools.ddk.xtext.util.EObjectUtil.getLocationString(EObjectUtil.java:215)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.delegate(ProxyCompositeNode.java:175)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.utils(ProxyCompositeNode.java:397)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at org.eclipse.xtext.nodemodel.util.NodeModelUtils.findActualNodeFor(NodeModelUtils.java:160)
~[org.eclipse.xtext_2.37.0.v20241119-0857.jar:?]
	at com.avaloq.tools.ddk.xtext.util.EObjectUtil.getLocationString(EObjectUtil.java:215)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.delegate(ProxyCompositeNode.java:175)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.utils(ProxyCompositeNode.java:397)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at org.eclipse.xtext.nodemodel.util.NodeModelUtils.findActualNodeFor(NodeModelUtils.java:160)
~[org.eclipse.xtext_2.37.0.v20241119-0857.jar:?]
	at com.avaloq.tools.ddk.xtext.util.EObjectUtil.getLocationString(EObjectUtil.java:215)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.delegate(ProxyCompositeNode.java:175)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.utils(ProxyCompositeNode.java:397)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250115-2010.jar:?] ...