### PR TITLE
chore: enable the PMD UnnecessaryImport rule

### DIFF
--- a/ddk-configuration/pmd/ruleset.xml
+++ b/ddk-configuration/pmd/ruleset.xml
@@ -120,7 +120,6 @@
     <exclude name="ShortVariable"/> <!--  not sensible -->
     <exclude name="TooManyStaticImports"/>
     <exclude name="UnnecessaryAnnotationValueElement"/>
-    <exclude name="UnnecessaryImport"/><!--Too many false positives after PMD 7 -->
     <exclude name="UnnecessaryModifier"/><!--Checkstyle-->
     <exclude name="UnnecessaryFullyQualifiedName"/>
     <exclude name="UnnecessaryLocalBeforeReturn"/>


### PR DESCRIPTION
Re-enables the `UnnecessaryImport` PMD rule (previously excluded with *"too many false positives after PMD 7"*).

**Blast radius: zero.** `mvn pmd:check` across the full reactor reports **0** `UnnecessaryImport` violations on current master. Generated roots (`src-gen`, `src-model`, `xtend-gen`) are already excluded from PMD, so only hand-written `src/` is scanned — and it's clean. The exclusion comment is stale.

Going forward this catches unused imports in hand-written source (nothing else in CI does — checkstyle has no unused-import rule; it would have caught e.g. the Javadoc-only imports recently cleaned up in the Xtend→Java migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)