### PR TITLE
fix: pin orbit-aggregation to 4.37.0 to restore test discovery

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,6 +50,14 @@ jobs:
         # Run pmd:pmd and pmd:cpd first to generate reports for all modules, then run pmd:check and pmd:cpd-check
         # This ensures all violations are collected and reported before the build fails
         run: xvfb-run mvn clean verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check -f ./ddk-parent/pom.xml --batch-mode --fail-at-end
+      - name: Fail on missing surefire reports
+        # Tycho-Surefire writes no TEST-*.xml when discovery is empty — fail the job in that case.
+        if: always()
+        run: |
+          if ! find . -path '*/target/surefire-reports/TEST-*.xml' -print -quit | grep -q .; then
+            echo "::error::No surefire reports found. Test discovery is likely broken."
+            exit 1
+          fi
       - name: Archive Tycho Surefire Plugin
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7

--- a/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/builder/XtextBuildTriggerTest.java
+++ b/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/builder/XtextBuildTriggerTest.java
@@ -23,7 +23,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.xtext.builder.impl.BuildScheduler;
-import org.eclipse.xtext.builder.impl.IBuildFlag;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.extensions.InjectionExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +59,7 @@ public class XtextBuildTriggerTest {
     // auto-build disabled
     when(workspace.isAutoBuilding()).thenReturn(false);
     buildTrigger.scheduleFullBuild();
-    verify(scheduler, never()).scheduleBuildIfNecessary(ArgumentMatchers.<Iterable<IProject>> any(), ArgumentMatchers.<IBuildFlag> any());
+    verify(scheduler, never()).scheduleBuildIfNecessary(ArgumentMatchers.<Iterable<IProject>> any());
 
     reset(workspace);
     reset(scheduler);
@@ -72,6 +71,6 @@ public class XtextBuildTriggerTest {
     when(workspace.getRoot()).thenReturn(root);
     when(root.getProjects()).thenReturn(projects);
     buildTrigger.scheduleFullBuild();
-    verify(scheduler).scheduleBuildIfNecessary(eq(Arrays.asList(projects)), ArgumentMatchers.<IBuildFlag[]> any());
+    verify(scheduler).scheduleBuildIfNecessary(eq(Arrays.asList(projects)));
   }
 }

--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="DDK Target" sequenceNumber="26">
+<target name="DDK Target" sequenceNumber="27">
 <locations>
   <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
   <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -19,10 +19,6 @@
   <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
   <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
   <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.39.0/"/>
-  </location>
-  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-    <unit id="org.eclipse.uml2.sdk.feature.group" version="0.0.0"/>
-    <repository location="https://download.eclipse.org/releases/2022-12/202212071000/"/>
   </location>
   <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
     <unit id="org.eclipse.xtend" version="0.0.0"/>
@@ -46,23 +42,27 @@
     <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
   </location>
   <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-    <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.39.0"/>
-    <unit id="net.bytebuddy.byte-buddy" version="1.18.5"/>
-    <unit id="org.objenesis" version="3.5.0"/>
-    <unit id="org.mockito.mockito-core" version="5.21.0"/>
+    <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.37.0"/>
+    <unit id="net.bytebuddy.byte-buddy" version="1.17.7"/>
+    <unit id="org.objenesis" version="3.4.0"/>
+    <unit id="org.mockito.mockito-core" version="5.19.0"/>
     <unit id="org.hamcrest" version="2.2.0"/>
     <unit id="org.apache.commons.logging" version="1.2.0"/>
