### PR TITLE
fix: derive a valid package for shallow export model URIs in ExportGeneratorX

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export.test/resource/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorXTest.export
+++ b/com.avaloq.tools.ddk.xtext.export.test/resource/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorXTest.export
@@ -1,0 +1,14 @@
+import "http://www.avaloq.com/tools/ddk/xtext/export/Export"
+
+interface {
+    InterfaceExpression=unordered;
+    UserData=name;
+}
+
+export InterfaceExpression as ref
+{
+    data ex = this.getExpr().toString();
+}
+export UserData as name
+{
+}

--- a/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorXTest.java
+++ b/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorXTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Group AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.export.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.avaloq.tools.ddk.xtext.export.export.ExportModel;
+import com.avaloq.tools.ddk.xtext.test.export.util.ExportTestUtil;
+import com.avaloq.tools.ddk.xtext.test.jupiter.AbstractXtextTest;
+
+
+/**
+ * Regression tests for URI-based package derivation in {@link ExportGeneratorX}.
+ */
+@SuppressWarnings("nls")
+public class ExportGeneratorXTest extends AbstractXtextTest {
+
+  private final ExportGeneratorX exportGeneratorX = getXtextTestUtil().get(ExportGeneratorX.class);
+
+  @Override
+  protected ExportTestUtil getXtextTestUtil() {
+    return ExportTestUtil.getInstance();
+  }
+
+  @Test
+  public void testShallowProjectUriFallsBackToProjectPackage() {
+    final ExportModel model = (ExportModel) getTestSource().getModel();
+
+    assertEquals("test.naming.ExportGeneratorXTestExportedNamesProvider", exportGeneratorX.getExportedNamesProvider(model));
+    assertEquals("test.resource.ExportGeneratorXTestResourceDescriptionManager", exportGeneratorX.getResourceDescriptionManager(model));
+    assertEquals("test.resource.ExportGeneratorXTestResourceDescriptionStrategy", exportGeneratorX.getResourceDescriptionStrategy(model));
+    assertEquals("test.resource.ExportGeneratorXTestResourceDescriptionConstants", exportGeneratorX.getResourceDescriptionConstants(model));
+    assertEquals("test.resource.ExportGeneratorXTestFingerprintComputer", exportGeneratorX.getFingerprintComputer(model));
+    assertEquals("test.resource.ExportGeneratorXTestFragmentProvider", exportGeneratorX.getFragmentProvider(model));
+  }
+}

--- a/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorXTest.java
+++ b/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorXTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Group AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.export.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
+import org.junit.jupiter.api.Test;
+
+import com.avaloq.tools.ddk.xtext.export.export.ExportFactory;
+import com.avaloq.tools.ddk.xtext.export.export.ExportModel;
+import com.avaloq.tools.ddk.xtext.test.export.util.ExportTestUtil;
+import com.avaloq.tools.ddk.xtext.test.jupiter.AbstractXtextTest;
+
+
+/**
+ * Regression tests for URI-based package derivation in {@link ExportGeneratorX}.
+ */
+@SuppressWarnings("nls")
+public class ExportGeneratorXTest extends AbstractXtextTest {
+
+  private static final String DERIVED_PACKAGE_PROVIDER = "com.avaloq.naming.fooExportedNamesProvider";
+  private static final String PROJECT_FALLBACK_PROVIDER = "MyProject.naming.fooExportedNamesProvider";
+  private static final String DEFAULT_FALLBACK_PROVIDER = "generated.naming.fooExportedNamesProvider";
+
+  private final ExportGeneratorX exportGeneratorX = getXtextTestUtil().get(ExportGeneratorX.class);
+
+  @Override
+  protected ExportTestUtil getXtextTestUtil() {
+    return ExportTestUtil.getInstance();
+  }
+
+  @Override
+  protected String getTestSourceFileName() {
+    return null; // all tests fabricate synthetic resource URIs
+  }
+
+  @Test
+  public void testNestedSourceFolderUrisKeepDerivedPackage() {
+    assertEquals(DERIVED_PACKAGE_PROVIDER, exportedNamesProviderFor("platform:/resource/MyProject/src/com/avaloq/foo.export"));
+    assertEquals(DERIVED_PACKAGE_PROVIDER, exportedNamesProviderFor("platform:/resource/MyProject/src-gen/com/avaloq/foo.export"));
+    assertEquals("main.java.com.avaloq.naming.fooExportedNamesProvider", exportedNamesProviderFor("platform:/resource/MyProject/src/main/java/com/avaloq/foo.export"));
+    assertEquals("com.naming.fooExportedNamesProvider", exportedNamesProviderFor("platform:/resource/MyProject/src/com/foo.export")); // 5 segments: derivation boundary
+  }
+
+  @Test
+  public void testShortUrisFallBackToValidPackage() {
+    assertEquals(PROJECT_FALLBACK_PROVIDER, exportedNamesProviderFor("platform:/resource/MyProject/foo.export"));
+    assertEquals(PROJECT_FALLBACK_PROVIDER, exportedNamesProviderFor("platform:/resource/MyProject/src/foo.export"));
+    assertEquals(DEFAULT_FALLBACK_PROVIDER, exportedNamesProviderFor("platform:/resource/1My-Project/foo.export"));
+    assertEquals(DEFAULT_FALLBACK_PROVIDER, exportedNamesProviderFor("MyProject/foo.export")); // 2 segments: below the project-name fallback
+  }
+
+  @Test
+  public void testSingleSegmentUriFallsBackToDefaultPackage() {
+    assertEquals(DEFAULT_FALLBACK_PROVIDER, exportedNamesProviderFor("foo.export"));
+  }
+
+  private String exportedNamesProviderFor(final String uri) {
+    final Resource resource = new ResourceImpl(URI.createURI(uri));
+    final ExportModel model = ExportFactory.eINSTANCE.createExportModel();
+    resource.getContents().add(model);
+    return exportGeneratorX.getExportedNamesProvider(model);
+  }
+}

