### PR TITLE
chore: set line.separator=\n in source-bearing bundles (step 2/3)

### DIFF
--- a/com.avaloq.tools.ddk.check.core.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.core.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.core/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.core/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.lib/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.lib/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.runtime.core.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.runtime.core.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.runtime.core/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.runtime.core/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.runtime.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.runtime.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.test.runtime.tests/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.test.runtime.tests/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.test.runtime.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.test.runtime.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.test.runtime/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.test.runtime/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.ui.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.ui.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.check.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.check.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.checkcfg.core.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.checkcfg.core.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.checkcfg.core/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.checkcfg.core/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.checkcfg.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.checkcfg.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.checkcfg.ui.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.checkcfg.ui.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.checkcfg.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.checkcfg.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.sample.helloworld.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.sample.helloworld.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.sample.helloworld.ui.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.sample.helloworld.ui.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.sample.helloworld.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.sample.helloworld.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.sample.helloworld/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.sample.helloworld/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.test.core/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.test.core/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.test.ui.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.test.ui.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.test.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.test.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.typesystem.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.typesystem.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.typesystem/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.typesystem/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.workflow/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.workflow/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.builder/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.builder/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.check.generator/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.check.generator/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.common.types.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.common.types.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.common.types/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.common.types/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.export.generator/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.export.generator/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.export.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.export.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.export.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.export.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.export.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.export.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.export/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.export/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.expression.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.expression.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.expression.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.expression.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.expression/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.expression/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.format.generator/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.format.generator/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.format.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.format.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.format.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.format.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.format.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.format.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.format/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.format/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.generator.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.generator.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.generator/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.generator/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.scope.generator/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.scope.generator/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.scope.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.scope.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.scope.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.scope.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.scope/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.scope/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.test.core/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.test.core/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.ui.test/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.ui.test/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.valid.ide/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.valid.ide/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.valid.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.valid.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext.valid/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext.valid/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/com.avaloq.tools.ddk.xtext/.settings/org.eclipse.core.runtime.prefs
+++ b/com.avaloq.tools.ddk.xtext/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n


### PR DESCRIPTION
## What

Step 2 of the LF-alignment stack. Fixes **Eclipse-side** emission (the IDE save path).

Adds `.settings/org.eclipse.core.runtime.prefs` to 59 source-bearing bundles (every bundle with a `src/` directory that didn't already have one). Each new file is two lines:

```properties
eclipse.preferences.version=1
line.separator=\n
```

## Why

`EclipseResourceFileSystemAccess2` (the FSA Xtext uses when generating from inside Eclipse) honours the project's `line.separator` preference. Without it, the **workspace default** applies — on Windows that's CRLF — producing committed src-gen that fights `.gitattributes` and the project's LF convention.

This is the second layer of the same fix:

- **Step 1** (#1352) fixed the Maven-side (MWE2) path
- **Step 2** (this PR) fixes the Eclipse-side path
- Step 3 will then be able to remove `LfNormalizingFileSystemAccess` (PR #1331) and close #1345

Only one bundle (`ddk-configuration`) had this preference before this PR, and step 1 fixed its previously-CRLF value. This PR propagates it to the remaining 59.

## Excluded bundles (intentionally)

- `ddk-target`, `ddk-repository`, `*.feature` bundles — no `src/` directory, no code emission.

## Stack

Stacked on `chore/emit-lf-step-1` (#1352). When step 1 merges, GitHub auto-retargets this PR's base to `master`.

## Verification

- `mvn clean verify -T 3C -f ./ddk-parent/pom.xml` is expected to pass — Maven ignores Eclipse-only `.settings/` content.
- After merge of steps 1+2, a Windows reviewer regenerating any `.check` / `.checkcfg` / `.scope` / `.format` / `.export` file in Eclipse should produce LF output natively (without the `LfNormalizingFileSystemAccess` decorator). This is the precondition for step 3.