### PR TITLE
refactor: convert log calls to parameterized logging in Check framework

### DIFF
--- a/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/AbstractCheckTestCase.java
+++ b/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/AbstractCheckTestCase.java
@@ -325,7 +325,7 @@ public abstract class AbstractCheckTestCase {
               IFile file = IResourcesSetupUtil.createFile(resourceURI.toPlatformString(true), contents);
               getFiles().add(file);
             } catch (IOException e) {
-              LOGGER.error("failed adding file to workspace: " + fileName, e);
+              LOGGER.error("failed adding file to workspace: {}", fileName, e);
               fail("Error adding file " + fileName + " to workspace: " + e.getMessage());
             }
           }

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/configuration/CheckConfigurationStoreService.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/configuration/CheckConfigurationStoreService.java
@@ -90,7 +90,7 @@ public class CheckConfigurationStoreService implements ICheckConfigurationStoreS
     try {
       return (String) marker.getAttribute(Issue.CODE_KEY);
     } catch (CoreException e) {
-      LOGGER.error("Could not get code for marker: " + marker, e); //$NON-NLS-1$
+      LOGGER.error("Could not get code for marker: {}", marker, e); //$NON-NLS-1$
       return null;
     }
   }
@@ -99,7 +99,7 @@ public class CheckConfigurationStoreService implements ICheckConfigurationStoreS
     try {
       return URI.createURI((String) marker.getAttribute(Issue.URI_KEY));
     } catch (CoreException e) {
-      LOGGER.error("Could not get uri for marker: " + marker, e); //$NON-NLS-1$
+      LOGGER.error("Could not get uri for marker: {}", marker, e); //$NON-NLS-1$
       return null;
     }
   }
