### PR TITLE
chore: drop stale Export-Package for non-existent generator.expression

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.generator/META-INF/MANIFEST.MF
@@ -26,7 +26,6 @@ Import-Package: org.apache.logging.log4j,
  org.apache.logging.log4j.util
 Export-Package: com.avaloq.tools.ddk.xtext.generator.builder,
  com.avaloq.tools.ddk.xtext.generator.ecore,
- com.avaloq.tools.ddk.xtext.generator.expression,
  com.avaloq.tools.ddk.xtext.generator.formatting,
  com.avaloq.tools.ddk.xtext.generator.languageconstants,
  com.avaloq.tools.ddk.xtext.generator.modelinference,


### PR DESCRIPTION
`com.avaloq.tools.ddk.xtext.generator`'s MANIFEST exported `com.avaloq.tools.ddk.xtext.generator.expression`, but that package no longer exists in the bundle (no source, generated, or tracked files under it). Removed the dangling export.

Found by a repo-wide inconsistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)