### PR TITLE
build: per-module test execution via tycho-build extension (PoC)

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export.test/pom.xml
+++ b/com.avaloq.tools.ddk.xtext.export.test/pom.xml
@@ -11,4 +11,85 @@
   <artifactId>com.avaloq.tools.ddk.xtext.export.test</artifactId>
   <packaging>eclipse-test-plugin</packaging>
 
+  <!--
+    Opt-in to per-module test execution. Default (`ddk.skipPerModuleTests=true`)
+    leaves test execution to the aggregator in `com.avaloq.tools.ddk.xtext.test`,
+    so default `mvn verify` runs the export tests exactly once. Focused
+    iteration uses:
+
+      mvn verify -pl :com.avaloq.tools.ddk.xtext.export.test -am \
+                 -Dddk.skipPerModuleTests=false -f ./ddk-parent/pom.xml
+  -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+          <skip>${ddk.skipPerModuleTests}</skip>
+          <testClass>com.avaloq.tools.ddk.xtext.test.export.ExportTestSuite</testClass>
+          <failIfNoTests>false</failIfNoTests>
+          <useUIThread>false</useUIThread>
+          <useUIHarness>true</useUIHarness>
+          <forkedProcessTimeoutInSeconds>${test.timeout}</forkedProcessTimeoutInSeconds>
+          <!--
+            `-Dorg.osgi.framework.system.packages.extra=jdk.incubator.vector`
+            is required on macOS where Adoptium/Temurin JDKs do not expose
+            the incubator module that Lucene 9.12 (transitively required by
+            org.eclipse.help.base, pulled in by `org.eclipse.help` feature)
+            imports. Without it, the Eclipse OSGi framework fails to resolve
+            org.eclipse.help.base at runtime startup.
+          -->
+          <argLine>-Dorg.osgi.framework.system.packages.extra=jdk.incubator.vector -Dslf4j.internal.verbosity=ERROR -Dlogback.configurationFile="${runtime.logbackConfig}" ${test.javaOptions}</argLine>
+          <appArgLine>-pluginCustomization ${runtime.pluginCustomization}</appArgLine>
+          <product>${runtime.product}</product>
+          <application>org.eclipse.ui.ide.workbench</application>
+          <dependencies>
+            <dependency>
+              <type>p2-installable-unit</type>
+              <artifactId>org.eclipse.platform.feature.group</artifactId>
+            </dependency>
+          </dependencies>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho.version}</version>
+        <configuration>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.xtext.sdk</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.pde</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.help</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.rcp</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.event</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -64,6 +64,17 @@
     <!-- Baseline version validation -->
     <baseline.repo.url>https://dsldevkit.github.io/dsl-devkit/p2/releases/latest/</baseline.repo.url>
     <snapshot.repo.url>https://dsldevkit.github.io/dsl-devkit/p2/snapshots/latest/</snapshot.repo.url>
