### PR TITLE
fix: null-safe fragment access in DefaultFragmentWithOverride.checkConfiguration

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/DefaultFragmentWithOverride.xtend
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/DefaultFragmentWithOverride.xtend
@@ -46,8 +46,8 @@ class DefaultFragmentWithOverride extends AbstractXtextGeneratorFragment {
   }
 
   override checkConfiguration(Issues issues) {
-    overrideFragment.checkConfiguration(issues)
-    defaultFragment.checkConfiguration(issues)
+    overrideFragment?.checkConfiguration(issues)
+    defaultFragment?.checkConfiguration(issues)
   }
 
 }


### PR DESCRIPTION
`DefaultFragmentWithOverride.defaultFragment` / `overrideFragment` are documented as optionally null ("or nothing if it is null"), and `generate()` and `initialize()` access them null-safely with `?.`. `checkConfiguration()` dereferenced them unconditionally → NPE whenever either is null. Added `?.` to match the rest of the class.

Found by a repo-wide inconsistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)