### PR TITLE
fix StackOverflowError while replacing the ProxyCompositeNode delegate

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
@@ -22,6 +22,7 @@ import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EContentsEList.FeatureIterator;
 import org.eclipse.emf.ecore.util.EContentsEList.Filterable;
@@ -174,12 +175,36 @@ class ProxyCompositeNode implements ICompositeNode, BidiTreeIterable<INode>, Ada
         ICompositeNode compositeNode = NodeModelUtils.getNode(semanticElement);
         if (!(compositeNode instanceof CompositeNode)) {
           URI uri = EcoreUtil.getURI(semanticElement);
-          throw new IllegalStateException("No composite node found for " + uri.toString() + " (" + semanticElement + "). Found " + compositeNode); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+          throw new IllegalStateException("No composite node found for " + uri.toString() + " (" + toString(semanticElement) + "). Found " + compositeNode); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         }
         delegate = (CompositeNode) compositeNode;
       }
     }
     return delegate;
+  }
+
+  /**
+   * A safe to string method that does not rely on possible custom implementations based on {@link org.eclipse.emf.ecore.impl.BasicEObjectImpl#toString()}.
+   * <p>
+   * Some custom implementations use the node model to give extra information,
+   * and this does not work when the node model is being replaced.
+   * </p>
+   *
+   * @param eObject
+   *          the EObject
+   * @return the string
+   */
+  private String toString(final EObject eObject) {
+    StringBuilder result = new StringBuilder(eObject.getClass().getName());
+    result.append('@');
+    result.append(Integer.toHexString(hashCode()));
+
+    if (eObject.eIsProxy() && eObject instanceof InternalEObject internal) {
+      result.append(" (eProxyURI: "); //$NON-NLS-1$
+      result.append(internal.eProxyURI());
+      result.append(')');
+    }
+    return result.toString();
   }
 
   @Override


### PR DESCRIPTION
fix StackOverflowError such as:

	at org.eclipse.xtext.nodemodel.util.NodeModelUtils.findNodesForFeature(NodeModelUtils.java:129)
~[org.eclipse.xtext_2.37.0.v20241119-0857.jar:?]
	at com.avaloq.tools.ddk.xtext.util.ParseTreeUtil.getParsedStringUnchecked(ParseTreeUtil.java:145)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250117-2009.jar:?]
	at com.avaloq.tools.ddk.xtext.util.ParseTreeUtil.getParsedString(ParseTreeUtil.java:94)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250117-2009.jar:?]
	at com.avaloq.tools.ddk.xtext.util.ParseTreeUtil.getParsedString(ParseTreeUtil.java:75)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250117-2009.jar:?]
	at com.avaloq.tools.dsl.avqscript.avqscript.impl.FeatureCallImplCustom.toString(FeatureCallImplCustom.java:38)
~[com.avaloq.tools.dsl.avqscript.core_19.5.0.v20250119-1823-J170-NIGHTLY.jar:?]
	at com.avaloq.tools.dsl.avqscript.avqscript.impl.ChainedFeatureCallImplCustom.toString(ChainedFeatureCallImplCustom.java:48)
~[com.avaloq.tools.dsl.avqscript.core_19.5.0.v20250119-1823-J170-NIGHTLY.jar:?]
	at java.lang.String.valueOf(String.java:4220) ~[?:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.delegate(ProxyCompositeNode.java:177)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250117-2009.jar:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.utils(ProxyCompositeNode.java:399)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250117-2009.jar:?]
	at org.eclipse.xtext.nodemodel.util.NodeModelUtils.findActualNodeFor(NodeModelUtils.java:160)
~[org.eclipse.xtext_2.37.0.v20241119-0857.jar:?]
	at org.eclipse.xtext.nodemodel.util.NodeModelUtils.findNodesForFeature(NodeModelUtils.java:129)
~[org.eclipse.xtext_2.37.0.v20241119-0857.jar:?]
	at com.avaloq.tools.ddk.xtext.util.ParseTreeUtil.getParsedStringUnchecked(ParseTreeUtil.java:145)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250117-2009.jar:?]
	at com.avaloq.tools.ddk.xtext.util.ParseTreeUtil.getParsedString(ParseTreeUtil.java:94)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250117-2009.jar:?]
	at com.avaloq.tools.ddk.xtext.util.ParseTreeUtil.getParsedString(ParseTreeUtil.java:75)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250117-2009.jar:?]
	at com.avaloq.tools.dsl.avqscript.avqscript.impl.FeatureCallImplCustom.toString(FeatureCallImplCustom.java:38)
~[com.avaloq.tools.dsl.avqscript.core_19.5.0.v20250119-1823-J170-NIGHTLY.jar:?]
	at com.avaloq.tools.dsl.avqscript.avqscript.impl.ChainedFeatureCallImplCustom.toString(ChainedFeatureCallImplCustom.java:48)
~[com.avaloq.tools.dsl.avqscript.core_19.5.0.v20250119-1823-J170-NIGHTLY.jar:?]
	at java.lang.String.valueOf(String.java:4220) ~[?:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.delegate(ProxyCompositeNode.java:177)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250117-2009.jar:?]
	at com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode.utils(ProxyCompositeNode.java:399)
~[com.avaloq.tools.ddk.xtext_14.5.0.v20250117-2009.jar:?]
	...