### PR TITLE
fix: guard pluginXml (not its never-null entries list) in CompareFragment2

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/ui/compare/CompareFragment2.xtend
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/ui/compare/CompareFragment2.xtend
@@ -67,7 +67,7 @@ class CompareFragment2 extends ResourceFactoryFragment2 {
     if (projectConfig.eclipsePlugin.manifest !== null) {
       projectConfig.eclipsePlugin.manifest.requiredBundles += bundleName
     }
-    if (projectConfig.eclipsePlugin.pluginXml.entries !== null) {
+    if (projectConfig.eclipsePlugin.pluginXml !== null) {
       projectConfig.eclipsePlugin.pluginXml.entries += eclipsePluginXmlContribution()
     }
   }


### PR DESCRIPTION
`CompareFragment2.generate()` guarded `if (projectConfig.eclipsePlugin.pluginXml.entries !== null)`. But `PluginXmlAccess.entries` is `val List … = newArrayList` — final and never null — so the guard is always true (never protects the intended null case) and dereferences `pluginXml.entries` *inside* the guard, NPEing when `pluginXml` itself is null.

Fixed to guard the container `pluginXml`, matching the adjacent `manifest != null` guard (line 67) and the superclass `ResourceFactoryFragment2` (which this class extends).

Found by a repo-wide inconsistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)