### PR TITLE
chore: exclude PMD InvalidLogMessageFormat (SLF4J trailing-Throwable convention)

### DIFF
--- a/ddk-configuration/pmd/ruleset.xml
+++ b/ddk-configuration/pmd/ruleset.xml
@@ -30,6 +30,7 @@
     <exclude name="DoNotTerminateVM"/>
     <exclude name="JumbledIncrementer"/><!--Checkstyle-->
     <exclude name="EmptyCatchBlock"/><!--Checkstyle-->
+    <exclude name="InvalidLogMessageFormat"/><!--Conflicts with the SLF4J trailing-Throwable idiom `LOGGER.x("...{}...", arg, throwable)`, which SLF4J documents as the intended way to log a parameterized message with an exception. See https://www.slf4j.org/faq.html#paramException -->
     <exclude name="NullAssignment"/>
     <exclude name="SingleMethodSingleton"/>
     <exclude name="UseEqualsToCompareStrings"/><!--Checkstyle-->


### PR DESCRIPTION
PMD's `InvalidLogMessageFormat` rule flags the SLF4J idiom `LOGGER.x("...{}...", arg, throwable)` as an argument-count mismatch (1 placeholder vs 2 args). Per [SLF4J's FAQ](https://www.slf4j.org/faq.html#paramException) this is the documented and intended way to log a parameterized message together with an exception — SLF4J trims the trailing `Throwable`, uses the remaining args for placeholders, and attaches the `Throwable` to the log event for stack-trace rendering. Excluding the rule in `ddk-configuration/pmd/ruleset.xml` removes the per-site `// NOPMD` noise that would otherwise be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)