### PR TITLE
fix: guard nullable workbench/page access before dereferencing

### DIFF
--- a/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/editor/PlatformPluginAwareEditorOpener.java
+++ b/com.avaloq.tools.ddk.check.runtime.ui/src/com/avaloq/tools/ddk/check/runtime/ui/editor/PlatformPluginAwareEditorOpener.java
@@ -78,15 +78,18 @@ public class PlatformPluginAwareEditorOpener extends LanguageSpecificURIEditorOp
       if (modelLocation != null) {
         PlatformPluginStorage storage = new PlatformPluginStorage(modelLocation);
         IEditorInput editorInput = new XtextReadonlyEditorInput(storage);
-        IWorkbenchPage activePage = workbench.getActiveWorkbenchWindow().getActivePage();
-        try {
-          IEditorPart editor = IDE.openEditor(activePage, editorInput, editorID);
-          selectAndReveal(editor, uri, crossReference, indexInList, select);
-          return EditorUtils.getXtextEditor(editor);
-        } catch (WrappedException e) {
-          LOG.error("Error while opening editor part for EMF URI '" + uri + "'", e.getCause()); //$NON-NLS-1$ //$NON-NLS-2$
-        } catch (PartInitException partInitException) {
-          LOG.error("Error while opening editor part for EMF URI '" + uri + "'", partInitException); //$NON-NLS-1$ //$NON-NLS-2$
+        final IWorkbenchWindow activeWorkbenchWindow = workbench.getActiveWorkbenchWindow();
+        if (activeWorkbenchWindow != null) {
+          IWorkbenchPage activePage = activeWorkbenchWindow.getActivePage();
+          try {
+            IEditorPart editor = IDE.openEditor(activePage, editorInput, editorID);
+            selectAndReveal(editor, uri, crossReference, indexInList, select);
+            return EditorUtils.getXtextEditor(editor);
+          } catch (WrappedException e) {
+            LOG.error("Error while opening editor part for EMF URI '" + uri + "'", e.getCause()); //$NON-NLS-1$ //$NON-NLS-2$
+          } catch (PartInitException partInitException) {
+            LOG.error("Error while opening editor part for EMF URI '" + uri + "'", partInitException); //$NON-NLS-1$ //$NON-NLS-2$
+          }
         }
       }
     }

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/navigation/CheckHyperlinkHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/navigation/CheckHyperlinkHelper.java
@@ -13,6 +13,8 @@ package com.avaloq.tools.ddk.check.ui.navigation;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.xtext.common.types.xtext.ui.TypeAwareHyperlinkHelper;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.resource.EObjectAtOffsetHelper;
@@ -39,8 +41,10 @@ public class CheckHyperlinkHelper extends TypeAwareHyperlinkHelper {
 
   @Override
   public void createHyperlinksByOffset(final XtextResource resource, final int offset, final IHyperlinkAcceptor acceptor) {
-    IEditorPart activeEditor = workbench.getActiveWorkbenchWindow().getActivePage().getActiveEditor();
-    if (activeEditor.getEditorInput() instanceof XtextReadonlyEditorInput) {
+    final IWorkbenchWindow activeWorkbenchWindow = workbench == null ? null : workbench.getActiveWorkbenchWindow();
+    final IWorkbenchPage activePage = activeWorkbenchWindow == null ? null : activeWorkbenchWindow.getActivePage();
+    final IEditorPart activeEditor = activePage == null ? null : activePage.getActiveEditor();
+    if (activeEditor != null && activeEditor.getEditorInput() instanceof XtextReadonlyEditorInput) {
       INode crossRefNode = eObjectAtOffsetHelper.getCrossReferenceNode(resource, new TextRegion(offset, 0));
       if (crossRefNode == null) {
         return;


### PR DESCRIPTION
Two UI helpers walked `workbench.getActiveWorkbenchWindow().getActivePage()…` with no null checks, NPEing when there's no active window/page/editor:

- **`PlatformPluginAwareEditorOpener.open()`** — the page lookup was *outside* the `try`, so the NPE escaped the `IDE.openEditor` error handling. Now guards `getActiveWorkbenchWindow()` (matching the in-file `getProjectName()` sibling) and falls back to the `super.open()` result when null.
- **`CheckHyperlinkHelper.createHyperlinksByOffset()`** — guards the whole chain (the injected `workbench` is `@Inject(optional = true)`, so nullable) and the active editor before `getEditorInput()`; falls through to `super` when null.

Found by a repo-wide inconsistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)