### PR TITLE
ci: split static-analysis into 4 parallel jobs (timing comparison vs #1333)

### DIFF
--- a/.github/scripts/annotate-violations.py
+++ b/.github/scripts/annotate-violations.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Annotate PMD, Checkstyle, and SpotBugs violations as GitHub workflow commands.
+
+Walks `target/` reports under GITHUB_WORKSPACE, emits one `::warning` or `::error`
+per violation (rendered inline on the PR's Files-changed view), and exits 1 if any
+violation was found so the workflow step fails fast.
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+
+def make_emit(root: Path):
+    count = 0
+
+    def emit(level: str, file, line, title: str, msg: str | None) -> None:
+        nonlocal count
+        count += 1
+        text = (msg or '').strip().replace('\n', ' ')[:1000]
+        try:
+            rel = Path(file).relative_to(root)
+        except ValueError:
+            rel = file
+        print(f"::{level} file={rel},line={line},title={title}::{text}")
+
+    return emit, lambda: count
+
+
+def parse_pmd(root: Path, emit) -> None:
+    for xml in root.rglob('target/pmd.xml'):
+        for f in ET.parse(xml).getroot().findall('file'):
+            for v in f.findall('violation'):
+                level = 'error' if v.attrib.get('priority') == '1' else 'warning'
+                emit(level, f.attrib['name'], v.attrib.get('beginline', '1'),
+                     f"PMD/{v.attrib.get('rule', '')}", v.text)
+
+
+def parse_checkstyle(root: Path, emit) -> None:
+    for xml in root.rglob('target/checkstyle-result.xml'):
+        for f in ET.parse(xml).getroot().findall('file'):
+            for e in f.findall('error'):
+                level = 'error' if e.attrib.get('severity') == 'error' else 'warning'
+                emit(level, f.attrib['name'], e.attrib.get('line', '1'),
+                     f"Checkstyle/{e.attrib.get('source', '').split('.')[-1]}",
+                     e.attrib.get('message', ''))
+
+
+def parse_spotbugs(root: Path, emit) -> None:
+    for xml in root.rglob('target/spotbugsXml.xml'):
+        # SpotBugs sourcepath is package-relative (e.g. "com/avaloq/tools/ddk/Foo.java"),
+        # not repo-relative — combine with the module's source root so GitHub renders the
+        # annotation inline on the file in the PR's Files-changed view.
+        module_dir = xml.parent.parent
+        for b in ET.parse(xml).getroot().findall('BugInstance'):
+            sl = b.find('SourceLine')
+            lm = b.find('LongMessage')
+            if sl is None or lm is None:
+                continue
+            sourcepath = sl.attrib.get('sourcepath', '?')
+            file_path = None
+            for src_root in ('src', 'src/main/java', 'src-gen'):
+                candidate = module_dir / src_root / sourcepath
+                if candidate.exists():
+                    file_path = candidate
+                    break
+            if file_path is None:
+                file_path = module_dir / sourcepath
+            emit('warning', file_path, sl.attrib.get('start', '1'),
+                 f"SpotBugs/{b.attrib.get('type', '')}", lm.text)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--pmd', action='store_true', help='annotate PMD violations')
+    parser.add_argument('--checkstyle', action='store_true', help='annotate Checkstyle violations')
+    parser.add_argument('--spotbugs', action='store_true', help='annotate SpotBugs violations')
+    args = parser.parse_args()
+
+    if not (args.pmd or args.checkstyle or args.spotbugs):
+        parser.error('pick at least one of --pmd, --checkstyle, --spotbugs')
+
+    root = Path(os.environ.get('GITHUB_WORKSPACE', '.'))
+    emit, total = make_emit(root)
+
+    if args.pmd:
+        parse_pmd(root, emit)
+    if args.checkstyle:
+        parse_checkstyle(root, emit)
+    if args.spotbugs:
+        parse_spotbugs(root, emit)
+
+    kinds = ' + '.join(k for k, on in (('PMD', args.pmd), ('Checkstyle', args.checkstyle), ('SpotBugs', args.spotbugs)) if on)
+    print(f"{kinds} violations: {total()}")
+    return 1 if total() > 0 else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,62 +4,6 @@ on:
     branches: [master]
   pull_request:
 jobs:
-  static-analysis:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      - name: Set up Workspace Environment Variable
-        run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
-      - name: Cache Maven dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
-        with:
-          path: /home/runner/.m2/repository
-          key: ${{ runner.os }}-maven-0-${{ hashFiles('**/pom.xml') }}
-      - name: Compile + generate PMD/Checkstyle reports
-        # Report goals (pmd:pmd, pmd:cpd, checkstyle:checkstyle) never fail the build, so
-        # every module's XML is produced — no Maven cascade-skip. `compile` runs in the
-        # same invocation so PMD's type-resolving rules (e.g. InvalidLogMessageFormat) get
-        # the aux-classpath they need; without it, those rules misfire on idioms like
-        # SLF4J's trailing-Throwable pattern.
-        run: |
-          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
-            compile \
-            pmd:pmd pmd:cpd \
-            checkstyle:checkstyle
-      - name: Annotate + count PMD/Checkstyle violations
-        # Emits one GitHub workflow-command annotation per violation (visible inline in
-        # PR Files-changed) and exits 1 if any are found — fail-fast that bypasses
-        # SpotBugs (slow) when PMD/Checkstyle already has issues. Runs even if a previous
-        # step failed.
-        if: always()
-        run: python3 .github/scripts/annotate-violations.py --pmd --checkstyle
-      - name: Enforce PMD/Checkstyle thresholds (Maven safety-net)
-        # Redundant in the success case (Python check above already passed). Provides
-        # official-tool validation in case the Python parser misreads schema. `compile`
-        # is required in this invocation too — pmd:check re-runs analysis from scratch
-        # rather than reading the prior pmd.xml, so it needs its own aux-classpath.
-        run: |
-          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
-            compile \
-            pmd:check pmd:cpd-check \
-            checkstyle:check
-      - name: Generate SpotBugs report
-        run: |
-          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
-            compile \
-            spotbugs:spotbugs
-      - name: Annotate + count SpotBugs violations
-        if: always()
-        run: python3 .github/scripts/annotate-violations.py --spotbugs
-      - name: Enforce SpotBugs threshold (Maven safety-net)
-        run: |
-          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
-            compile \
-            spotbugs:check
   line-endings:
     runs-on: ubuntu-24.04
     steps:
@@ -78,6 +22,90 @@ jobs:
             echo "$violations"
             exit 1
           fi
+  pmd-checkstyle-analyze:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Set up Workspace Environment Variable
+        run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
+      - name: Cache Maven dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: /home/runner/.m2/repository
+          key: ${{ runner.os }}-maven-0-${{ hashFiles('**/pom.xml') }}
+      - name: Compile + generate PMD/Checkstyle reports
+        # Report goals never fail the build, so every module's XML is produced — no
+        # Maven cascade-skip. `compile` runs in the same invocation so PMD's
+        # type-resolving rules (e.g. InvalidLogMessageFormat) get the aux-classpath they
+        # need; without it, those rules misfire on idioms like SLF4J's trailing-Throwable.
+        run: |
+          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
+            compile \
+            pmd:pmd pmd:cpd \
+            checkstyle:checkstyle
+      - name: Annotate + count PMD/Checkstyle violations
+        # Emits one GitHub workflow-command annotation per violation (visible inline in
+        # PR Files-changed) and exits 1 if any are found. Runs even if a previous step
+        # failed so partial reports still surface as annotations.
+        if: always()
+        run: python3 .github/scripts/annotate-violations.py --pmd --checkstyle
+  spotbugs-analyze:
+    runs-on: ubuntu-24.04
+    env:
+      MAVEN_OPTS: -Xmx4g
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Set up Workspace Environment Variable
+        run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
+      - name: Cache Maven dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: /home/runner/.m2/repository
+          key: ${{ runner.os }}-maven-0-${{ hashFiles('**/pom.xml') }}
+      - name: Compile + generate SpotBugs report
+        run: |
+          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
+            compile \
+            spotbugs:spotbugs
+      - name: Annotate + count SpotBugs violations
+        if: always()
+        run: python3 .github/scripts/annotate-violations.py --spotbugs
+  maven-gate:
+    # Authoritative Maven-side validation. Runs every analyzer's :check goal in one
+    # invocation so they share aux-classpath and JVM state. Defense against the Python
+    # parser misreading XML schema; if Maven and Python ever disagree on violations,
+    # this job surfaces the divergence.
+    runs-on: ubuntu-24.04
+    env:
+      MAVEN_OPTS: -Xmx4g
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Set up Workspace Environment Variable
+        run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
+      - name: Cache Maven dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: /home/runner/.m2/repository
+          key: ${{ runner.os }}-maven-0-${{ hashFiles('**/pom.xml') }}
+      - name: Compile + run all :check goals
+        run: |
+          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
+            compile \
+            pmd:check pmd:cpd-check \
+            checkstyle:check \
+            spotbugs:check
   maven-verify:
     runs-on: ubuntu-24.04
     steps:
@@ -97,6 +125,9 @@ jobs:
           path: /home/runner/.m2/repository
           key: ${{ runner.os }}-maven-0-${{ hashFiles('**/pom.xml') }}
       - name: Build with Maven within a virtual X Server Environment
+        # Tests aren't safely parallelizable across modules in this codebase (shared
+        # workspace state), so no -T flag here. Static-analysis :check goals are
+        # handled in the maven-gate job, not duplicated here.
         run: xvfb-run mvn clean verify -f ./ddk-parent/pom.xml --batch-mode --fail-at-end
       - name: Fail on missing surefire reports
         # Tycho-Surefire writes no TEST-*.xml when discovery is empty — fail the job in that case.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
   pull_request:
 jobs:
-  pmd:
+  static-analysis:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -14,20 +14,52 @@ jobs:
           java-version: '21'
       - name: Set up Workspace Environment Variable
         run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
-      - name: PMD Check
-        run: mvn pmd:pmd pmd:cpd pmd:check pmd:cpd-check -f ./ddk-parent/pom.xml --batch-mode --fail-at-end
-  checkstyle:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
+      - name: Cache Maven dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
-          distribution: 'temurin'
-          java-version: '21'
-      - name: Set up Workspace Environment Variable
-        run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
-      - name: Checkstyle Check
-        run: mvn checkstyle:checkstyle checkstyle:check -f ./ddk-parent/pom.xml --batch-mode --fail-at-end
+          path: /home/runner/.m2/repository
+          key: ${{ runner.os }}-maven-0-${{ hashFiles('**/pom.xml') }}
+      - name: Compile + generate PMD/Checkstyle reports
+        # Report goals (pmd:pmd, pmd:cpd, checkstyle:checkstyle) never fail the build, so
+        # every module's XML is produced — no Maven cascade-skip. `compile` runs in the
+        # same invocation so PMD's type-resolving rules (e.g. InvalidLogMessageFormat) get
+        # the aux-classpath they need; without it, those rules misfire on idioms like
+        # SLF4J's trailing-Throwable pattern.
+        run: |
+          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
+            compile \
+            pmd:pmd pmd:cpd \
+            checkstyle:checkstyle
+      - name: Annotate + count PMD/Checkstyle violations
+        # Emits one GitHub workflow-command annotation per violation (visible inline in
+        # PR Files-changed) and exits 1 if any are found — fail-fast that bypasses
+        # SpotBugs (slow) when PMD/Checkstyle already has issues. Runs even if a previous
+        # step failed.
+        if: always()
+        run: python3 .github/scripts/annotate-violations.py --pmd --checkstyle
+      - name: Enforce PMD/Checkstyle thresholds (Maven safety-net)
+        # Redundant in the success case (Python check above already passed). Provides
+        # official-tool validation in case the Python parser misreads schema. `compile`
+        # is required in this invocation too — pmd:check re-runs analysis from scratch
+        # rather than reading the prior pmd.xml, so it needs its own aux-classpath.
+        run: |
+          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
+            compile \
+            pmd:check pmd:cpd-check \
+            checkstyle:check
+      - name: Generate SpotBugs report
+        run: |
+          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
+            compile \
+            spotbugs:spotbugs
+      - name: Annotate + count SpotBugs violations
+        if: always()
+        run: python3 .github/scripts/annotate-violations.py --spotbugs
+      - name: Enforce SpotBugs threshold (Maven safety-net)
+        run: |
+          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
+            compile \
+            spotbugs:check
   line-endings:
     runs-on: ubuntu-24.04
     steps:
@@ -64,10 +96,8 @@ jobs:
         with:
           path: /home/runner/.m2/repository
           key: ${{ runner.os }}-maven-0-${{ hashFiles('**/pom.xml') }}
-      - name: Build with Maven  within a virtual X Server Environment
-        # Run pmd:pmd and pmd:cpd first to generate reports for all modules, then run pmd:check and pmd:cpd-check
-        # This ensures all violations are collected and reported before the build fails
-        run: xvfb-run mvn clean verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check -f ./ddk-parent/pom.xml --batch-mode --fail-at-end
+      - name: Build with Maven within a virtual X Server Environment
+        run: xvfb-run mvn clean verify -f ./ddk-parent/pom.xml --batch-mode --fail-at-end
       - name: Fail on missing surefire reports
         # Tycho-Surefire writes no TEST-*.xml when discovery is empty — fail the job in that case.
         if: always()


### PR DESCRIPTION
**Comparison PR — do not merge.** Built off #1333's tip (`deaf0ba`) so the python script and compile-in-same-invocation fix are inherited. Restructures only the CI shape.

## Structure

| Job | Goals | Threads | Heap |
|---|---|---|---|
| `line-endings` | git ls-files | n/a | default |
| `pmd-checkstyle-analyze` | `compile + pmd:pmd + pmd:cpd + checkstyle:checkstyle` + python annotate | -T 2C | default |
| `spotbugs-analyze` | `compile + spotbugs:spotbugs` + python annotate | -T 2C | -Xmx4g |
| `maven-gate` | `compile + pmd:check + pmd:cpd-check + checkstyle:check + spotbugs:check` | -T 2C | -Xmx4g |
| `maven-verify` | `xvfb-run mvn clean verify` (no checks, no -T) | none | default |

All siblings, no `needs:`. Wall-clock = max of any single job.

## Goal of this comparison

#1333 (sequential single static-analysis job) measured at **32m 49s** on a recent run. Master's design is **~20m**. This PR tests whether splitting into independent parallel jobs gets us close to master's wall-clock while keeping #1333's correctness fix (compile-in-same-invocation for type-resolving PMD rules).

## Branch protection

If this lands instead of #1333, required checks must change: drop `static-analysis`, add `pmd-checkstyle-analyze`, `spotbugs-analyze`, `maven-gate`. Keep `line-endings` and `maven-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)