### PR TITLE
Fix ddk-target classifier mismatch (dsl-sdk → ddk)

### DIFF
--- a/ddk-target/pom.xml
+++ b/ddk-target/pom.xml
@@ -27,7 +27,7 @@
                 <artifact>
                   <file>ddk.target</file>
                   <type>target</type>
-                  <classifier>dsl-sdk</classifier>
+                  <classifier>ddk</classifier>
                 </artifact>
               </artifacts>
             </configuration>


### PR DESCRIPTION
## Summary

One-line fix: `ddk-target/pom.xml` attached the `.target` artifact with classifier `dsl-sdk`, but `ddk-parent`'s `target-platform-configuration` expects classifier `ddk` (from `${target.platform}` property).

This mismatch meant the target artifact could never be resolved from `~/.m2/repository` — it only worked in-reactor where Tycho resolves it directly. This blocked any isolated module build (`mvn -pl :module`) and external build tools from resolving the target platform.

## Test plan

- [x] `mvn compile -T 3C` from `ddk-parent/` still passes (full reactor, 24s)
- [x] `mvn install -pl ../ddk-target` from `ddk-parent/` now installs as `ddk-target-17.2.0-SNAPSHOT-ddk.target` (was `dsl-sdk`)
- [x] `mvn compile -pl :com.avaloq.tools.ddk` works after installing ddk-target (7.9s, was broken before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)