### PR TITLE
fix: replace global needRebuild() with project-scoped rebuild APIs

### DIFF
--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/BuildContext.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/BuildContext.java
@@ -117,8 +117,17 @@ public class BuildContext implements IBuildContext {
   @Override
   public void needRebuild() {
     rebuildRequired = true;
+  }
+
+  @Override
+  public void needRebuild(final IProject project) {
+    rebuildRequired = true;
     if (builder != null) {
-      builder.needRebuild();
+      if (getBuiltProject().equals(project)) {
+        builder.triggerRequestProjectRebuild();
+      } else {
+        builder.triggerRequestProjectsRebuild(project);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Remove the vestigial `IncrementalProjectBuilder.needRebuild()` call that triggered **global** workspace rebuilds every time a builder participant generated a file
- Override `needRebuild(IProject)` using Eclipse 3.17+ project-scoped APIs, matching the upstream Xtext 2.27+ pattern

### What Changes

**No-arg `needRebuild()`:** Remove `builder.needRebuild()`, keeping only the internal `rebuildRequired` flag.

**New `needRebuild(IProject)` override:** Uses project-scoped Eclipse APIs:
- Same project: `builder.triggerRequestProjectRebuild()` — rebuilds only this project
- Different project: `builder.triggerRequestProjectsRebuild(project)` — rebuilds only that project

### References

- [Eclipse Bug 579082](https://bugs.eclipse.org/bugs/show_bug.cgi?id=579082) — `needRebuild()` identified as cause of O(n²) build behavior
- [Eclipse Bug 452399](https://bugs.eclipse.org/bugs/show_bug.cgi?id=452399) — original bug that motivated `RebuildingXtextBuilder`
- [Xtext #1820](https://github.com/eclipse/xtext-eclipse/issues/1820) / [PR #1821](https://github.com/eclipse/xtext-eclipse/pull/1821) — upstream fix adding project-scoped `needRebuild(IProject)`

## Test plan

- [ ] Open workspace with multiple DSL projects
- [ ] Edit a file in one project that triggers code generation
- [ ] Verify only the affected project rebuilds (not the entire workspace)
- [ ] Verify generated sources are still correctly reprocessed (internal loop still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)