### PR TITLE
chore: remove orphan CHECKSTYLE:OFF in CheckCfgOutlineTreeProvider

### DIFF
--- a/com.avaloq.tools.ddk.checkcfg.ui/src/com/avaloq/tools/ddk/checkcfg/ui/outline/CheckCfgOutlineTreeProvider.java
+++ b/com.avaloq.tools.ddk.checkcfg.ui/src/com/avaloq/tools/ddk/checkcfg/ui/outline/CheckCfgOutlineTreeProvider.java
@@ -33,8 +33,6 @@ public class CheckCfgOutlineTreeProvider extends DefaultOutlineTreeProvider {
   @Inject
   private StylerFactory stylerFactory;
 
-  // CHECKSTYLE:OFF
-
   /**
    * Gets the outline node text for a configured catalog. Tries to resolve linked catalog's <em>name</em>.
    * If the reference is not resolvable, an appropriate unresolved label is returned.


### PR DESCRIPTION
A stray `// CHECKSTYLE:OFF` sat after the `@Inject` fields with **no matching `// CHECKSTYLE:ON`**, so checkstyle was silently disabled from there until the first `_text()` method's `ON` (line 51). The file otherwise uses a self-contained per-method `OFF`/`ON` pair around each `_text(...)` dispatch signature (49/51, 75/77, 112/115); the orphan is removed so the surrounding code is checked again.

Found by a repo-wide inconsistency sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)