### PR TITLE
fix: another thread safety issue in MapCache

### DIFF
--- a/com.avaloq.tools.ddk/src/com/avaloq/tools/ddk/caching/MapCache.java
+++ b/com.avaloq.tools.ddk/src/com/avaloq/tools/ddk/caching/MapCache.java
@@ -107,11 +107,7 @@ public class MapCache<K, V> implements ICache<K, V>, Map<K, V> {
 
   @Override
   public V putIfAbsent(final K key, final V value) {
-    V oldValue = get(key);
-    if (oldValue == null) {
-      oldValue = put(key, value);
-    }
-    return oldValue;
+    return backend.asMap().putIfAbsent(key, value);
   }
 
   @Override


### PR DESCRIPTION
In 2025d7584f1ee2a9e5aff796d606806cd9a07273, we improved the thread safety of the MapCache class by implementing all methods of the Map interface in the class itself, instead of inheriting the (non-thread-safe) default implementations of the interface. On closer inspection, it turns out that the putIfAbsent method was already implemented, but in a non-thread-safe way.