### PR TITLE
chore: harmonize Maven to 3.9.12

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
-          maven-version: 3.9.11
+          maven-version: 3.9.12
       - uses: actions/checkout@v6
       - name: Set up JDK 21
         uses: actions/setup-java@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This document helps AI coding agents work effectively with the DSL DevKit codeba
 - **Type**: Multi-module Tycho/Eclipse/OSGi project
 - **Purpose**: DSL development toolkit built on Xtext
 - **Java**: 21+
-- **Maven**: 3.9+
+- **Maven**
 - **Tycho**
 - **Xtext/Xtend**
 

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -43,7 +43,7 @@
     <test.testClass>com.avaloq.tools.ddk.xtext.AllTests</test.testClass>
 
     <!-- maven enforced version -->
-    <maven-enforcer-rule.version>3.3.9</maven-enforcer-rule.version>
+    <maven-enforcer-rule.version>3.9.12</maven-enforcer-rule.version>
 
     <!-- maven plugin versions -->
     <checkstyle.plugin.version>3.6.0</checkstyle.plugin.version>


### PR DESCRIPTION
## Summary
- raise the enforced Maven minimum in the parent POM to 3.9.12
- align the GitHub Actions Maven setup to 3.9.12
- remove the specific Maven version from AGENTS.md instead of pinning it there

## Verification
- mvn -N -f ./ddk-parent/pom.xml validate --batch-mode
