### PR TITLE
build: align xtext to 2.43 in xtend-maven-plugin and antlr target

### DIFF
--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -55,7 +55,7 @@
     <pmd.plugin.version>3.28.0</pmd.plugin.version>
     <pmd.version>7.24.0</pmd.version>
     <tycho.version>5.0.2</tycho.version>
-    <xtend.version>2.42.0</xtend.version>
+    <xtend.version>2.43.0</xtend.version>
   </properties>
 
   <modules>

--- a/ddk-target/ddk-antlr.target
+++ b/ddk-target/ddk-antlr.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="DDK Target - ANTLR" sequenceNumber="6">
+<target name="DDK Target - ANTLR" sequenceNumber="7">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <repository location="https://download.itemis.com/updates/releases/2.1.1/" />
@@ -13,7 +13,7 @@
       <repository location="https://download.eclipse.org/releases/2022-12/202212071000/" />
       <repository location="https://download.eclipse.org/modeling/m2t/xpand/updates/releases/R201605260315/" />
       <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/" />
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.42.0/" />
+      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.43.0/" />
       <repository location="https://download.eclipse.org/lsp4j/updates/releases/1.0.0/" />
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository" />
     </location>


### PR DESCRIPTION
## Summary

Two pinned `2.42.0` references were left behind after the upgrade that moved `ddk-target/ddk.target` to xtext `2.43.0`:

- `ddk-parent/pom.xml`: `<xtend.version>` → `2.43.0`
- `ddk-target/ddk-antlr.target`: itemis xtext-antlr repo URL → `releases/2.43.0/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)