### PR TITLE
chore: enable CPD detection (pmd.cpd.min → 100), de-dup and baseline

### DIFF
--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/DispatchingCheckImpl.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/DispatchingCheckImpl.java
@@ -35,6 +35,7 @@ import com.google.inject.Inject;
 @SuppressWarnings({"checkstyle:AbstractClassName"})
 public abstract class DispatchingCheckImpl extends AbstractCheckImpl {
 
+  // CPD-OFF — incidental token overlap (DI field + trace/try idiom), not an extractable unit (#1339)
   @Inject
   private ITraceSet traceSet;
 
@@ -72,6 +73,7 @@ public abstract class DispatchingCheckImpl extends AbstractCheckImpl {
 
     State state = new State();
     state.chain = diagnostics;
+    // CPD-ON
     state.eventCollector = eventCollector;
 
     validate(checkMode, object, state);
@@ -123,6 +125,7 @@ public abstract class DispatchingCheckImpl extends AbstractCheckImpl {
     if (!disabledMethodTracker.isDisabled(contextName)) {
       Collector eventCollector = diagnosticCollector.getEventCollector();
       try {
+        // CPD-OFF — incidental token overlap (DI field + trace/try idiom), not an extractable unit (#1339)
         traceStart(qContextName, object, eventCollector);
         checkAction.run();
       } catch (Exception e) {
@@ -160,6 +163,7 @@ public abstract class DispatchingCheckImpl extends AbstractCheckImpl {
     // CHECKSTYLE:OFF
     public DiagnosticChain chain;
     public CheckType currentCheckType;
+    // CPD-ON
     public boolean hasErrors;
     public ResourceValidationRuleSummaryEvent.Collector eventCollector;
     // CHECKSTYLE:ON

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/AbstractCheckDocumentationExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/AbstractCheckDocumentationExtensionHelper.java
@@ -44,4 +44,18 @@ public abstract class AbstractCheckDocumentationExtensionHelper extends Abstract
     return !config.isGenerateLanguageInternalChecks();
   }
 
+  /**
+   * Documentation extensions do not reference a generated target class, so documentation helpers have no target class name and
+   * provide their own {@link #isExtensionUpdateRequired} logic that never consults it.
+   *
+   * @param catalog
+   *          the check catalog
+   * @return never returns normally
+   */
+  @SuppressWarnings("PMD.UnusedFormalParameter")
+  @Override
+  protected String getTargetClassName(final CheckCatalog catalog) {
+    throw new UnsupportedOperationException("Documentation extension helpers have no target class"); //$NON-NLS-1$
+  }
+
 }

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/AbstractCheckExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/AbstractCheckExtensionHelper.java
@@ -148,6 +148,41 @@ public abstract class AbstractCheckExtensionHelper implements ICheckExtensionHel
   }
 
   /**
+   * Checks whether a class-referencing extension (validator / quickfix) needs updating: it must point at this helper's
+   * extension point and reference exactly one element whose target class, language and catalog name still match the
+   * check catalog. Shared by the validator and quickfix helpers, whose only difference is {@link #getTargetClassName}.
+   *
+   * @param catalog
+   *          the catalog
+   * @param extension
+   *          the extension
+   * @param elements
+   *          the elements
+   * @return true, if the extension must be regenerated
+   */
+  protected boolean isTargetClassExtensionUpdateRequired(final CheckCatalog catalog, final IPluginExtension extension, final Iterable<IPluginElement> elements) {
+    // CHECKSTYLE:OFF
+    // @Format-Off
+    return getExtensionPointId().equals(extension.getPoint())
+        && (!extensionNameMatches(extension, catalog)
+        || Iterables.size(elements) != 1
+        || !targetClassMatches(Iterables.get(elements, 0), getTargetClassName(catalog))
+        || catalog.getGrammar() == null && Iterables.get(elements, 0).getAttribute(LANGUAGE_ELEMENT_TAG) != null
+        || catalog.getGrammar() != null && !languageNameMatches(Iterables.get(elements, 0), catalog.getGrammar().getName()));
+    // @Format-On
+    // CHECKSTYLE:ON
+  }
+
+  /**
+   * Gets the target class name based on the package path of given check catalog.
+   *
+   * @param catalog
+   *          the check catalog
+   * @return the target class FQN
+   */
+  protected abstract String getTargetClassName(CheckCatalog catalog);
+
+  /**
    * Updates a given extension to values calculated using given check catalog.
    *
    * @param catalog

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckPreferencesExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckPreferencesExtensionHelper.java
@@ -160,7 +160,8 @@ public final class CheckPreferencesExtensionHelper extends AbstractCheckExtensio
    *          the check catalog
    * @return the target class FQN
    */
-  private String getTargetClassName(final CheckCatalog catalog) {
+  @Override
+  protected String getTargetClassName(final CheckCatalog catalog) {
     return getFromServiceProvider(CheckGeneratorNaming.class, catalog).qualifiedPreferenceInitializerClassName(catalog);
   }
 

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckQuickfixExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckQuickfixExtensionHelper.java
@@ -120,22 +120,14 @@ public final class CheckQuickfixExtensionHelper extends AbstractCheckExtensionHe
    *          the check catalog
    * @return the target class FQN
    */
-  private String getTargetClassName(final CheckCatalog catalog) {
+  @Override
+  protected String getTargetClassName(final CheckCatalog catalog) {
     return getFromServiceProvider(CheckGeneratorNaming.class, catalog).qualifiedQuickfixClassName(catalog);
   }
 
   @Override
   public boolean isExtensionUpdateRequired(final CheckCatalog catalog, final IPluginExtension extension, final Iterable<IPluginElement> elements) {
-    // CHECKSTYLE:OFF
-    // @Format-Off
-    return QUICKFIX_EXTENSION_POINT_ID.equals(extension.getPoint())
-        && (!extensionNameMatches(extension, catalog)
-        || Iterables.size(elements) != 1
-        || !targetClassMatches(Iterables.get(elements, 0), getTargetClassName(catalog))
-        || catalog.getGrammar() == null && Iterables.get(elements, 0).getAttribute(LANGUAGE_ELEMENT_TAG) != null
-        || catalog.getGrammar() != null && !languageNameMatches(Iterables.get(elements, 0), catalog.getGrammar().getName()));
-    // @Format-On
-    // CHECKSTYLE:ON
+    return isTargetClassExtensionUpdateRequired(catalog, extension, elements);
   }
 
 }

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckValidatorExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckValidatorExtensionHelper.java
@@ -112,23 +112,14 @@ public final class CheckValidatorExtensionHelper extends AbstractCheckExtensionH
    *          the check catalog
    * @return the target class FQN
    */
-  private String getTargetClassName(final CheckCatalog catalog) {
+  @Override
+  protected String getTargetClassName(final CheckCatalog catalog) {
     return getFromServiceProvider(CheckGeneratorNaming.class, catalog).qualifiedValidatorClassName(catalog);
   }
 
   @Override
   public boolean isExtensionUpdateRequired(final CheckCatalog catalog, final IPluginExtension extension, final Iterable<IPluginElement> elements) {
-    // CHECKSTYLE:OFF
-    // @Format-Off
-    return CHECK_EXTENSION_POINT_ID.equals(extension.getPoint())
-        && (!extensionNameMatches(extension, catalog)
-        || Iterables.size(elements) != 1
-        || !targetClassMatches(Iterables.get(elements, 0), getTargetClassName(catalog))
-        || catalog.getGrammar() == null && Iterables.get(elements, 0).getAttribute(LANGUAGE_ELEMENT_TAG) != null
-        || catalog.getGrammar() != null && !languageNameMatches(Iterables.get(elements, 0), catalog.getGrammar().getName())
-    );
-    // @Format-On
-    // CHECKSTYLE:ON
+    return isTargetClassExtensionUpdateRequired(catalog, extension, elements);
   }
 
 }

--- a/com.avaloq.tools.ddk.checkcfg.core.test/src/com/avaloq/tools/ddk/checkcfg/contentassist/CheckCfgContentAssistTest.java
+++ b/com.avaloq.tools.ddk.checkcfg.core.test/src/com/avaloq/tools/ddk/checkcfg/contentassist/CheckCfgContentAssistTest.java
@@ -45,6 +45,7 @@ public class CheckCfgContentAssistTest extends AbstractAcfContentAssistTest {
       }
       """;
 
+  // CPD-OFF — sibling test-class scaffolding, kept explicit (#1339)
   @Override
   protected AbstractXtextTestUtil getXtextTestUtil() {
     return CheckCfgTestUtil.getInstance();
@@ -70,6 +71,7 @@ public class CheckCfgContentAssistTest extends AbstractAcfContentAssistTest {
 
   @Test
   public void testConfiguredParameterProposals() {
+  // CPD-ON
     final String source = SOURCE_TEMPLATE.formatted(TestPropertySpecificationWithExpectedValues.INSTANCE.getName(), expected(TestPropertySpecificationWithExpectedValues.INSTANCE.getExpectedValues()));
     assertKernelSourceProposals("ConfiguredParameterProposals.checkcfg", source);
   }

--- a/com.avaloq.tools.ddk.checkcfg.core.test/src/com/avaloq/tools/ddk/checkcfg/validation/CheckCfgConfiguredParameterValidationsTest.java
+++ b/com.avaloq.tools.ddk.checkcfg.core.test/src/com/avaloq/tools/ddk/checkcfg/validation/CheckCfgConfiguredParameterValidationsTest.java
@@ -28,6 +28,7 @@ import com.avaloq.tools.ddk.xtext.test.jupiter.AbstractXtextTestUtil;
 
 public class CheckCfgConfiguredParameterValidationsTest extends AbstractValidationTest {
 
+  // CPD-OFF — sibling test-class scaffolding, kept explicit (#1339)
   @Override
   protected AbstractXtextTestUtil getXtextTestUtil() {
     return CheckCfgTestUtil.getInstance();
@@ -53,6 +54,7 @@ public class CheckCfgConfiguredParameterValidationsTest extends AbstractValidati
 
   @Test
   public void testConfiguredParameterValues() {
+  // CPD-ON
     final TestPropertySpecificationWithExpectedValues allowedOnly = TestPropertySpecificationWithExpectedValues.INSTANCE;
     final TestPropertySpecificationWithOutExpectedValues acceptsAny = TestPropertySpecificationWithOutExpectedValues.INSTANCE;
     final String source = """

--- a/com.avaloq.tools.ddk.typesystem.test/src/com/avaloq/tools/ddk/typesystem/ParameterListMatcherTest.java
+++ b/com.avaloq.tools.ddk.typesystem.test/src/com/avaloq/tools/ddk/typesystem/ParameterListMatcherTest.java
@@ -893,6 +893,7 @@ public class ParameterListMatcherTest {
     assertSame(unnamedFormal2, matchResult.getUnnamedFormalsAfterNamed().get(1), UNNAMED_FORMAL_AFTER_NAMED_NOT_LOCATED);
   }
 
+  // CPD-OFF — explicit parameterized test cases, kept readable over shared (#1339)
   @Test
   void testForceMatchByPosition1() {
     List<NamedFormalParameter> formals = new ArrayList<NamedFormalParameter>();
@@ -946,5 +947,6 @@ public class ParameterListMatcherTest {
     checkParameterMatch(IParameterMatchChecker.MatchStatus.MATCH, actuals.get(1), formals.get(1), matches.get(1));
     checkParameterMatch(IParameterMatchChecker.MatchStatus.MATCH, actuals.get(2), formals.get(2), matches.get(2));
   }
+  // CPD-ON
 
 }

--- a/com.avaloq.tools.ddk.xtext.format.generator/src/com/avaloq/tools/ddk/xtext/format/generator/FormatFragment2.java
+++ b/com.avaloq.tools.ddk.xtext.format.generator/src/com/avaloq/tools/ddk/xtext/format/generator/FormatFragment2.java
@@ -164,6 +164,7 @@ public class FormatFragment2 extends AbstractStubGeneratingFragment {
       protected void appendTo(final TargetStringConcatenation builder) {
         builder.append("import com.avaloq.tools.ddk.xtext.formatting.ExtendedLineEntry");
         builder.newLine();
+        // CPD-OFF — parallel Xtend/Java formatter-stub emission, kept explicit (#1339)
         builder.append("import java.util.List");
         builder.newLine();
         builder.newLine();
@@ -184,6 +185,7 @@ public class FormatFragment2 extends AbstractStubGeneratingFragment {
         builder.append(" */");
         builder.newLine();
         builder.append("class ");
+        // CPD-ON
         builder.append(getFormatterStub(getGrammar()).getSimpleName());
         builder.append(" extends ");
         builder.append(FormatGeneratorUtil.getFormatterName(getGrammar(), "Abstract"));
@@ -251,6 +253,7 @@ public class FormatFragment2 extends AbstractStubGeneratingFragment {
         builder.append("import java.util.List;");
         builder.newLine();
         builder.newLine();
+        // CPD-OFF — parallel Xtend/Java formatter-stub emission, kept explicit (#1339)
         builder.append("import org.eclipse.xtext.TerminalRule;");
         builder.newLine();
         builder.newLine();
@@ -271,6 +274,7 @@ public class FormatFragment2 extends AbstractStubGeneratingFragment {
         builder.append(" */");
         builder.newLine();
         builder.append("public class ");
+        // CPD-ON
         builder.append(getFormatterStub(getGrammar()).getSimpleName());
         builder.append(" extends ");
         builder.append(FormatGeneratorUtil.getFormatterName(getGrammar(), "Abstract"));

--- a/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/jvmmodel/FormatJvmModelInferrer.java
+++ b/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/jvmmodel/FormatJvmModelInferrer.java
@@ -110,6 +110,7 @@ import com.google.inject.Inject;
  */
 @SuppressWarnings({"nls", "checkstyle:MethodName", "PMD.UnusedFormalParameter"})
 public class FormatJvmModelInferrer extends AbstractModelInferrer {
+  // CPD-OFF — migrated Xtend dispatch/emission code, kept faithful; de-dup is a migration follow-up (#1339)
   // CHECKSTYLE:CONSTANTS-OFF the repeated literals are Java source fragments emitted by this generator, not nameable constants
   // CHECKSTYLE:CHECK-OFF LambdaBodyLength the model-inference closures mirror the Xtext JvmTypesBuilder API and are kept whole
 

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/jupiter/AbstractValidationTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/jupiter/AbstractValidationTest.java
@@ -377,6 +377,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
      *          actual message
      */
     private void createErrorMessage(final Integer pos, final List<Resource.Diagnostic> diagnosticsOnTargetPosition, final boolean issueFound, final boolean expectedSeverityMatches, final int actualSeverity, final boolean expectedMessageMatches, final String actualMessage) {
+      // CPD-OFF — test scaffolding; per-test clarity beats extraction (#1339)
       StringBuilder errorMessage = new StringBuilder(200);
       if (issueMustBeFound && !issueFound) {
         errorMessage.append("Expected issue not found. Code '").append(issueCode).append('\n');
@@ -398,6 +399,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
         }
         memorizeErrorOnPosition(pos, errorMessage.toString());
       }
+      // CPD-ON
     }
 
     /**
@@ -1002,6 +1004,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
    */
   @SuppressWarnings("PMD.UnusedFormalParameter")
   public static void assertLinkingErrorsOnResourceExist(final EObject object, final String referenceType, final String... referenceNames) {
+    // CPD-OFF — test scaffolding; per-test clarity beats extraction (#1339)
     final List<Resource.Diagnostic> linkingErrors = object.eResource().getErrors().stream().filter(error -> error instanceof XtextLinkingDiagnostic).collect(Collectors.toList());
     final List<String> errorMessages = Lists.transform(linkingErrors, Resource.Diagnostic::getMessage);
     for (final String referenceName : referenceNames) {
@@ -1012,6 +1015,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
           break;
         }
       }
+      // CPD-ON
       assertTrue(found, NLS.bind("Expected linking error on \"{0}\" but could not find it", referenceName));
     }
   }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractFingerprintComputer.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractFingerprintComputer.java
@@ -14,19 +14,15 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
-import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.xtext.linking.lazy.LazyLinkingResource;
 
 import com.google.common.collect.Iterables;
@@ -210,43 +206,6 @@ public abstract class AbstractFingerprintComputer implements IFingerprintCompute
   }
 
   /**
-   * Return an Iterable containing all the contents of the given feature of the given object. If the
-   * feature is not many-valued, the resulting iterable will have one element. If the feature is an EReference,
-   * the iterable may contain proxies. The iterable may contain null values.
-   *
-   * @param <T>
-   *          The Generic type of the objects in the iterable
-   * @param obj
-   *          The object
-   * @param feature
-   *          The feature
-   * @return An iterable over all the contents of the feature of the object.
-   */
-  @SuppressWarnings("unchecked")
-  private <T> Iterable<T> featureIterable(final EObject obj, final EStructuralFeature feature) {
-    if (feature == null) {
-      return Collections.emptyList();
-    }
-    if (feature.isMany()) {
-      if (feature instanceof EAttribute || ((EReference) feature).isContainment()) {
-        return (Iterable<T>) obj.eGet(feature);
-      }
-      return new Iterable<T>() {
-        @Override
-        public Iterator<T> iterator() {
-          EList<T> list = (EList<T>) obj.eGet(feature);
-          if (list instanceof InternalEList<T> internalList) {
-            return internalList.basicIterator(); // Don't resolve
-          } else {
-            return list.iterator();
-          }
-        }
-      };
-    }
-    return Collections.singletonList((T) obj.eGet(feature, false)); // Don't resolve
-  }
-
-  /**
    * Generate a fingerprint for the target object using its URI.
    *
    * @param target
@@ -319,7 +278,7 @@ public abstract class AbstractFingerprintComputer implements IFingerprintCompute
     if (obj == null) {
       return NULL_STRING;
     }
-    final Iterable<? extends EObject> targets = featureIterable(obj, ref);
+    final Iterable<? extends EObject> targets = FingerprintFeatures.featureIterable(obj, ref);
     if (targets == null) {
       return NULL_STRING;
     }
@@ -370,7 +329,7 @@ public abstract class AbstractFingerprintComputer implements IFingerprintCompute
     if (obj == null) {
       return NULL_STRING;
     }
-    final Iterable<? extends Object> values = featureIterable(obj, attr);
+    final Iterable<? extends Object> values = FingerprintFeatures.featureIterable(obj, attr);
     if (values == null) {
       return NULL_STRING;
     }
@@ -468,7 +427,7 @@ public abstract class AbstractFingerprintComputer implements IFingerprintCompute
     if (obj == null) {
       return NO_EXPORT;
     }
-    final Iterable<? extends EObject> targets = featureIterable(obj, ref);
+    final Iterable<? extends EObject> targets = FingerprintFeatures.featureIterable(obj, ref);
     if (targets == null) {
       return NO_EXPORT;
     }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractStreamingFingerprintComputer.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractStreamingFingerprintComputer.java
@@ -11,19 +11,15 @@
 package com.avaloq.tools.ddk.xtext.resource;
 
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
-import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.emf.ecore.util.InternalEList;
 import org.eclipse.xtext.linking.lazy.LazyLinkingResource;
 
 import com.google.common.collect.Iterables;
@@ -134,43 +130,6 @@ public abstract class AbstractStreamingFingerprintComputer implements IFingerpri
   }
 
   /**
-   * Return an Iterable containing all the contents of the given feature of the given object. If the
-   * feature is not many-valued, the resulting iterable will have one element. If the feature is an EReference,
-   * the iterable may contain proxies. The iterable may contain null values.
-   *
-   * @param <T>
-   *          The Generic type of the objects in the iterable
-   * @param obj
-   *          The object
-   * @param feature
-   *          The feature
-   * @return An iterable over all the contents of the feature of the object.
-   */
-  @SuppressWarnings("unchecked")
-  private <T> Iterable<T> featureIterable(final EObject obj, final EStructuralFeature feature) {
-    if (feature == null) {
-      return Collections.emptyList();
-    }
-    if (feature.isMany()) {
-      if (feature instanceof EAttribute || ((EReference) feature).isContainment()) {
-        return (Iterable<T>) obj.eGet(feature);
-      }
-      return new Iterable<T>() {
-        @Override
-        public Iterator<T> iterator() {
-          EList<T> list = (EList<T>) obj.eGet(feature);
-          if (list instanceof InternalEList<T> internalList) {
-            return internalList.basicIterator(); // Don't resolve
-          } else {
-            return list.iterator();
-          }
-        }
-      };
-    }
-    return Collections.singletonList((T) obj.eGet(feature, false)); // Don't resolve
-  }
-
-  /**
    * Generate a fingerprint for the target object using its URI.
    *
    * @param target
@@ -249,7 +208,7 @@ public abstract class AbstractStreamingFingerprintComputer implements IFingerpri
       hasher.putUnencodedChars(NULL_STRING);
       return;
     }
-    final Iterable<? extends EObject> targets = featureIterable(obj, ref);
+    final Iterable<? extends EObject> targets = FingerprintFeatures.featureIterable(obj, ref);
     if (targets == null) {
       hasher.putUnencodedChars(NULL_STRING);
       return;
@@ -306,7 +265,7 @@ public abstract class AbstractStreamingFingerprintComputer implements IFingerpri
       hasher.putUnencodedChars(NULL_STRING);
       return;
     }
-    final Iterable<? extends Object> values = featureIterable(obj, attr);
+    final Iterable<? extends Object> values = FingerprintFeatures.featureIterable(obj, attr);
     if (values == null) {
       hasher.putUnencodedChars(NULL_STRING);
       return;
@@ -409,7 +368,7 @@ public abstract class AbstractStreamingFingerprintComputer implements IFingerpri
     if (obj == null) {
       return;
     }
-    final Iterable<? extends EObject> targets = featureIterable(obj, ref);
+    final Iterable<? extends EObject> targets = FingerprintFeatures.featureIterable(obj, ref);
     if (targets == null) {
       return;
     }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/FingerprintFeatures.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/FingerprintFeatures.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Group AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.resource;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.util.InternalEList;
+
+
+/**
+ * Shared helpers for iterating over the contents of {@link EStructuralFeature}s when computing fingerprints.
+ */
+final class FingerprintFeatures {
+
+  private FingerprintFeatures() {
+    // utility class
+  }
+
+  /**
+   * Return an Iterable containing all the contents of the given feature of the given object. If the
+   * feature is not many-valued, the resulting iterable will have one element. If the feature is an EReference,
+   * the iterable may contain proxies. The iterable may contain null values.
+   *
+   * @param <T>
+   *          The Generic type of the objects in the iterable
+   * @param obj
+   *          The object
+   * @param feature
+   *          The feature
+   * @return An iterable over all the contents of the feature of the object.
+   */
+  @SuppressWarnings("unchecked")
+  static <T> Iterable<T> featureIterable(final EObject obj, final EStructuralFeature feature) {
+    if (feature == null) {
+      return Collections.emptyList();
+    }
+    if (feature.isMany()) {
+      if (feature instanceof EAttribute || ((EReference) feature).isContainment()) {
+        return (Iterable<T>) obj.eGet(feature);
+      }
+      return new Iterable<T>() {
+        @Override
+        public Iterator<T> iterator() {
+          EList<T> list = (EList<T>) obj.eGet(feature);
+          if (list instanceof InternalEList<T> internalList) {
+            return internalList.basicIterator(); // Don't resolve
+          } else {
+            return list.iterator();
+          }
+        }
+      };
+    }
+    return Collections.singletonList((T) obj.eGet(feature, false)); // Don't resolve
+  }
+
+}

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -32,7 +32,7 @@
     <!-- analysis parameter -->
     <compiler.showWarnings>true</compiler.showWarnings>
     <pmd.ruleset>${workspace}/ddk-configuration/pmd/ruleset.xml</pmd.ruleset>
-    <pmd.cpd.min>100000</pmd.cpd.min>
+    <pmd.cpd.min>100</pmd.cpd.min>
     <checkstyle.configLocation>${workspace}/ddk-configuration/checkstyle/avaloq.xml</checkstyle.configLocation>
     <checkstyle.test.configLocation>${workspace}/ddk-configuration/checkstyle/avaloq-test.xml</checkstyle.test.configLocation>
     <spotbugs.excludeFilterFile>${workspace}/ddk-configuration/findbugs/exclusion-filter.xml</spotbugs.excludeFilterFile>


### PR DESCRIPTION
Closes #1339.

## Problem
`ddk-parent/pom.xml` set `pmd.cpd.min=100000`, which effectively **disables** PMD's copy/paste detector — `pmd:cpd-check` passes on virtually any duplication (#1339).

## What this does
- Lowers `pmd.cpd.min` to **100** (PMD's default), so CPD actually detects duplication going forward.
- At 100 the reactor surfaces **pre-existing duplications in 8 file-groups**. Each was assessed for whether it is genuinely extractable logic or incidental/deliberate similarity:
  - **2 refactored** (C, E) — genuine duplicated logic; behavior-neutral extraction.
  - **6 baselined** (A, B, D, F, G, H) with `// CPD-OFF` markers carrying a per-site reason.
- **Verified:** full local gate (`clean verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check`) → BUILD SUCCESS, `pmd:cpd-check` clean across the full reactor at threshold 100.

## Dispositions

| Group | File(s) | Kind | Disposition | Rationale |
|---|---|---|---|---|
| **A** | `AbstractValidationTest` (test core) | test scaffolding | **baseline** | error-message assembly + assert helpers in a test base; per-test clarity beats a shared extraction that would obscure intent. |
| **B** | `ParameterListMatcherTest` (typesystem test) | test cases | **baseline** | sibling `testForceMatchByPosition*` cases share an arrange-act-assert skeleton, kept explicit for readability. |
| **C** | `Check{Validator,Quickfix}ExtensionHelper` (prod UI) | helper pair | **refactored** | identical `isExtensionUpdateRequired` guard chain lifted to `AbstractCheckExtensionHelper`, keyed on the existing `getExtensionPointId()` plus a new `protected getTargetClassName()` hook. The documentation-helper subtree (no target class) declares that hook unsupported once in its shared parent. |
| **D** | `DispatchingCheckImpl` (prod runtime) | incidental | **baseline** | the matched spans are incidental token overlap (DI field declarations + the trace/try/run/catch/finally idiom), not an extractable unit. |
| **E** | `Abstract{,Streaming}FingerprintComputer` (prod) | helper pair | **refactored** | the identical private `featureIterable` helper extracted to a shared package-private `FingerprintFeatures` utility. |
| **F** | `FormatJvmModelInferrer` (prod, migrated) | dispatch/emission | **baseline (file-scoped)** | 9 self-duplications across the per-locator emission blocks of freshly-migrated Xtend dispatch code, kept faithful to the migration; de-duplication belongs to the migration readability follow-ups, not this PR. |
| **G** | `FormatFragment2` (prod generator, migrated) | stub emission | **baseline** | the parallel Xtend- and Java-formatter stub emission runs are deliberately explicit twins. |
| **H** | `CheckCfg{ContentAssist,ConfiguredParameterValidations}Test` | test scaffolding | **baseline** | sibling test classes share `@Override` setup scaffolding, kept explicit per class. |

## Notes
- The lifted `isExtensionUpdateRequired` overrides keep their `public` visibility: the hook is deliberately public so tests can exercise it directly on injected helpers; #1460 makes the whole hierarchy uniformly public.
- CPD has no SARIF renderer, so it gates (the build goes red on a duplication) but doesn't annotate inline; a `cpd.xml`→SARIF transform is a possible follow-up.
- On the current workflow CPD gates via `maven-verify`'s `pmd:cpd-check`; once #1396's lint lane lands, its CPD gate becomes meaningful too (its "threshold currently very high" note can then be dropped).

**Merge chain:** ~~#1399~~ (merged) → #1396 → #1400 → #1456 → #1457 → ***#1397 (this PR)***

🤖 Generated with [Claude Code](https://claude.com/claude-code)