### PR TITLE
chore: upgrade Xtext to 2.40

### DIFF
--- a/com.avaloq.tools.ddk.check.test.runtime/src-gen/com/avaloq/tools/ddk/check/validation/ExecutionEnvironmentCheckCatalog.java
+++ b/com.avaloq.tools.ddk.check.test.runtime/src-gen/com/avaloq/tools/ddk/check/validation/ExecutionEnvironmentCheckCatalog.java
@@ -17,7 +17,7 @@ public class ExecutionEnvironmentCheckCatalog extends AbstractIssue {
   @Inject
   private ICheckConfigurationStoreService checkConfigurationStoreService;
 
-  private static final ImmutableMap<String, String> issueCodeToLabelMap = ImmutableMap.<String, String>builder()
+  private static final ImmutableMap<String, String> issueCodeToLabelMap = ImmutableMap.<String, String>builderWithExpectedSize(2)
       .put(ExecutionEnvironmentIssueCodes.FRANZNAME, "Greeting name length")
       .put(ExecutionEnvironmentIssueCodes.NAMELENGTH, "Greeting name length")
       .build()

--- a/com.avaloq.tools.ddk.check.test.runtime/src-gen/com/avaloq/tools/ddk/check/validation/LibraryChecksCheckCatalog.java
+++ b/com.avaloq.tools.ddk.check.test.runtime/src-gen/com/avaloq/tools/ddk/check/validation/LibraryChecksCheckCatalog.java
@@ -18,7 +18,7 @@ public class LibraryChecksCheckCatalog extends AbstractIssue {
   @Inject
   private ICheckConfigurationStoreService checkConfigurationStoreService;
 
-  private static final ImmutableMap<String, String> issueCodeToLabelMap = ImmutableMap.<String, String>builder()
+  private static final ImmutableMap<String, String> issueCodeToLabelMap = ImmutableMap.<String, String>builderWithExpectedSize(4)
       .put(LibraryChecksIssueCodes.CACHE_DOESNT_WORK, "Cache doesn't work")
       .put(LibraryChecksIssueCodes.CACHE_INJECTION_FAILED, "Cache injection failed")
       .put(LibraryChecksIssueCodes.CHECK_CATALOG_IS_ACTIVE, "Check catalog is active")

--- a/com.avaloq.tools.ddk.sample.helloworld/dsl-gen/com/avaloq/tools/ddk/sample/helloworld/validation/ExecutionEnvironmentCheckCatalog.java
+++ b/com.avaloq.tools.ddk.sample.helloworld/dsl-gen/com/avaloq/tools/ddk/sample/helloworld/validation/ExecutionEnvironmentCheckCatalog.java
@@ -17,7 +17,7 @@ public class ExecutionEnvironmentCheckCatalog extends AbstractIssue {
   @Inject
   private ICheckConfigurationStoreService checkConfigurationStoreService;
 
-  private static final ImmutableMap<String, String> issueCodeToLabelMap = ImmutableMap.<String, String>builder()
+  private static final ImmutableMap<String, String> issueCodeToLabelMap = ImmutableMap.<String, String>builderWithExpectedSize(2)
       .put(ExecutionEnvironmentIssueCodes.FRANZNAME, "Greeting name length")
       .put(ExecutionEnvironmentIssueCodes.NAMELENGTH, "Greeting name length")
       .build()

--- a/com.avaloq.tools.ddk.sample.helloworld/dsl-gen/com/avaloq/tools/ddk/sample/helloworld/validation/LibraryChecksCheckCatalog.java
+++ b/com.avaloq.tools.ddk.sample.helloworld/dsl-gen/com/avaloq/tools/ddk/sample/helloworld/validation/LibraryChecksCheckCatalog.java
@@ -18,7 +18,7 @@ public class LibraryChecksCheckCatalog extends AbstractIssue {
   @Inject
   private ICheckConfigurationStoreService checkConfigurationStoreService;
 
-  private static final ImmutableMap<String, String> issueCodeToLabelMap = ImmutableMap.<String, String>builder()
+  private static final ImmutableMap<String, String> issueCodeToLabelMap = ImmutableMap.<String, String>builderWithExpectedSize(4)
       .put(LibraryChecksIssueCodes.CACHE_DOESNT_WORK, "Cache doesn't work")
       .put(LibraryChecksIssueCodes.CACHE_INJECTION_FAILED, "Cache injection failed")
       .put(LibraryChecksIssueCodes.CHECK_CATALOG_IS_ACTIVE, "Check catalog is active")

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -55,7 +55,7 @@
     <pmd.plugin.version>3.27.0</pmd.plugin.version>
     <pmd.version>7.15.0</pmd.version>
     <tycho.version>5.0.0</tycho.version>
-    <xtend.version>2.39.0</xtend.version>
+    <xtend.version>2.40.0</xtend.version>
   </properties>
 
   <modules>
@@ -228,7 +228,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.xtend</groupId>
+        <groupId>org.eclipse.xtext</groupId>
         <artifactId>xtend-maven-plugin</artifactId>
         <version>${xtend.version}</version>
         <executions>

--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="DDK Target" sequenceNumber="23">
+<target name="DDK Target" sequenceNumber="24">
 <locations>
   <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
   <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -37,7 +37,7 @@
     <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
     <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
     <unit id="org.eclipse.xtext.xtext.generator" version="0.0.0"/>
-    <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.39.0/"/>
+    <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.40.0/"/>
   </location>
   <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
     <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.23.1/"/>


### PR DESCRIPTION
Update the target file to use the new version.
Update parent/pom.xml version and group id.
