### PR TITLE
perf: lazy initialize the PolymorphicDispatcher

### DIFF
--- a/com.avaloq.tools.ddk.typesystem/src/com/avaloq/tools/ddk/typesystem/AbstractTypeLabelProvider.java
+++ b/com.avaloq.tools.ddk.typesystem/src/com/avaloq/tools/ddk/typesystem/AbstractTypeLabelProvider.java
@@ -24,12 +24,19 @@ import com.avaloq.tools.ddk.typesystem.typemodel.IType;
  */
 public abstract class AbstractTypeLabelProvider implements ITypeLabelProvider {
 
-  private final PolymorphicDispatcher<String> textDispatcher = new PolymorphicDispatcher<String>("text", 1, 1, Collections.singletonList(this), new ErrorHandler<String>() { //$NON-NLS-1$
-    @Override
-    public String handle(final Object[] params, final Throwable e) {
-      return handleTextError(params, e);
+  private PolymorphicDispatcher<String> textDispatcher;
+
+  private PolymorphicDispatcher<String> getPolymorphicDispatcher() {
+    if (textDispatcher == null) {
+      textDispatcher = new PolymorphicDispatcher<String>("text", 1, 1, Collections.singletonList(this), new ErrorHandler<String>() { //$NON-NLS-1$
+        @Override
+        public String handle(final Object[] params, final Throwable e) {
+          return handleTextError(params, e);
+        }
+      });
     }
-  });
+    return textDispatcher;
+  }
 
   /**
    * Handles error exceptions from polymorphic text dispatcher.
@@ -49,7 +56,7 @@ public abstract class AbstractTypeLabelProvider implements ITypeLabelProvider {
 
   @Override
   public String getText(final IType type) {
-    return textDispatcher.invoke(type);
+    return getPolymorphicDispatcher().invoke(type);
   }
 
   /**


### PR DESCRIPTION
as otherwise it is initialized eagerly during resource creation, even if no label is ever asked from the label provider.

Creating the dispatcher is an expensive operation because it will scan all the methods of the class and create an ArrayList with all the candidates.