### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 *.xtendbin
 /*/xtend-gen/*
 !/*/xtend-gen/.gitignore
+
+# macOS
+.DS_Store


### PR DESCRIPTION
## Summary
- macOS Finder writes \`.DS_Store\` files into any directory it opens, including this working tree
- adding \`.DS_Store\` to \`.gitignore\` keeps these out of \`git status\` for macOS contributors

## Test plan
- [x] \`git status\` no longer reports \`.DS_Store\` after a \`touch .DS_Store\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)