### PR TITLE
chore: remove unnecessary @SuppressWarnings annotations

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/resource/CheckBatchLinkableResource.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/resource/CheckBatchLinkableResource.java
@@ -49,7 +49,6 @@ public class CheckBatchLinkableResource extends BatchLinkableResource {
     };
   }
 
-  @SuppressWarnings("restriction")
   @Override
   public void load(final Map<?, ?> options) throws IOException {
     modelLocation = (IModelLocation) options.get(MAYBE_LOCATION_DATA);

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckContextsGenerator.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckContextsGenerator.java
@@ -172,7 +172,6 @@ public class CheckContextsGenerator {
    * @throws CoreException
    *           the core exception
    */
-  @SuppressWarnings("unchecked")
   public void removeContexts(final Delta delta) throws CoreException {
     final IProject project = RuntimeProjectUtil.getProject(delta.getUri(), mapper);
     if (project != null) {

--- a/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/ClassRunner.java
+++ b/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/junit/runners/ClassRunner.java
@@ -100,7 +100,6 @@ public class ClassRunner extends BlockJUnit4ClassRunner {
   public static final String PROPERTY_UNSTABLE_FAIL = "com.avaloq.test.unstablefail"; //$NON-NLS-1$
   /** Class-wide logger. */
   private static final Logger LOGGER = LogManager.getLogger(ClassRunner.class);
-  @SuppressWarnings("unchecked")
   private static final List<Class<? extends Annotation>> TEST_ANNOTATIONS = Lists.newArrayList(Test.class, UnitTest.class, ModuleTest.class, IntegrationTest.class, SystemTest.class, PerformanceTest.class, BugTest.class);
   private List<FrameworkMethod> expectedMethods;
   private int currentMethodIndex;

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/layered/XtextBuildTrigger.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/layered/XtextBuildTrigger.java
@@ -21,7 +21,7 @@ import com.google.inject.Inject;
 /**
  * Build trigger that actually does trigger a full build. Assumes we have a {@link IWorkspace} and a {@link BuildScheduler}.
  */
-@SuppressWarnings({"deprecation", "removal"})
+@SuppressWarnings("deprecation")
 public class XtextBuildTrigger implements IXtextBuildTrigger {
 
   @Inject

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/contentassist/AbstractAcfContentAssistTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/contentassist/AbstractAcfContentAssistTest.java
@@ -188,7 +188,6 @@ public abstract class AbstractAcfContentAssistTest extends AbstractXtextMarkerBa
    * @param sourceFileName
    *          the filename of the test source that the proposals were to be computed from, must not be {@code null}
    */
-  @SuppressWarnings("restriction")
   private void assertSourceProposals(final String sourceFileName) {
     try {
       AcfContentAssistProcessorTestBuilder builder = newBuilder().append(getTestSource(sourceFileName).getContent());

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/generator/AbstractGeneratorTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/generator/AbstractGeneratorTest.java
@@ -60,7 +60,7 @@ import com.google.inject.Provider;
 /**
  * A base class for xtext generator tests. Allows creating a project and adding files.
  */
-@SuppressWarnings({"PMD.AbstractClassWithoutAbstractMethod", "restriction", "nls"})
+@SuppressWarnings({"PMD.AbstractClassWithoutAbstractMethod", "nls"})
 public abstract class AbstractGeneratorTest {
   private static final String MESSAGE_GENERATED_FILE_MUST_EXIST = "Generated file ''{0}'' must exist.";
   private static final String MESSAGE_GENERATED_CODE_MUST_BE_CORRECT = "Generated contents of ''{0}'' must be correct.";

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/junit/runners/XtextClassRunner.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/junit/runners/XtextClassRunner.java
@@ -101,7 +101,6 @@ public class XtextClassRunner extends XtextRunner {
   public static final String PROPERTY_UNSTABLE_FAIL = "com.avaloq.test.unstablefail"; //$NON-NLS-1$
   /** Class-wide logger. */
   private static final Logger LOGGER = LogManager.getLogger(XtextClassRunner.class);
-  @SuppressWarnings("unchecked")
   private static final List<Class<? extends Annotation>> TEST_ANNOTATIONS = Lists.newArrayList(Test.class, UnitTest.class, ModuleTest.class, IntegrationTest.class, SystemTest.class, PerformanceTest.class, BugTest.class);
   private List<FrameworkMethod> expectedMethods;
   private int currentMethodIndex;

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/jupiter/AbstractAcfContentAssistTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/jupiter/AbstractAcfContentAssistTest.java
@@ -187,7 +187,6 @@ public abstract class AbstractAcfContentAssistTest extends AbstractXtextMarkerBa
    * @param sourceFileName
    *          the filename of the test source that the proposals were to be computed from, must not be {@code null}
    */
-  @SuppressWarnings("restriction")
   private void assertSourceProposals(final String sourceFileName) {
     try {
       AcfContentAssistProcessorTestBuilder builder = newBuilder().append(getTestSource(sourceFileName).getContent());

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractFingerprintComputer.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractFingerprintComputer.java
@@ -517,7 +517,6 @@ public abstract class AbstractFingerprintComputer implements IFingerprintCompute
    *          the URIs or by calling a generated function, must not be {@code null}
    * @return the fingerprint
    */
-  @SuppressWarnings("unchecked")
   protected ExportItem fingerprintExpr(final Object obj, final EObject context, final FingerprintOrder order, final FingerprintIndirection indirection) {
     if (obj instanceof EObject) {
       if (indirection == FingerprintIndirection.INDIRECT) {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractStreamingFingerprintComputer.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractStreamingFingerprintComputer.java
@@ -456,7 +456,6 @@ public abstract class AbstractStreamingFingerprintComputer implements IFingerpri
    * @param hasher
    *          hasher to stream to
    */
-  @SuppressWarnings("unchecked")
   protected void fingerprintExpr(final Object obj, final EObject context, final FingerprintOrder order, final FingerprintIndirection indirection, final Hasher hasher) {
     if (obj instanceof EObject) {
       if (indirection == FingerprintIndirection.INDIRECT) {


### PR DESCRIPTION
## Summary
- Remove 10 `@SuppressWarnings` annotations that are no longer needed
- Covers `"removal"`, `"restriction"`, and `"unchecked"` suppressions across 10 files where the suppressed condition no longer exists

## Test plan
- [x] CI passes (no compilation or runtime impact — these are compile-time-only annotations)
- [x] Eclipse workspace shows fewer warnings after checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)