### PR TITLE
chore: enable PMD PreserveStackTrace rule

### DIFF
--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/configuration/AbstractModelLocation.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/configuration/AbstractModelLocation.java
@@ -63,7 +63,7 @@ public abstract class AbstractModelLocation implements IModelLocation {
     try {
       return catalogUrl.toURI();
     } catch (URISyntaxException e) {
-      throw new IllegalStateException(NLS.bind("URL of catalog {0} cannot be converted to URI", catalogUrl.toString())); //$NON-NLS-1$
+      throw new IllegalStateException(NLS.bind("URL of catalog {0} cannot be converted to URI", catalogUrl.toString()), e); //$NON-NLS-1$
     }
   }
 

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckExtensionGenerator.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckExtensionGenerator.java
@@ -541,7 +541,7 @@ class CheckExtensionGenerator {
     } catch (SWTException e) {
       // If the build was cancelled while in syncExec() it will throw an SWTException
       if (monitor.isCanceled()) {
-        throw new OperationCanceledException();
+        throw new OperationCanceledException(); // NOPMD PreserveStackTrace - SWTException is just the cancellation signal
       } else {
         throw e;
       }

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/CoreSwtbotTools.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/CoreSwtbotTools.java
@@ -276,7 +276,8 @@ public final class CoreSwtbotTools {
             page = workbench.showPerspective("com.avaloq.ice.perspectives.Development", window);
           } catch (final WorkbenchException second) {
             // Both perspectives are missing
-            throw new AssertionFailedException("Could not switch to Avaloq Perspective: " + exception.getLocalizedMessage());
+            second.addSuppressed(exception);
+            throw new IllegalStateException("Could not switch to Avaloq Perspective", second);
           }
         }
         if (page != null) {
@@ -418,7 +419,7 @@ public final class CoreSwtbotTools {
         try {
           PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().showView(id);
         } catch (final PartInitException exception) {
-          throw new AssertionFailedException("Could not open change view: " + exception.getLocalizedMessage());
+          throw new IllegalStateException("Could not open change view: " + exception.getLocalizedMessage(), exception);
         }
       }
     });

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/resourceloader/ParallelResourceLoader.java
@@ -248,7 +248,7 @@ public class ParallelResourceLoader extends AbstractResourceLoader {
           try {
             resource = parent.getResource(uri, true);
           } catch (WrappedException e) {
-            throw new LoadOperationException(uri, e.exception());
+            throw new LoadOperationException(uri, e.exception()); // NOPMD PreserveStackTrace - intentional unwrap of WrappedException
             // CHECKSTYLE:OFF
           } catch (Exception e) {
             // CHECKSTYLE:ON

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/PluginTestProjectManager.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/PluginTestProjectManager.java
@@ -111,7 +111,7 @@ public class PluginTestProjectManager extends XtextTestProjectManager {
       IResourcesSetupUtil.waitForBuild();
       createPluginProject(injector, TEST_PROJECT_NAME);
     } catch (CoreException e) {
-      throw new IllegalStateException("Failed to create plugin project");
+      throw new IllegalStateException("Failed to create plugin project", e);
     }
   }
 
@@ -145,7 +145,7 @@ public class PluginTestProjectManager extends XtextTestProjectManager {
     } catch (InvocationTargetException e) {
       LOGGER.error(e.getCause().getMessage());
     } catch (InterruptedException e) {
-      throw new AssertionError("Interrupted");
+      throw new AssertionError("Interrupted", e);
     }
   }
 

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/linking/LazyLinkingResource2.java
@@ -164,7 +164,7 @@ public class LazyLinkingResource2 extends DerivedStateAwareResource implements I
     } catch (FastLazyURIEncoder.DecodingError err) {
       RuntimeException cause = err.getCause();
       getErrors().add(new ExceptionDiagnostic(cause));
-      throw new WrappedException(cause);
+      throw new WrappedException(cause); // NOPMD PreserveStackTrace - intentional unwrap of DecodingError transport wrapper
     } catch (WrappedException e) {
       boolean logged = false;
       try {

--- a/ddk-configuration/pmd/ruleset.xml
+++ b/ddk-configuration/pmd/ruleset.xml
@@ -84,7 +84,6 @@
     <exclude name="UnitTestShouldUseBeforeAnnotation"/><!--Checkstyle-->
     <exclude name="UnitTestShouldUseTestAnnotation"/>
     <exclude name="NonExhaustiveSwitch"/>
-    <exclude name="PreserveStackTrace"/><!--TODO-->
     <exclude name="UnnecessaryWarningSuppression"/> <!--Experimental, too many false positives-->
     <exclude name="UnusedLocalVariable"/><!--Checkstyle-->
     <exclude name="JUnit5TestShouldBePackagePrivate"/>


### PR DESCRIPTION
## Summary
- Pass caught exceptions as cause to newly thrown exceptions where missing
- Replace `AssertionFailedException` (no cause constructor) with `IllegalStateException` in test utilities
- Suppress with `// NOPMD PreserveStackTrace` where unwrapping is intentional (e.g. `WrappedException.exception()`, cancellation signals)
- Remove the `PreserveStackTrace` exclusion from the PMD ruleset

## Test plan
- [x] `mvn compile pmd:pmd pmd:check` passes with no violations
- [x] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)