@@ -111,7 +111,7 @@ public class CheckConfigurationStoreService implements ICheckConfigurationStoreS
       if (resourceServiceProvider != null) {
         return resourceServiceProvider.get(Injector.class).getInstance(Key.get(String.class, Names.named(Constants.LANGUAGE_NAME)));
       } else {
-        LOGGER.error("Could not fetch a ResourceServiceProvider for URI: " + uri); //$NON-NLS-1$
+        LOGGER.error("Could not fetch a ResourceServiceProvider for URI: {}", uri); //$NON-NLS-1$
       }
     } else {
       LOGGER.warn("Could not fetch eResource from issue: URI to problem is null"); //$NON-NLS-1$

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/context/AbstractCheckContext.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/context/AbstractCheckContext.java
@@ -73,7 +73,7 @@ public class AbstractCheckContext implements ICheckContext {
           // caught and disabled by the usual check infrastructure.
         } catch (Exception e) {
           // CHECKSTYLE:CHECK-ON IllegalCatch
-          LOGGER.error("Failed to execute predicate " + method.getName() + " for issue code " + issueCode + ". Removing predicate for this issue code.", e); //$NON-NLS-1$ //$NON-NLS-2$//$NON-NLS-3$
+          LOGGER.error("Failed to execute predicate {} for issue code {}. Removing predicate for this issue code.", method.getName(), issueCode, e); //$NON-NLS-1$
           predicatesForIssueCode.remove(issueCode, method);
         }
       }

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/AbstractCheckImpl.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/AbstractCheckImpl.java
@@ -40,8 +40,8 @@ public abstract class AbstractCheckImpl implements ICheckValidatorImpl {
   protected void logCheckMethodFailure(final String rule, final EObject object, final Exception e) {
     final Throwable cause = e instanceof InvocationTargetException ? ((InvocationTargetException) e).getTargetException() : e;
     final Resource res = object.eResource();
-    LOGGER.error("Permanently disabling check method " + rule + " for context " + object.getClass().getName() + " because of failure" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-        + (res != null ? " in " + res.getURI() : ""), cause); //$NON-NLS-1$ //$NON-NLS-2$
+    LOGGER.error("Permanently disabling check method {} for context {} because of failure{}", rule, object.getClass().getName(), //$NON-NLS-1$
+        (res != null ? " in " + res.getURI() : ""), cause); //$NON-NLS-1$ //$NON-NLS-2$
   }
 
   /**

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/label/CheckRuleLabelProvider.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/label/CheckRuleLabelProvider.java
@@ -109,7 +109,7 @@ public class CheckRuleLabelProvider implements ICheckRuleLabelProvider {
     final Map<String, String> mergedMap = new HashMap<String, String>();
     maps.map(Map::entrySet).flatMap(Set::stream).forEach(entry -> {
       if (null != mergedMap.putIfAbsent(entry.getKey(), entry.getValue())) {
-        LOGGER.warn("Non-unique Check issue code found: " + entry.getKey()); //$NON-NLS-1$
+        LOGGER.warn("Non-unique Check issue code found: {}", entry.getKey()); //$NON-NLS-1$
       }
     });
     return mergedMap;

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/validation/AbstractCheckValidator.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/validation/AbstractCheckValidator.java
@@ -19,7 +19,6 @@ import org.apache.logging.log4j.LogManager;
 import org.eclipse.emf.common.util.DiagnosticChain;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.osgi.util.NLS;
 import org.eclipse.xtext.validation.AbstractInjectableValidator;
 
 import com.avaloq.tools.ddk.check.runtime.issue.ICheckValidatorImpl;
@@ -83,7 +82,7 @@ public abstract class AbstractCheckValidator extends AbstractInjectableValidator
     if (language == null) {
       throw new IllegalArgumentException("Input language cannot be null"); //$NON-NLS-1$
     } else if (injector == null) {
-      LOGGER.debug(NLS.bind("No injector found for {0}. Could not inject registered validators.", language)); //$NON-NLS-1$
+      LOGGER.debug("No injector found for {}. Could not inject registered validators.", language); //$NON-NLS-1$
     }
 
     final List<ICheckValidatorImpl> result = Lists.newArrayList();
@@ -98,7 +97,7 @@ public abstract class AbstractCheckValidator extends AbstractInjectableValidator
           // CHECKSTYLE:OFF
         } catch (Exception e) {
           // CHECKSTYLE:ON
-          LOGGER.error("failed to inject validator " + validator, e); //$NON-NLS-1$
+          LOGGER.error("failed to inject validator {}", validator, e); //$NON-NLS-1$
         }
       }
     }

--- a/com.avaloq.tools.ddk.check.runtime.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.check.runtime.ui/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
-Import-Package: org.apache.logging.log4j
+Import-Package: org.apache.logging.log4j,
+ org.apache.logging.log4j.util
 Export-Package: com.avaloq.tools.ddk.check.runtime.ui.editor,
  com.avaloq.tools.ddk.check.runtime.ui.editor.model,
  com.avaloq.tools.ddk.check.runtime.ui.quickfix,

--- a/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/validation/CheckMarkerUpdateJob.java
+++ b/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/validation/CheckMarkerUpdateJob.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.check.runtime.ui.validation;
 
-import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.Set;
 
@@ -95,9 +94,7 @@ public class CheckMarkerUpdateJob extends Job {
         return (IFile) storage.getFirst();
       }
     }
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug(MessageFormat.format("Could not find storage for URI {0}", fileUri.toString())); //$NON-NLS-1$
-    }
+    LOGGER.debug("Could not find storage for URI {}", fileUri::toString); //$NON-NLS-1$
     return null;
   }
 
@@ -135,9 +132,7 @@ public class CheckMarkerUpdateJob extends Job {
       final IResourceServiceProvider serviceProvider = serviceProviderRegistry.getResourceServiceProvider(uri);
       if (serviceProvider == null) {
         // This may happen for non-Xtext resources in ice entities
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.debug(MessageFormat.format("Could not validate {0}: no resource service provider found", uri.toString())); //$NON-NLS-1$
-        }
+        LOGGER.debug("Could not validate {}: no resource service provider found", uri::toString); //$NON-NLS-1$
         continue; // Skip to next URI
       }
 
@@ -152,7 +147,7 @@ public class CheckMarkerUpdateJob extends Job {
       }
 
       if (resourceValidator == null) {
-        LOGGER.error(MessageFormat.format("Could not validate {0}: no resource validator found", iFile.getName())); //$NON-NLS-1$
+        LOGGER.error("Could not validate {}: no resource validator found", iFile.getName()); //$NON-NLS-1$
       } else if (iFile != null) {
         monitor.subTask("loading " + iFile.getName()); //$NON-NLS-1$
 
@@ -175,11 +170,11 @@ public class CheckMarkerUpdateJob extends Job {
           // CHECKSTYLE:OFF
         } catch (final RuntimeException e) {
           // CHECKSTYLE:ON
-          LOGGER.error(MessageFormat.format("{0} could not be validated.", iFile.getName()), e); //$NON-NLS-1$
+          LOGGER.error("{} could not be validated.", iFile.getName(), e); //$NON-NLS-1$
         } finally {
           if (eResource != null) {
             validateAndCreateMarkers(resourceValidator, markerCreator, iFile, eResource, monitor);
-            LOGGER.debug("Validated " + uri); //$NON-NLS-1$
+            LOGGER.debug("Validated {}", uri); //$NON-NLS-1$
             if (loaded) { // NOPMD
               // unload any resource that was previously loaded as part of this loop.
               eResource.unload();

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckProjectHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckProjectHelper.java
@@ -52,6 +52,7 @@ import com.google.inject.name.Named;
 public class CheckProjectHelper {
 
   private static final Logger LOGGER = LogManager.getLogger(CheckProjectHelper.class);
+  private static final String LOG_PLUGIN_PATH_ERROR = "Could not determine plugin path for catalog {}";
 
   @Inject
   private IStorage2UriMapper mapper;
@@ -90,7 +91,7 @@ public class CheckProjectHelper {
       String result = packageFragment.getElementName().replace('.', '/');
       return result + '/' + file.getName();
     } catch (JavaModelException e) {
-      LOGGER.error("Could not determine plugin path for catalog " + catalog.getName(), e);
+      LOGGER.error(LOG_PLUGIN_PATH_ERROR, catalog.getName(), e);
     }
     return null;
   }
@@ -114,7 +115,7 @@ public class CheckProjectHelper {
       final String fileNameWithoutExtension = file.getName().substring(0, file.getName().length() - (file.getFileExtension().length() + 1));
       return packageFragment.getElementName() + '.' + fileNameWithoutExtension;
     } catch (JavaModelException e) {
-      LOGGER.error("Could not determine plugin path for catalog " + catalog.getName(), e);
+      LOGGER.error(LOG_PLUGIN_PATH_ERROR, catalog.getName(), e);
     }
     return null;
   }

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/popup/actions/DeployJob.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/popup/actions/DeployJob.java
@@ -101,7 +101,7 @@ public class DeployJob extends Job {
       return new Status(Status.ERROR, Activator.getPluginId(), Messages.DeployJob_CouldNotDeployCheckBundle, e);
     }
 
-    LOGGER.info(NLS.bind("Generated bundle from project {0} deployed.", project.getName())); //$NON-NLS-1$
+    LOGGER.info("Generated bundle from project {} deployed.", project.getName()); //$NON-NLS-1$
 
     try {
       deployCheckConfiguration();
@@ -109,7 +109,7 @@ public class DeployJob extends Job {
       return new Status(Status.ERROR, Activator.getPluginId(), Messages.DeployJob_CannotDeployMoreThanOneCheckConfiguration, e);
     }
 
-    LOGGER.info(NLS.bind("Check configuration for project {0} deployed.", project.getName())); //$NON-NLS-1$
+    LOGGER.info("Check configuration for project {} deployed.", project.getName()); //$NON-NLS-1$
 
     return Status.OK_STATUS;
   }
@@ -146,7 +146,7 @@ public class DeployJob extends Job {
       }
     }
 
-    LOGGER.info(NLS.bind("Starting the bundle {0} generated from the project {1}", bundleLocation, project.getName())); //$NON-NLS-1$
+    LOGGER.info("Starting the bundle {} generated from the project {}", bundleLocation, project.getName()); //$NON-NLS-1$
     try {
       managedBundle = bundleContext.installBundle(bundleLocation, Files.asByteSource(jar).openStream());
       managedBundle.start();

--- a/com.avaloq.tools.ddk.checkcfg.core/src/com/avaloq/tools/ddk/checkcfg/CheckCfgUtil.java
+++ b/com.avaloq.tools.ddk.checkcfg.core/src/com/avaloq/tools/ddk/checkcfg/CheckCfgUtil.java
@@ -82,7 +82,7 @@ public class CheckCfgUtil {
         try {
           contributions.add((ICheckCfgPropertySpecification) element.createExecutableExtension(PROPERTY_EXECUTABLE_EXTENSION_ATTRIBUTE));
         } catch (CoreException e) {
-          LOGGER.warn("Failed to instantiate property from " + element.getContributor(), e); //$NON-NLS-1$
+          LOGGER.warn("Failed to instantiate property from {}", element.getContributor(), e); //$NON-NLS-1$
         }
       }
     } else {


### PR DESCRIPTION
## Summary

Replace string concatenation, `NLS.bind`, and `MessageFormat.format` in log calls with parameterized `{}` placeholders. Use `Supplier`/method-refs for lazy argument evaluation where appropriate.

**Modules:** `check.core.test`, `check.runtime.core`, `check.runtime.ui`, `check.ui`, `checkcfg.core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)