### PR TITLE
fix: minor robustness/logging cleanups from the inconsistency sweep

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/CustomClassAwareEcoreGenerator.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/CustomClassAwareEcoreGenerator.java
@@ -111,21 +111,21 @@ public class CustomClassAwareEcoreGenerator extends EcoreGenerator {
       Diagnostic diagnostic = generator.generate(model, GenBaseGeneratorAdapter.MODEL_PROJECT_TYPE, new BasicMonitor());
 
       if (diagnostic.getSeverity() != Diagnostic.OK) {
-        LOGGER.info(diagnostic);
+        LOGGER.warn(diagnostic);
       }
     }
 
     if (generateEdit) {
       Diagnostic editDiag = generator.generate(model, GenBaseGeneratorAdapter.EDIT_PROJECT_TYPE, new BasicMonitor());
       if (editDiag.getSeverity() != Diagnostic.OK) {
-        LOGGER.info(editDiag);
+        LOGGER.warn(editDiag);
       }
     }
 
     if (generateEditor) {
       Diagnostic editorDiag = generator.generate(model, GenBaseGeneratorAdapter.EDITOR_PROJECT_TYPE, new BasicMonitor());
       if (editorDiag.getSeverity() != Diagnostic.OK) {
-        LOGGER.info(editorDiag);
+        LOGGER.warn(editorDiag);
       }
     }
   }

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/resource/ScopeResourceDescriptionStrategy.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/resource/ScopeResourceDescriptionStrategy.java
@@ -70,6 +70,11 @@ public class ScopeResourceDescriptionStrategy extends DefaultResourceDescription
       LOG.warn("Could not resolve scope model " + EcoreUtil.getURI(obj));
       return "";
     }
-    return ((XtextResource) obj.eResource()).getParseResult().getRootNode().getText();
+    final XtextResource resource = (XtextResource) obj.eResource();
+    if (resource.getParseResult() == null) {
+      LOG.warn("No parse result for scope model " + EcoreUtil.getURI(obj));
+      return "";
+    }
+    return resource.getParseResult().getRootNode().getText();
   }
 }


### PR DESCRIPTION
Two low-risk cleanups from the repo-wide inconsistency sweep (bundled as one small PR):

- **`ScopeResourceDescriptionStrategy.getSourceText`** — guard a null `getParseResult()` before `getRootNode()` (node-model-less resources exist, e.g. direct-linking storage), returning `""` as it already does for the proxy case. Without the guard the NPE is swallowed by the enclosing `catch (RuntimeException)` and the scope model is silently not indexed at all; with it, the model is indexed with the source text contributing as empty.
- **`CustomClassAwareEcoreGenerator`** — non-OK EMF generation diagnostics were logged at `INFO`, so warnings/errors were easy to miss; log them at `WARN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)