--- a/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/test/export/ExportTestSuite.java
+++ b/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/test/export/ExportTestSuite.java
@@ -13,6 +13,7 @@ package com.avaloq.tools.ddk.xtext.test.export;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
+import com.avaloq.tools.ddk.xtext.export.generator.ExportGeneratorXTest;
 import com.avaloq.tools.ddk.xtext.export.exporting.ExportExportingTest;
 import com.avaloq.tools.ddk.xtext.export.formatting.ExportFormattingTest;
 import com.avaloq.tools.ddk.xtext.export.scoping.ExportScopingTest;
@@ -23,6 +24,6 @@ import com.avaloq.tools.ddk.xtext.export.validation.ExportValidationTest;
  * Empty class serving only as holder for JUnit4 annotations.
  */
 @Suite
-@SelectClasses({ExportFormattingTest.class, ExportValidationTest.class, ExportScopingTest.class, ExportExportingTest.class})
+@SelectClasses({ExportFormattingTest.class, ExportValidationTest.class, ExportScopingTest.class, ExportExportingTest.class, ExportGeneratorXTest.class})
 public class ExportTestSuite {
 }

--- a/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/test/export/ExportTestSuite.java
+++ b/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/test/export/ExportTestSuite.java
@@ -13,6 +13,7 @@ package com.avaloq.tools.ddk.xtext.test.export;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
+import com.avaloq.tools.ddk.xtext.export.generator.ExportGeneratorXTest;
 import com.avaloq.tools.ddk.xtext.export.exporting.ExportExportingTest;
 import com.avaloq.tools.ddk.xtext.export.formatting.ExportFormattingTest;
 import com.avaloq.tools.ddk.xtext.export.scoping.ExportScopingTest;
@@ -24,6 +25,6 @@ import com.avaloq.tools.ddk.xtext.export.validation.ExportValidationTest;
  * Empty class serving only as holder for JUnit 5 suite annotations.
  */
 @Suite
-@SelectClasses({ExportFormattingTest.class, ExportValidationTest.class, ExportValidationOkTest.class, ExportScopingTest.class, ExportExportingTest.class})
+@SelectClasses({ExportFormattingTest.class, ExportValidationTest.class, ExportValidationOkTest.class, ExportScopingTest.class, ExportExportingTest.class, ExportGeneratorXTest.class})
 public class ExportTestSuite {
 }

