### PR TITLE
fix: close streams and writers with try-with-resources

### DIFF
--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckExtensionGenerator.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckExtensionGenerator.java
@@ -601,8 +601,8 @@ class CheckExtensionGenerator {
     if (file == null || !file.exists()) {
       return false;
     }
-    try {
-      SAXParserFactory.newInstance().newSAXParser().parse(new BufferedInputStream(file.getContents(true)), new PluginHandler(false));
+    try (BufferedInputStream stream = new BufferedInputStream(file.getContents(true))) {
+      SAXParserFactory.newInstance().newSAXParser().parse(stream, new PluginHandler(false));
       return true;
     } catch (SAXException | IOException | ParserConfigurationException | CoreException e) {
       return false;

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/popup/actions/DeployJob.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/popup/actions/DeployJob.java
@@ -199,8 +199,8 @@ public class DeployJob extends Job {
     String uriString = pathMan.getURIValue(CheckCfgConstants.CHECK_CFG_VAR_NAME).toString();
     URI uri = URI.createURI(uriString, true);
     Resource resource = rs.createResource(uri);
-    try {
-      resource.load(new FileInputStream(new File(pathMan.getURIValue(CheckCfgConstants.CHECK_CFG_VAR_NAME))), rs.getLoadOptions());
+    try (FileInputStream input = new FileInputStream(new File(pathMan.getURIValue(CheckCfgConstants.CHECK_CFG_VAR_NAME)))) {
+      resource.load(input, rs.getLoadOptions());
       rs.getURIResourceMap().put(uri, resource);
       EcoreUtil.resolveAll(resource);
       CheckConfiguration checkConfig = (CheckConfiguration) resource.getContents().get(0);

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/KeywordAnalysisHelper.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/KeywordAnalysisHelper.java
@@ -178,9 +178,8 @@ public final class KeywordAnalysisHelper {
    *           if an I/O error occurs
    */
   public void printViolations(final String srcGenPath) {
-    try {
-      String fileName = getKeywordsDiagnosticReportFileName(srcGenPath);
-      PrintWriter writer = new PrintWriter(new File(fileName), StandardCharsets.UTF_8);
+    String fileName = getKeywordsDiagnosticReportFileName(srcGenPath);
+    try (PrintWriter writer = new PrintWriter(new File(fileName), StandardCharsets.UTF_8)) {
       writer.println("Please check in this file, so a diff can be used to detect unexpected changes");
       writer.println();
       writer.println("  identifiers rejected    - are not listed in MWE2 file as reserved words");
@@ -266,7 +265,6 @@ public final class KeywordAnalysisHelper {
         writer.println(ruleName);
       }
       writer.println("if any of them is used to parse identifiers, add them to identifierRules in MWE2 file");
-      writer.close();
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -441,13 +439,13 @@ public final class KeywordAnalysisHelper {
   public void printReport(final String srcGenPath) {
     try {
       String fileName = getReportFileName(srcGenPath);
-      PrintWriter writer = new PrintWriter(new File(fileName), StandardCharsets.UTF_8);
-      writer.print(report.build());
-      writer.close();
+      try (PrintWriter writer = new PrintWriter(new File(fileName), StandardCharsets.UTF_8)) {
+        writer.print(report.build());
+      }
       String docuFileName = getDocFileName(srcGenPath);
-      PrintWriter docuWriter = new PrintWriter(new File(docuFileName), StandardCharsets.UTF_8);
-      docuWriter.print(new CombinedGrammarReportBuilder(grammarExtensions).getDocumentation(grammar, parserRules, enumRules));
-      docuWriter.close();
+      try (PrintWriter docuWriter = new PrintWriter(new File(docuFileName), StandardCharsets.UTF_8)) {
+        docuWriter.print(new CombinedGrammarReportBuilder(grammarExtensions).getDocumentation(grammar, parserRules, enumRules));
+      }
       LOGGER.info("report on keywords is written into {}", fileName);
     } catch (IOException e) {
       throw new UncheckedIOException(e);


### PR DESCRIPTION
Several streams/writers were leaked on non-happy paths:

- **`DeployJob`** — `FileInputStream` passed to EMF `Resource.load` (which doesn't close caller-supplied streams).
- **`CheckExtensionGenerator`** — `BufferedInputStream` passed to `SAXParser.parse`.
- **`KeywordAnalysisHelper`** (`printViolations` / `printReport`) — `PrintWriter`s closed only on the happy path.

Each is wrapped in try-with-resources so it's always closed. (The two `IFile.getContents()` sites in `CheckTocGenerator`/`CheckContextsGenerator` are handled separately — their `throws CoreException` methods need `IOException`-from-`close()` handling.)

Found by a repo-wide inconsistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)