### PR TITLE
fix: always log the null-marker-creator error, not only when debug is enabled

### DIFF
--- a/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/validation/CheckMarkerUpdateJob.java
+++ b/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/validation/CheckMarkerUpdateJob.java
@@ -236,9 +236,7 @@ public class CheckMarkerUpdateJob extends Job {
         markerCreator.createMarker(issue, file, MarkerTypes.forCheckType(issue.getType()));
       }
     } else {
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.error("Could not create markers. The marker creator is null."); //$NON-NLS-1$
-      }
+      LOGGER.error("Could not create markers. The marker creator is null."); //$NON-NLS-1$
     }
   }
 


### PR DESCRIPTION
`CheckMarkerUpdateJob` logged *"Could not create markers. The marker creator is null."* at **ERROR** level but wrapped in `if (LOGGER.isDebugEnabled())`, so in production (debug off) a genuine failure to create markers was silently swallowed. Removed the `isDebugEnabled` guard — that guard is for gating expensive debug/trace output, not real errors.

Found by a repo-wide inconsistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)