### PR TITLE
fix: unused import warnings

### DIFF
--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/formatting/ExtendedFormattingConfigBasedStream.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/formatting/ExtendedFormattingConfigBasedStream.java
@@ -27,7 +27,6 @@ import java.util.Stack;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.osgi.util.NLS;
 import org.eclipse.xtext.AbstractElement;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.ParserRule;


### PR DESCRIPTION
Removed unused import statements that remained after the NLS.bind function calls were replaced.