### PR TITLE
build: add tycho-build extension for OSGi-aware reactor expansion

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>org.eclipse.tycho</groupId>
+    <artifactId>tycho-build</artifactId>
+    <version>${tycho.version}</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dtycho.version=5.0.2


### PR DESCRIPTION
## What

Adds `tycho-build` as a Maven core extension so `mvn -pl :<module> -am` walks Tycho's `Require-Bundle` graph when computing the reactor. Without it, `-am` only sees Maven `<dependency>` blocks, which are nearly empty in this codebase.

## Usage

```
mvn -pl :ddk-target,:<module> -am -DskipTests clean verify
```

(`:ddk-target` always required — target-platform references aren't part of the Maven dep graph.)

## mvnd

Incompatible — `DependencyGraph` `ClassCastException` across `ClassRealm`s. Tracked in [eclipse-tycho/tycho#266](https://github.com/eclipse-tycho/tycho/issues/266). Use plain `mvn` for `-am`.