### PR TITLE
build: upgrade to Xtext 2.38

### DIFF
--- a/com.avaloq.tools.ddk.test.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.test.ui/META-INF/MANIFEST.MF
@@ -10,7 +10,6 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: com.avaloq.tools.ddk.test.core, 
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
- org.eclipse.draw2d,
  org.eclipse.swt,
  org.eclipse.swtbot.eclipse.core,
  org.eclipse.swtbot.eclipse.finder;visibility:=reexport,

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/DragAndDropUtil.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/DragAndDropUtil.java
@@ -126,24 +126,6 @@ public class DragAndDropUtil {
   }
 
   /**
-   * Performs a drag and drop operation from this widget to the given target
-   * at the given location from target origin. The drag start location will be
-   * chosen depending on this widget's default implementation.
-   *
-   * @param source
-   *          the source widget to drag
-   * @param target
-   *          To perform the drop on
-   * @param locationOnTarget
-   *          The target locations, from target origin, where the DND shall
-   *          finish.
-   * @see #dragAndDrop(Point)
-   */
-  public void dragAndDrop(final AbstractSWTBot<? extends Widget> source, final AbstractSWTBot<? extends Widget> target, final org.eclipse.draw2d.geometry.Point locationOnTarget) {
-    dragAndDrop(source, target, new Point(locationOnTarget.x, locationOnTarget.y));
-  }
-
-  /**
    * Performs a DND operation to an arbitrary location. The drag start
    * location will be chosen depending on this widget's default
    * implementation.

--- a/com.avaloq.tools.ddk.xtext.format.ui.test/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.format.ui.test/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Export-Package: com.avaloq.tools.ddk.xtext.format.ui;x-internal=true
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,
  org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.junit,
  org.eclipse.xtext.xbase.testing,
  org.eclipse.xtext.ui.testing,
  org.eclipse.xtext.xbase.ui.testing

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/ui/quickfix/AbstractQuickFixTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/ui/quickfix/AbstractQuickFixTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.test.ui.quickfix;
 
-import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -23,6 +22,7 @@ import org.eclipse.xtext.ui.editor.quickfix.IssueResolution;
 import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionProvider;
 import org.eclipse.xtext.validation.Issue;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.text.IsEqualCompressingWhiteSpace;
 import org.junit.Assert;
 
 import com.avaloq.tools.ddk.check.runtime.quickfix.ICoreModificationContext;
@@ -386,7 +386,7 @@ public abstract class AbstractQuickFixTest extends AbstractXtextEditorTest {
     String expected = expectedContent.replaceAll(CR_LF, LF);
     String actual = actualContent.replaceAll(CR_LF, LF);
     if (ignoreFormatting) {
-      MatcherAssert.assertThat(message, actual, equalToIgnoringWhiteSpace(expected));
+      MatcherAssert.assertThat(message, actual, IsEqualCompressingWhiteSpace.equalToCompressingWhiteSpace(expected));
     } else {
       assertEquals(message, expected, actual);
     }

--- a/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/AllTests.java
+++ b/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/AllTests.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext;
 
-import org.eclipse.xtext.ui.testing.util.TargetPlatformUtil;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -55,9 +53,4 @@ import com.avaloq.tools.ddk.xtext.ui.test.XtextUiTestSuite;
 })
 // @Format-On
 public class AllTests {
-  @BeforeClass
-  public static void setUp() throws Exception {
-    // Make sure PDE can deal with plugin projects we may create in our tests.
-    TargetPlatformUtil.setTargetPlatform(AllTests.class);
-  }
 }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/DefaultInferredElementFragmentProvider.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/DefaultInferredElementFragmentProvider.java
@@ -11,6 +11,7 @@
 
 package com.avaloq.tools.ddk.xtext.modelinference;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 
@@ -20,7 +21,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.naming.QualifiedName;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Maps;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
@@ -97,7 +97,7 @@ public class DefaultInferredElementFragmentProvider implements IInferredElementF
   protected HashCode computeHash(final EClass eClass, final QualifiedName name) {
     byte[] eClassUriBytes = eClassToUriBytesMap.get(eClass);
     if (eClassUriBytes == null) {
-      eClassUriBytes = EcoreUtil.getURI(eClass).toString().getBytes(Charsets.UTF_8);
+      eClassUriBytes = EcoreUtil.getURI(eClass).toString().getBytes(StandardCharsets.UTF_8);
       eClassToUriBytesMap.put(eClass, eClassUriBytes);
     }
 

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractFingerprintComputer.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractFingerprintComputer.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.resource;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
@@ -28,7 +29,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.xtext.linking.lazy.LazyLinkingResource;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
@@ -194,7 +194,7 @@ public abstract class AbstractFingerprintComputer implements IFingerprintCompute
   protected final CharSequence encodeFingerprint(final ExportItem export) {
     try {
       final MessageDigest md5 = MessageDigest.getInstance("MD5"); //$NON-NLS-1$
-      final byte[] digest = md5.digest(export.getKeyAsString().getBytes(Charsets.UTF_8));
+      final byte[] digest = md5.digest(export.getKeyAsString().getBytes(StandardCharsets.UTF_8));
       /* Now encode it as a string. */
       final StringBuilder result = new StringBuilder();
       for (byte element : digest) {

--- a/ddk-target/ddk-antlr.target
+++ b/ddk-target/ddk-antlr.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="DDK Target - ANTLR" sequenceNumber="4">
+<target name="DDK Target - ANTLR" sequenceNumber="5">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <repository location="https://download.itemis.com/updates/releases/2.1.1/" />
@@ -9,12 +9,12 @@
     <location type="Target" uri="file:${project_loc:/ddk-target}/ddk.target" />
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <repository location="http://download.eclipse.org/technology/swtbot/releases/4.0.0/" />
+      <repository location="https://download.eclipse.org/eclipse/updates/4.34/" />
       <repository location="https://download.eclipse.org/releases/2022-12/202212071000/" />
       <repository location="https://download.eclipse.org/modeling/m2t/xpand/updates/releases/R201605260315/" />
-      <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.20.0/" />
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.37.0/" />
+      <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.21.0/" />
+      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.38.0/" />
       <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.23.1/" />
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository" />
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository" />
     </location>
   </locations>

--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -1,56 +1,57 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="DDK Target" sequenceNumber="22">
+<target name="DDK Target" sequenceNumber="23">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.swtbot.ide.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/technology/swtbot/releases/4.1.0/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-  <unit id="org.eclipse.pde.source.feature.group" version="3.14.1400.v20221123-1800"/>
-  <unit id="org.eclipse.jdt.source.feature.group" version="3.18.1400.v20221123-1800"/>
-  <unit id="org.eclipse.platform.feature.group" version="4.26.0.v20221123-2302"/>
-  <unit id="org.eclipse.platform.source.feature.group" version="4.26.0.v20221123-2302"/>
-  <unit id="org.eclipse.emf.codegen.ecore.ui.feature.group" version="2.32.0.v20220925-1245"/>
-  <repository location="https://download.eclipse.org/releases/2022-12/202212071000/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-  <unit id="org.eclipse.xpand.sdk.feature.group" version="0.0.0"/>
-  <repository location="https://download.eclipse.org/modeling/m2t/xpand/updates/releases/R201605260315/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-  <unit id="org.eclipse.emf.mwe2.runtime.sdk.feature.group" version="0.0.0"/>
-  <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
-  <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.20.0/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-  <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
-  <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-  <unit id="org.eclipse.xtext.xtext.generator" version="0.0.0"/>
-  <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.37.0/"/>
-</location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+  <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
+  <unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
+  <unit id="org.eclipse.swtbot.ide.feature.group" version="0.0.0"/>
+  <unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="0.0.0"/>
+  <repository location="http://download.eclipse.org/technology/swtbot/releases/4.2.1/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <unit id="org.eclipse.pde.source.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.platform.source.feature.group" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/eclipse/updates/4.34/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+  <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+  <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.39.0/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <unit id="org.eclipse.uml2.sdk.feature.group" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/releases/2022-12/202212071000/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <unit id="org.eclipse.xpand.sdk.feature.group" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/modeling/m2t/xpand/updates/releases/R201605260315/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <unit id="org.eclipse.emf.mwe2.runtime.sdk.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.21.0/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.xtext.generator" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.38.0/"/>
+  </location>
   <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
     <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.23.1/"/>
     <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
-  </location>
-  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-    <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository"/>
-    <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
-    <unit id="org.hamcrest.core.source" version="1.3.0.v20180420-1519"/>
-    <unit id="org.hamcrest.library" version="1.3.0.v20180524-2246"/>
-    <unit id="org.hamcrest.library.source" version="1.3.0.v20180524-2246"/>
-    <unit id="org.mockito" version="2.23.0.v20200310-1642"/>
-    <unit id="org.mockito.source" version="2.23.0.v20200310-1642"/>
-    <unit id="org.slf4j.ext" version="1.7.30.v20200204-2150"/>
   </location>
   <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
     <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository"/>
     <unit id="org.apache.logging.log4j" version="2.17.1.v20220106-2156"/>
     <unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
     <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
+    <unit id="org.slf4j.ext" version="1.7.30.v20200204-2150"/>
+    <unit id="org.mockito" version="2.23.0.v20200310-1642"/>
+    <unit id="org.hamcrest" version="2.2.0.v20210711-0821"/>
+    <unit id="org.junit" version="4.13.2.v20211018-1956"/>
   </location>
 </locations>
 </target>


### PR DESCRIPTION
- a dependency on draw2d can be removed by removing an unused method
that
is just a wrapper over another method in the same class.

- For the UI tests to run:
  - mockito, hamcrest and junit needs to be updated.
  - the dependency of com.avaloq.tools.ddk.xtext.format.ui.test on
com.avaloq.tools.ddk.xtext.format.ui.test

- fix deprecations

- SWTBot has been updated as well while modifying the target files, even though it is not required for the upgrade.