### PR TITLE
fix: do not delete .gitignore files during maven clean phase

### DIFF
--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -373,6 +373,9 @@
                 <includes>
                   <include>**</include>
                 </includes>
+                <excludes>
+                  <exclude>.gitignore</exclude>
+                </excludes>
               </fileset>
             </filesets>
           </configuration>


### PR DESCRIPTION
## Summary

- Exclude `.gitignore` from the `maven-clean-plugin` fileset in `ddk-parent/pom.xml` so that `mvn clean` no longer deletes the placeholder `.gitignore` files inside `xtend-gen/` directories.
- Without this, every `mvn clean` leaves a dirty working tree (31 deleted files) that has to be restored manually.

## Test plan

- [x] Run `mvn clean -f ./ddk-parent/pom.xml` and verify `git status` shows no deleted `.gitignore` files afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)