### PR TITLE
build: remove obsolete Solaris profile

### DIFF
--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -399,20 +399,6 @@
     <profile>
       <activation>
         <os>
-          <name>sunos</name>
-          <family>unix</family>
-        </os>
-      </activation>
-      <id>solaris</id>
-      <properties>
-        <osgi.os>solaris</osgi.os>
-        <osgi.ws>gtk</osgi.ws>
-        <osgi.arch>x86</osgi.arch>
-      </properties>
-    </profile>
-    <profile>
-      <activation>
-        <os>
           <name>linux</name>
           <arch>amd64</arch>
           <family>unix</family>


### PR DESCRIPTION
Removes the `solaris` profile from `ddk-parent/pom.xml`. SunOS/Solaris is no longer a supported target platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)