### PR TITLE
feat: introduce timeout and retry parameter for BM executor shutdown

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/util/ParseTreeUtil.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/util/ParseTreeUtil.java
@@ -138,8 +138,11 @@ public final class ParseTreeUtil {
   public static void ensureNodeModelLoaded(final Resource resource) {
     if (resource instanceof LazyLinkingResource2 lazyLinkinResource && lazyLinkinResource.isLoadedFromStorage()) {
       EObject root = resource.getContents().get(0);
-      if (root != null && NodeModelUtils.getNode(root) instanceof ICompositeNode composite) {
-        composite.getText(); // side-effect on removing com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode
+      if (root != null) {
+        ICompositeNode rootNode = NodeModelUtils.getNode(root);
+        if (rootNode != null) {
+          rootNode.getText(); // side-effect on removing com.avaloq.tools.ddk.xtext.resource.persistence.ProxyCompositeNode
+        }
       }
     }
   }


### PR DESCRIPTION
The awaitBinaryStorageExecutorTermination() in
MonitoredClusteringBuilderState is extended with parameters that allow the timeout for the shutdown and the number of attempts to make to be specified.

(also implement 2 small cleanups of code causing a compile error depending on settings and a FB warning suppression that is no longer necessary)