### PR TITLE
chore: upgrade Xtext to 2.39

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
@@ -13,6 +13,7 @@ package com.avaloq.tools.ddk.xtext.linking;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -121,6 +122,11 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
   @Override
   public String getSourceText() throws IOException {
     return SerializationUtil.getCompleteContent(this);
+  }
+
+  @Override
+  protected LinkedHashSet<Triple<EObject, EReference, INode>> getResolvingSet(final boolean initial) {
+    return resolving;
   }
 
   /**

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -55,7 +55,7 @@
     <pmd.plugin.version>3.26.0</pmd.plugin.version>
     <pmd.version>7.13.0</pmd.version>
     <tycho.version>4.0.12</tycho.version>
-    <xtend.version>2.38.0</xtend.version>
+    <xtend.version>2.39.0</xtend.version>
   </properties>
 
   <modules>

--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -37,7 +37,7 @@
     <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
     <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
     <unit id="org.eclipse.xtext.xtext.generator" version="0.0.0"/>
-    <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.38.0/"/>
+    <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.39.0/"/>
   </location>
   <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
     <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.23.1/"/>


### PR DESCRIPTION
Take advantage of a new feature in Xtext, see
https://github.com/eclipse-xtext/xtext/pull/3329