### PR TITLE
ci: restore Maven cache from master-produced caches in maven-verify

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -45,11 +45,18 @@ jobs:
         run: mvn --version
       - name: Set up Workspace Environment Variable
         run: echo "WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
-      - name: Cache Maven dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      - name: Restore Maven dependency cache
+        # Restore-only: PR scopes cannot share caches with each other, so per-PR
+        # saves are dead weight that evicts the useful master-scoped caches
+        # (10 GB repo budget). The producer is snapshot.yml on master pushes
+        # (Linux-maven-publish-*). Path and key must mirror snapshot.yml exactly:
+        # the literal path spec is hashed into the cache *version*, so any
+        # variation (~/.m2 vs /home/runner/.m2) makes its caches unmatchable.
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          path: /home/runner/.m2/repository
-          key: ${{ runner.os }}-maven-0-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-publish-${{ hashFiles('**/pom.xml', '**/*.target') }}
+          restore-keys: ${{ runner.os }}-maven-publish-
       - name: Build with Maven  within a virtual X Server Environment
         # Run pmd:pmd and pmd:cpd first to generate reports for all modules, then run pmd:check and pmd:cpd-check
         # This ensures all violations are collected and reported before the build fails


### PR DESCRIPTION
The `maven-verify` cache never hits in practice. Three compounding causes, verified against the live cache inventory:

1. **Exact-key-only restore:** the key embeds `hashFiles('**/pom.xml')`, so every pom-touching PR (each dependabot bump) missed outright — e.g. run 27416121979: `Cache not found for input keys: Linux-maven-0-3ecae…` followed by a full cold download.
2. **PR scope isolation:** the eight open PRs each held a **byte-identical 704 MB cache** under their own `refs/pull/N/merge` scope, invisible to one another. Only master-scoped caches are shareable, and `verify.yml` (pull_request-only) never saves there. Meanwhile `snapshot.yml` *does* produce a master-scoped `Linux-maven-publish-*` cache on every push.
3. **Eviction churn:** the redundant per-PR saves pushed the repo over its 10 GB cache budget (10.35 GB / 14 caches), so LRU eviction also killed same-PR reuse.

The fix stays within the one cache step:

- **`actions/cache/restore`** (restore-only): PRs stop saving — ends the duplicate-cache churn and the eviction pressure (steady state ≈ a few master caches).
- **Mirror the producer exactly:** the step adopts `snapshot.yml`'s literal path spec (`~/.m2/repository`) and key recipe (`Linux-maven-publish-` + `hashFiles('**/pom.xml', '**/*.target')`). This is load-bearing: GitHub serves a cache only when key **and version** match, and the version is a hash of the *literal path spec* — `/home/runner/.m2/repository` vs `~/.m2/repository` alone puts producer and consumer in disjoint version families (visible in the repo's cache inventory as two distinct version hashes for the same directory). A PR that touches no pom/target files exact-hits master's newest cache; any other PR prefix-restores it via `restore-keys`.
- **Cache-bust lever:** rename the `maven-publish` family in `snapshot.yml` and here together.

**Proven live on this PR — A/B, one commit apart, same three publish caches present on master:**

| Head | maven-verify cache step | Duration |
|------|------------------------|----------|
| pre-fix `0301a0538` ([run 28912306532](https://github.com/dsldevkit/dsl-devkit/actions/runs/28912306532)) | `Cache not found for input keys: Linux-maven-0-813d39e…, Linux-maven-0-, Linux-maven-publish-` → cold download | 16m16s |
| fixed `a3330b5fe` ([run 28913047642](https://github.com/dsldevkit/dsl-devkit/actions/runs/28913047642)) | `Cache restored from key: Linux-maven-publish-a45921afc7…` (~1096 MB, exact hit on master's newest cache) | 14m23s |

Post-run, the cache API shows **zero caches under `refs/pull/1399/merge`** — PRs no longer save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
