### PR TITLE
fix: correct NLS bundle name in xtext.ui Messages

### DIFF
--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/Messages.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/Messages.java
@@ -17,7 +17,7 @@ import org.eclipse.osgi.util.NLS;
  * Internationalization: messages.
  */
 public final class Messages extends NLS {
-  private static final String BUNDLE_NAME = "om.avaloq.tools.ddk.xtext.ui"; //$NON-NLS-1$
+  private static final String BUNDLE_NAME = "com.avaloq.tools.ddk.xtext.ui.messages"; //$NON-NLS-1$
   // CHECKSTYLE:OFF
   public static String AbstractAcfLabelProvider_NULL;
   public static String AbstractAcfLabelProvider_NAME_FALLBACK;


### PR DESCRIPTION
`Messages.BUNDLE_NAME` was `"om.avaloq.tools.ddk.xtext.ui"` — missing the leading `c` **and** the `.messages` segment — so `NLS.initializeMessages` could not find `com/avaloq/tools/ddk/xtext/ui/messages.properties`, leaving every `Messages` field as an unresolved-key placeholder.

Corrected to `"com.avaloq.tools.ddk.xtext.ui.messages"`, matching the properties-file location and the sibling `Messages` classes (e.g. `check.validation.Messages` → `…check.validation.messages`).

Found by a repo-wide inconsistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)