### PR TITLE
fix: ScopingFragment2 declares RUNTIME_PLUGIN on the eclipse-plugin manifest (not runtime)

### DIFF
--- a/com.avaloq.tools.ddk.xtext.scope.generator/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopingFragment2.java
+++ b/com.avaloq.tools.ddk.xtext.scope.generator/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopingFragment2.java
@@ -44,7 +44,7 @@ public class ScopingFragment2 extends AbstractXtextGeneratorFragment {
     }
 
     if (getProjectConfig().getEclipsePlugin().getManifest() != null) {
-      getProjectConfig().getRuntime().getManifest().getRequiredBundles().add(RUNTIME_PLUGIN);
+      getProjectConfig().getEclipsePlugin().getManifest().getRequiredBundles().add(RUNTIME_PLUGIN);
     }
   }
 }


### PR DESCRIPTION
`ScopingFragment2.generate()` guards on `getEclipsePlugin().getManifest() != null` but adds `RUNTIME_PLUGIN` to `getRuntime().getManifest()` (already present → no-op), so generated UI plugins never get `com.avaloq.tools.ddk.xtext` declared as a required bundle. All six sibling `*Fragment2` generators write to `eclipsePlugin.manifest` in this block; this aligns `ScopingFragment2` with them.

Latent — not an active break: current consumers don't reference `com.avaloq.tools.ddk.xtext` packages directly. Pre-existing on master; the Xtend→Java migration (#1380) faithfully preserved it, this corrects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
