### PR TITLE
ci: pin actions to SHAs and remove setup-maven

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,8 +7,8 @@ jobs:
   pmd:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -19,8 +19,8 @@ jobs:
   checkstyle:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -35,16 +35,16 @@ jobs:
         uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.9.13
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: 'temurin'
           java-version: '21'
       - name: Set up Workspace Enviroment Variable
         run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
       - name: Cache Maven dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: /home/runner/.m2/repository
           key: ${{ runner.os }}-maven-0-${{ hashFiles('**/pom.xml') }}
@@ -54,7 +54,7 @@ jobs:
         run: xvfb-run mvn clean verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check -f ./ddk-parent/pom.xml --batch-mode --fail-at-end
       - name: Archive Tycho Surefire Plugin
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: tycho-surefire-plugin
           path: ${{ env.GITHUB_WORKSPACE }}/com.avaloq.tools.ddk.xtext.test/target/work/data/.metadata/.log

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,16 +31,14 @@ jobs:
   maven-verify:
     runs-on: ubuntu-24.04
     steps:
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
-        with:
-          maven-version: 3.9.13
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: 'temurin'
           java-version: '21'
+      - name: Log Maven version
+        run: mvn --version
       - name: Set up Workspace Enviroment Variable
         run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
       - name: Cache Maven dependencies


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in `verify.yml` to immutable commit SHAs (mutable version tags are a supply-chain risk)
- Remove third-party `stCarolas/setup-maven` — Ubuntu 24.04 runners ship Maven 3.9.14, covered by the enforcer rule `[3.9.0,4)`

## Actions pinned

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v6.0.2 | `de0fac2e` |
| `actions/setup-java` | v5.2.0 | `be666c2f` |
| `actions/cache` | v5.0.5 | `27d5ce7f` |
| `actions/upload-artifact` | v7.0.1 | `043fb46d` |

All SHAs verified against latest subversion tags.

## Test plan

- [ ] CI passes with runner-provided Maven (no explicit Maven setup step)
- [ ] PMD, Checkstyle, and maven-verify jobs all succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)