--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorX.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorX.xtend
@@ -32,6 +32,10 @@ import org.eclipse.xtext.Grammar
 
 class ExportGeneratorX {
 
+  static val URI_PROJECT_SEGMENT_INDEX = 1
+  static val URI_PACKAGE_START_INDEX = 3
+  static val DEFAULT_PACKAGE_SEGMENT = "generated"
+
   @Inject
   extension Naming
 
@@ -51,15 +55,13 @@ class ExportGeneratorX {
   }
 
   def String getExportedNamesProvider(ExportModel model) {
-    val uri = model.eResource().getURI();
     // TODO this is a hack; to support modularization we should probably add name to export models (as with scope models)
-    return String.join(".", uri.segmentsList().subList(3, uri.segmentCount() - 1)) + ".naming." + getName(model) + "ExportedNamesProvider";
+    return model.basePackage + ".naming." + getName(model) + "ExportedNamesProvider";
   }
 
   def String getResourceDescriptionManager(ExportModel model) {
-    val uri = model.eResource().getURI();
     // TODO this is a hack; to support modularization we should probably add name to export models (as with scope models)
-    return String.join(".", uri.segmentsList().subList(3, uri.segmentCount() - 1)) + ".resource." + getName(model) + "ResourceDescriptionManager";
+    return model.basePackage + ".resource." + getName(model) + "ResourceDescriptionManager";
   }
 
   def String getResourceDescriptionManager(Grammar grammar) {
@@ -67,33 +69,76 @@ class ExportGeneratorX {
   }
 
   def String getResourceDescriptionStrategy(ExportModel model) {
-    val uri = model.eResource().getURI();
     // TODO this is a hack; to support modularization we should probably add name to export models (as with scope models)
-    return String.join(".", uri.segmentsList().subList(3, uri.segmentCount() - 1)) + ".resource." + getName(model) + "ResourceDescriptionStrategy";
+    return model.basePackage + ".resource." + getName(model) + "ResourceDescriptionStrategy";
   }
 
   def String getResourceDescriptionConstants(ExportModel model) {
-    val uri = model.eResource().getURI();
     // TODO this is a hack; to support modularization we should probably add name to export models (as with scope models)
-    return String.join(".", uri.segmentsList().subList(3, uri.segmentCount() - 1)) + ".resource." + getName(model) + "ResourceDescriptionConstants";
+    return model.basePackage + ".resource." + getName(model) + "ResourceDescriptionConstants";
   }
 
   def String getFingerprintComputer(ExportModel model) {
-    val uri = model.eResource().getURI();
     // TODO this is a hack; to support modularization we should probably add name to export models (as with scope models)
-    return String.join(".", uri.segmentsList().subList(3, uri.segmentCount() - 1)) + ".resource." + getName(model) + "FingerprintComputer";
+    return model.basePackage + ".resource." + getName(model) + "FingerprintComputer";
   }
 
   def String getFragmentProvider(ExportModel model) {
-    val uri = model.eResource().getURI();
     // TODO this is a hack; to support modularization we should probably add name to export models (as with scope models)
-    return String.join(".", uri.segmentsList().subList(3, uri.segmentCount() - 1)) + ".resource." + getName(model) + "FragmentProvider";
+    return model.basePackage + ".resource." + getName(model) + "FragmentProvider";
   }
 
   def String getExportFeatureExtension(ExportModel model) {
-    val uri = model.eResource().getURI();
     // TODO we still need to add a package to the models. Extension models already have a name in contrast to cases above
-    return String.join(".", uri.segmentsList().subList(3, uri.segmentCount() - 1)) + ".resource." + model.name + "ExportFeatureExtension";
+    return model.basePackage + ".resource." + model.name + "ExportFeatureExtension";
+  }
+
+  private def String getBasePackage(ExportModel model) {
+    val uri = model.eResource.URI
+    val packageFromUri = uri.packageFromUri
+    if (packageFromUri !== null) {
+      return packageFromUri
+    }
+    return uri.fallbackPackage
+  }
+
+  private def String getPackageFromUri(org.eclipse.emf.common.util.URI uri) {
+    val packageSegments = uri.segmentsList
+    if (packageSegments.size > URI_PACKAGE_START_INDEX + 1 && "src".equals(packageSegments.get(URI_PROJECT_SEGMENT_INDEX + 1))) {
+      return String.join(".", packageSegments.subList(URI_PACKAGE_START_INDEX, uri.segmentCount - 1))
+    }
+    return null
+  }
+
+  private def String getFallbackPackage(org.eclipse.emf.common.util.URI uri) {
+    val segments = uri.segmentsList
+    if (segments.size > URI_PROJECT_SEGMENT_INDEX) {
+      return segments.get(URI_PROJECT_SEGMENT_INDEX).safePackageSegment
+    }
+    return DEFAULT_PACKAGE_SEGMENT
+  }
+
+  private def String getSafePackageSegment(String segment) {
+    if (segment === null || segment.empty) {
+      return DEFAULT_PACKAGE_SEGMENT
+    }
+    val normalizedSegment = segment.toLowerCase
+    val builder = new StringBuilder()
+    for (var i = 0; i < normalizedSegment.length; i++) {
+      val character = normalizedSegment.charAt(i)
+      if (builder.length == 0) {
+        if (Character.isJavaIdentifierStart(character)) {
+          builder.append(character)
+        } else if (Character.isJavaIdentifierPart(character)) {
+          builder.append('_').append(character)
+        } else {
+          builder.append('_')
+        }
+      } else {
+        builder.append(if (Character.isJavaIdentifierPart(character)) character else '_')
+      }
+    }
+    return if (builder.length == 0) DEFAULT_PACKAGE_SEGMENT else builder.toString
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorX.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorX.xtend
@@ -24,6 +24,7 @@ import com.google.inject.Inject
 import java.util.Collection
 import java.util.List
 import java.util.Map
+import javax.lang.model.SourceVersion
 import org.eclipse.emf.ecore.EAttribute
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EClassifier
@@ -53,11 +54,15 @@ class ExportGeneratorX {
 
   def List<String> getPrefix(URI uri) {
     // TODO we still need to add a package to the models. Extension models already have a name in contrast to cases above
-    if (uri.segmentsList().size > 3) {
-      return uri.segmentsList().subList(3, uri.segmentCount() - 1);      
-    } else {
-      return uri.segmentsList().subList(uri.segmentCount() - 2, uri.segmentCount() - 1);
+    val segments = uri.segmentsList
+    if (segments.size > 4) {
+      return segments.subList(3, segments.size - 1)
     }
+    // shorter shapes have no package segments: fall back to a valid package name
+    if (segments.size > 2 && SourceVersion.isName(segments.get(1))) {
+      return #[segments.get(1)]
+    }
+    return #['generated']
   }
 
   def String getExportedNamesProvider(ExportModel model) {


### PR DESCRIPTION
## Summary
`ExportGeneratorX.getPrefix` derives the target package from raw URI segment arithmetic and misbehaves on every short URI shape:
- **1 segment** (e.g. ParseHelper's `__synthetic0.export`): `subList(-1, 0)` → `IndexOutOfBoundsException`.
- **2 segments**: emits the literal segment `resource` as the package.
- **project root** (`platform:/resource/<project>/<file>.export`): emits the raw project name — uncompilable generated code when the project is not named like a Java package (e.g. `My-Project`).
- **source-folder root** (`<project>/src/<file>.export`): emits an empty package, producing leading-dot qualified names (`.naming.…`).

The derived value feeds both the generated `package` declaration and the output file path via the seven accessor methods (ExportedNamesProvider, ResourceDescriptionManager/Strategy/Constants, FingerprintComputer, FragmentProvider, ExportFeatureExtension).

The fix is confined to that one method:
- URIs with **five or more segments keep the previous derivation byte for byte** (segments between position 3 and the file, regardless of the source folder's name) — no behavior change for any layout that worked before, including `src-gen` nesting and `src/main/java`.
- Shorter shapes fall back to the **project name when it already is a valid Java package name** (`SourceVersion.isName`, byte-identical to previous behavior for the project-root shape), or `generated` otherwise.

No existing test ever failed on this: the 1-segment crash is only reachable from synthetic ParseHelper URIs — workspace builds always see ≥3-segment platform URIs — and the builder participant catches and logs per-resource exceptions rather than failing the build; the export tests assert validation/scoping, never generated output. (The long-standing `ERROR … Error during compilation of '….export'` noise in master test runs stems from `getGrammar`'s failing demand-load, tolerated separately by #1459.) The new `ExportGeneratorXTest` pins the shape table with synthetic resource URIs — including the 5-segment derivation boundary and the 2-segment fallback — with no fixture files needed.

## Verification
- Full local gate on this head: `mvn -T 3C clean verify checkstyle:check pmd:check pmd:cpd-check spotbugs:check` → BUILD SUCCESS, 0 test failures, including the new `ExportGeneratorXTest` (runs in CI via `ExportTestSuite` → `AllTests`).
- A/B: the new tests grafted onto plain master (production code unchanged) fail on exactly the broken shapes — `IndexOutOfBoundsException: fromIndex = -1` for the single-segment URI and wrong/leading-dot packages for the short shapes — while the behavior-preservation tests (nested derivations, valid project-name fallback) pass on both master and this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
