### PR TITLE
fix: declare loggers with the enclosing class, not another/super class

### DIFF
--- a/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/quickfix/DefaultCheckQuickfixProvider.java
+++ b/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/quickfix/DefaultCheckQuickfixProvider.java
@@ -56,7 +56,7 @@ import com.google.inject.name.Named;
  */
 public class DefaultCheckQuickfixProvider extends DefaultQuickfixProvider {
 
-  private static final Logger LOGGER = LogManager.getLogger(DefaultQuickfixProvider.class);
+  private static final Logger LOGGER = LogManager.getLogger(DefaultCheckQuickfixProvider.class);
 
   @Inject
   @Named(Constants.LANGUAGE_NAME)

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/CustomClassAwareEcoreGenerator.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/CustomClassAwareEcoreGenerator.java
@@ -44,7 +44,7 @@ import com.google.common.collect.Lists;
  */
 @SuppressWarnings("nls")
 public class CustomClassAwareEcoreGenerator extends EcoreGenerator {
-  private static final Logger LOGGER = LogManager.getLogger(EcoreGenerator.class);
+  private static final Logger LOGGER = LogManager.getLogger(CustomClassAwareEcoreGenerator.class);
 
   private String genModel;
   private final List<String> suppressedSrcPaths = Lists.newLinkedList();

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/EObjectDescriptions.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/EObjectDescriptions.java
@@ -33,7 +33,7 @@ import com.google.common.collect.Iterables;
 public final class EObjectDescriptions {
 
   /** Class-wide logger. */
-  private static final Logger LOGGER = LogManager.getLogger(NameFunctions.class);
+  private static final Logger LOGGER = LogManager.getLogger(EObjectDescriptions.class);
 
   /** No public instantiation. */
   private EObjectDescriptions() {


### PR DESCRIPTION
Three `LogManager.getLogger(...)` declarations used the wrong class literal, so their log records appear under an unrelated category:

| File | Was | Now |
|---|---|---|
| `EObjectDescriptions` | `NameFunctions.class` (unrelated class) | `EObjectDescriptions.class` |
| `DefaultCheckQuickfixProvider` | `DefaultQuickfixProvider.class` (superclass) | `DefaultCheckQuickfixProvider.class` |
| `CustomClassAwareEcoreGenerator` | `EcoreGenerator.class` (superclass) | `CustomClassAwareEcoreGenerator.class` |

Each declares its own `LOGGER` field, so the category should be the enclosing class. Found by a repo-wide inconsistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)