+
+    <!--
+      Opt-in flag for per-module tycho-surefire execution. Defaults to `true`
+      so that the aggregator in `com.avaloq.tools.ddk.xtext.test` remains the
+      single point of test execution (no double-execution of tests already
+      pulled in via the aggregator's Require-Bundle path). Per-module test
+      bundles that have their own tycho-surefire configuration should bind
+      their `<skip>` to this property so that focused dev workflows can opt
+      in via `-Dddk.skipPerModuleTests=false -pl :the.module -am`.
+    -->
+    <ddk.skipPerModuleTests>true</ddk.skipPerModuleTests>
   </properties>
 
   <modules>


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #1283.** The bottom commit is #1283 (`build: enable UI tests on macOS via Tycho profile + JRE docs`). This PR contains 3 additional commits on top. CI failures here until #1283 lands are expected; rebase onto `master` once #1283 merges.

## Summary

Proof of concept demonstrating that **per-module Maven test execution is viable** for this codebase via two changes:

1. Register `tycho-build` as a Maven core extension so `-am` walks OSGi `Require-Bundle` / `Import-Package` dependencies (Maven natively only walks `<dependency>` blocks, which are empty for Tycho bundles).
2. Add an opt-in property gate (`ddk.skipPerModuleTests`, default `true`) for per-module surefire blocks, so that opting modules in does not double-execute tests already discovered by the aggregator in `com.avaloq.tools.ddk.xtext.test`.

The PoC pilots the pattern on `com.avaloq.tools.ddk.xtext.export.test` (smallest blast radius). After this lands, the same shape can be applied to other `*.test` modules on demand.

## Commits

1. **`build: add tycho-build extension`** — `.mvn/extensions.xml` + `.mvn/maven.config`. Version sourced from `${tycho.version}` to keep a single source of truth.
2. **`build: add ddk.skipPerModuleTests property`** — declares the property in `ddk-parent`. No behaviour change yet.
3. **`build: opt xtext.export.test into per-module test execution`** — adds full `tycho-surefire-plugin` + `target-platform-configuration` to the bundle, gated by the property. `<testClass>` points at `ExportTestSuite`. Mirrors `xtext.test`'s surefire block, with one extra `argLine` flag (`-Dorg.osgi.framework.system.packages.extra=jdk.incubator.vector`) needed on macOS for `org.eclipse.help.base` to resolve.

## Verification (run on this branch, JDK 21, macOS aarch64)

| # | Scenario | Command | Result |
|---|---|---|---|
| **B** | Cold sanity (tycho-build extension) | `find . -name target -type d -exec rm -rf {} + ; mvn -pl :check.core -am -DskipTests clean verify` | ✅ Reactor expanded from **1 project** (without extension) to **12 projects** (with extension), BUILD SUCCESS cold |
| **C** | Focused dev — standalone tests with override | `mvn verify -pl :xtext.export.test -am -Dddk.skipPerModuleTests=false` | ✅ Reactor 17 projects; `Tests run: 14, Failures: 0`; **21.2s** wall clock |
| **D** | Default behaviour — gate skips standalone | `mvn verify -pl :xtext.export.test -am` (default property=true) | ✅ `[INFO] Skipping tests` logged; export.test packaged in **1.0s** (vs 7.0s when tests ran) |
| **E** | Full-reactor double-execution proof | `mvn verify -Dddk.skipPerModuleTests=false` (full 60-project reactor) | ✅ **371 tests run** (357 aggregator + 14 standalone), two distinct surefire summaries, exit code 0, **1m30s** total wall clock |

### Empirical findings worth highlighting

- **Wall-clock is fast.** Full reactor with property flipped (every dependency built + aggregator + standalone) completes in **1m30s** on an M-series Mac. The aggregator alone consumes 1m05s of that. The 30-minute timeout in `AGENTS.md` reflects pessimism, not measured behaviour.
- **Double-execution is exactly as predicted.** Two surefire summaries land in the log: `Tests run: 14` (standalone) and `Tests run: 357` (aggregator). 357 matches the baseline test count on master (CI run on `d6897f240`). The 14 extra are the export tests running a second time as standalone — confirming the gate's intent.
- **Cost of opt-in (when enabled)**: an extra ~7 seconds of test execution + Eclipse runtime startup for export.test. Trivial. Most of the standalone runtime cost is amortized into reactor build steps that happen anyway.
- **The PoC is gated on #1283.** Without #1283's `macosx` Maven profile, the standalone test runtime fetches SWT-win32 (target environments default to `win32/win32/x86_64`), which can't load on macOS → `ClassNotFoundException: org.eclipse.swt.SWTError`. With #1283's macosx profile (sets `osgi.os=macosx, osgi.ws=cocoa, osgi.arch=aarch64` and appends `-XstartOnFirstThread`), the issue resolves cleanly. Documented as the stack dependency above.
- **The Lucene/`jdk.incubator.vector` cascade affects Maven surefire too**, not just `.launch` files. Same root cause as the existing open work; same fix (`-Dorg.osgi.framework.system.packages.extra=jdk.incubator.vector`). The aggregator likely has the same latent issue on macOS but no one runs it via plain `mvn verify` on Mac normally — CI is Linux, which doesn't trigger it. A broader fix is open as a follow-up.
- **Required environment for standalone Mac runs**: `JAVA_HOME` pointing to JDK 21 (project's BREE — `openjdk@21` on Homebrew; the default `openjdk` is 25 and has separate `sun.misc.Unsafe` issues), and `WORKSPACE=$(pwd)` (needed by the logback config path in `ddk-parent`).

## Usage

CI (unchanged):

```bash
mvn verify -f ./ddk-parent/pom.xml
```

Focused dev iteration on export tests only:

```bash
export WORKSPACE=\$(pwd)
mvn verify -pl :com.avaloq.tools.ddk.xtext.export.test -am \\
           -Dddk.skipPerModuleTests=false -f ./ddk-parent/pom.xml
```

## Known limitation

`tycho-build` is incompatible with `mvnd` — the embedded Takari SmartBuilder collides with tycho-build's dependency graph (`DependencyGraph` `ClassCastException` across `ClassRealm`s, independent of `-b` flag). Use plain `mvn` for `-am` workflows; `mvnd` remains usable for full-reactor builds without `-am`.

## Test plan

- [ ] CI runs `mvn verify` (default property) and aggregator tests pass without regression (357 tests, same as master baseline). Validates Scenario D under full CI load.
- [ ] CI runs `mvn verify -pl :com.avaloq.tools.ddk.xtext.export.test -am -Dddk.skipPerModuleTests=false` and 14 export tests pass standalone. Validates Scenario C on Linux.
- [ ] Once green: rebase onto master after #1283 merges; verify both scenarios still pass.

_Left by Claude at João's request._