-    <unit id="org.apache.commons.text" version="1.15.0"/>
-    <unit id="org.junit" version=" 4.13.2.v20240929-1000"/>
-    <unit id="org.apache.commons.lang3" version="3.20.0"/>
-    <unit id="org.apache.logging.log4j.core" version="2.25.3"/>
-    <unit id="org.apache.logging.log4j.api" version="2.25.3"/>
-    <unit id="org.apache.log4j" version="1.2.26"/> <!--use reload4j 1.2.26 for org.eclipse.xtext dependencies to log4j--> 
-  </location>
-  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-    <repository location="https://download.eclipse.org/tools/orbit/simrel/maven-osgi/release/4.39.0"/>
-    <unit id="junit-jupiter-api" version="5.14.3"/>
-    <unit id="junit-vintage-engine" version="5.14.3"/>
+    <unit id="org.apache.commons.text" version="1.14.0"/>
+    <unit id="org.junit" version="4.13.2.v20240929-1000"/>
+    <unit id="org.apache.commons.lang3" version="3.18.0"/>
+    <unit id="org.apache.logging.log4j.core" version="2.25.1"/>
+    <unit id="org.apache.logging.log4j.api" version="2.25.1"/>
+    <unit id="org.apache.log4j" version="1.2.26"/> <!--use reload4j 1.2.26 for org.eclipse.xtext dependencies to log4j-->
+    <unit id="junit-jupiter-api" version="5.13.4"/>
+    <unit id="junit-jupiter-engine" version="5.13.4"/>
+    <unit id="junit-jupiter-params" version="5.13.4"/>
+    <unit id="junit-vintage-engine" version="5.13.4"/>
+    <unit id="junit-platform-commons" version="1.13.4"/>
+    <unit id="junit-platform-engine" version="1.13.4"/>
+    <unit id="junit-platform-launcher" version="1.13.4"/>
+    <unit id="junit-platform-suite-api" version="1.13.4"/>
+    <unit id="junit-platform-suite-engine" version="1.13.4"/>
   </location>
 </locations>
 </target>


### PR DESCRIPTION
## Summary

Tests have been silently reporting `Tests run: 0` since #1292 (2026-04-01) bumped orbit-aggregation from 2025-09 to 4.39.0. Tycho-Surefire treats zero discovered tests as success, so CI stayed green while coverage dropped to nothing. This PR pins orbit to 4.37.0, restoring 307 tests across 75 classes.

## Why 4.37.0

orbit-aggregation 4.38.0+ ships every JUnit Jupiter / Platform / Vintage IU at **both** 5.x and 6.x simultaneously. Tycho's planner installs both families, leaving the OSGi runtime with two `Class<?>` instances of JUnit Platform types — `LinkageError` / `ArrayStoreException` / `ServiceConfigurationError` at test discovery, silently swallowed as `Tests run: 0`.

orbit 4.37.0 (Sept 2025) is the most recent release that ships JUnit at a single family (5.13.4 / Platform 1.13.4) and matches Eclipse 4.34's PDE JUnit runtime bridge. Pinning collapses the three JUnit-Platform-bearing classloaders (Tycho-Surefire's bundled provider, OSGi runtime, Eclipse PDE) onto a single agreed Platform version.

## Changes

- **`ddk-target/ddk.target`**: orbit-aggregation `4.39.0` → `4.37.0`; adjust dep versions to 4.37.0-era values (Mockito 5.21→5.19, byte-buddy 1.18.5→1.17.7, etc.); inline 9 JUnit IUs at 5.13.4 / 1.13.4; drop the now-redundant `maven-osgi/release/4.39.0` location (a second source of dual-version pollution) and the unused UML2 location at `releases/2022-12` (stealth source of additional 5.9.1/1.9.1 IUs).
- **`XtextBuildTriggerTest.java`**: drop the second `IBuildFlag` varargs matcher on two `verify()` sites — Mockito 5 enforces strict varargs counting, and the production `scheduleBuildIfNecessary(Iterable<IProject>)` is single-arg.
- **`.github/workflows/verify.yml`**: fail the job if no `TEST-*.xml` files were written under any module (Tycho-Surefire writes none when discovery is empty — precise guard against silent-zero).

## Verification

Local macOS aarch64 (`-Dosgi.os=macosx -Dosgi.ws=cocoa -Dosgi.arch=aarch64`, `-XstartOnFirstThread`, `--add-modules=jdk.incubator.vector`): 307 tests across 75 classes, 0 failures, ~1:29 wall clock. Tycho-Surefire's auto-detection selects the `junit5vintage` provider given Jupiter + vintage-engine on the classpath; no `<providerHint>` override is needed.

## Step 1 of 4

Step 1 of a staged JUnit cleanup: step 2 (#1324, #1325) migrates remaining JUnit 4 source surface to Jupiter, step 3 (#1326) drops `org.junit 4.13.2` and vintage-engine, step 4 (#1327) atomically upgrades to JUnit 6 + Eclipse 4.39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

