### PR TITLE
fix: correct 'Enviroment' typo in verify.yml

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,7 +39,7 @@ jobs:
           java-version: '21'
       - name: Log Maven version
         run: mvn --version
-      - name: Set up Workspace Enviroment Variable
+      - name: Set up Workspace Environment Variable
         run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
       - name: Cache Maven dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5


### PR DESCRIPTION
Fix a typo in the `verify.yml` workflow step name: `Enviroment` → `Environment`. Step name only; no behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)