### PR TITLE
fix: restore missing listAttribute opener in ExportTestSuite.launch

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export.test/ExportTestSuite.launch
+++ b/com.avaloq.tools.ddk.xtext.export.test/ExportTestSuite.launch
@@ -14,6 +14,7 @@
 <booleanAttribute key="includeOptional" value="true"/>
 <stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
 <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
 <listEntry value="/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/test/export/ExportTestSuite.java"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">


### PR DESCRIPTION
The opening `<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">` tag was dropped in 38918bcad (`feat: use junit5 platform in our tests`), which replaced it with the new `ATTR_FORCE_SYSTEM_CONSOLE_ENCODING` attribute instead of inserting alongside. The following `<listEntry>` and `</listAttribute>` have been orphaned ever since, leaving the file malformed XML.

Eclipse PDE's launch-config parser was lenient enough to keep the launch usable, but Eclipse's XML language server now flags it as a parse error:

> The element type "launchConfiguration" must be terminated by the matching end-tag "</launchConfiguration>". [ETagRequired]

`xmllint --noout` confirms the file is well-formed after the fix; all other `.launch` files in the repo were already valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)