### PR TITLE
fix: drop Export-Package entries for deleted JUnit 4 packages

### DIFF
--- a/com.avaloq.tools.ddk.test.core/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.test.core/META-INF/MANIFEST.MF
@@ -21,7 +21,6 @@ Require-Bundle: org.eclipse.core.runtime,
 Import-Package: org.apache.logging.log4j
 Export-Package: com.avaloq.tools.ddk.test.core,
  com.avaloq.tools.ddk.test.core.data,
- com.avaloq.tools.ddk.test.core.junit.runners,
  com.avaloq.tools.ddk.test.core.jupiter,
  com.avaloq.tools.ddk.test.core.mock,
  com.avaloq.tools.ddk.test.core.util

--- a/com.avaloq.tools.ddk.test.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.test.ui/META-INF/MANIFEST.MF
@@ -25,7 +25,6 @@ Require-Bundle: com.avaloq.tools.ddk.test.core,
  org.eclipse.emf.common,
  com.avaloq.tools.ddk
 Export-Package: com.avaloq.tools.ddk.test.ui,
- com.avaloq.tools.ddk.test.ui.junit.runners,
  com.avaloq.tools.ddk.test.ui.swtbot,
  com.avaloq.tools.ddk.test.ui.swtbot.condition,
  com.avaloq.tools.ddk.test.ui.swtbot.util

--- a/com.avaloq.tools.ddk.xtext.test.core/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.test.core/META-INF/MANIFEST.MF
@@ -28,17 +28,8 @@ Require-Bundle: com.avaloq.tools.ddk.xtext,
  junit-jupiter-api
 Import-Package: org.apache.logging.log4j
 Export-Package: com.avaloq.tools.ddk.xtext.test,
- com.avaloq.tools.ddk.xtext.test.contentassist,
- com.avaloq.tools.ddk.xtext.test.conversion,
- com.avaloq.tools.ddk.xtext.test.formatting,
- com.avaloq.tools.ddk.xtext.test.generator,
- com.avaloq.tools.ddk.xtext.test.junit.runners,
  com.avaloq.tools.ddk.xtext.test.jupiter,
  com.avaloq.tools.ddk.xtext.test.jvmmodel,
- com.avaloq.tools.ddk.xtext.test.linking,
  com.avaloq.tools.ddk.xtext.test.model,
- com.avaloq.tools.ddk.xtext.test.modelinference,
- com.avaloq.tools.ddk.xtext.test.resource,
- com.avaloq.tools.ddk.xtext.test.scoping,
  com.avaloq.tools.ddk.xtext.test.validation
 Automatic-Module-Name: com.avaloq.tools.ddk.xtext.test.core


### PR DESCRIPTION
Three `MANIFEST.MF` files still listed `Export-Package` entries for packages removed in the JUnit 4 cleanup. Eclipse PDE flags these as "Plug-in Problem" markers:

> Package 'com.avaloq.tools.ddk.xtext.test.contentassist' does not exist in this plug-in

Affected manifests:

- `com.avaloq.tools.ddk.test.core/META-INF/MANIFEST.MF` — drops `test.core.junit.runners`
- `com.avaloq.tools.ddk.test.ui/META-INF/MANIFEST.MF` — drops `test.ui.junit.runners`
- `com.avaloq.tools.ddk.xtext.test.core/META-INF/MANIFEST.MF` — drops 9 entries (`contentassist`, `conversion`, `formatting`, `generator`, `junit.runners`, `linking`, `modelinference`, `resource`, `scoping`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)