### PR TITLE
fix: use private lock objects in test utilities, accept override widening

### DIFF
--- a/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/mock/ExtensionRegistryMock.java
+++ b/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/mock/ExtensionRegistryMock.java
@@ -37,6 +37,8 @@ import com.google.common.collect.Multimap;
 /** Provides a mocking framework for the extension point registry. */
 public final class ExtensionRegistryMock {
 
+  private static final Object LOCK = new Object();
+
   private static IExtensionRegistry registry;
   private static IExtensionRegistry registrySpy;
   private static Multimap<String, IConfigurationElement> configurationElements = LinkedHashMultimap.create();
@@ -52,18 +54,20 @@ public final class ExtensionRegistryMock {
    *           if the registry provider cannot be set
    */
   @SuppressWarnings("restriction") // for accessing RegistryProviderFactory
-  public static synchronized void mockRegistry() {
-    if (registrySpy == null) {
-      registry = RegistryFactory.getRegistry();
-      registrySpy = spy(registry);
-      org.eclipse.core.internal.registry.RegistryProviderFactory.releaseDefault();
-      try {
-        RegistryFactory.setDefaultRegistryProvider(() -> {
-          return registrySpy;
-        });
-      } catch (CoreException e) {
-        // This shouldn't happen as the default was released.
-        throw new WrappedException(e);
+  public static void mockRegistry() {
+    synchronized (LOCK) {
+      if (registrySpy == null) {
+        registry = RegistryFactory.getRegistry();
+        registrySpy = spy(registry);
+        org.eclipse.core.internal.registry.RegistryProviderFactory.releaseDefault();
+        try {
+          RegistryFactory.setDefaultRegistryProvider(() -> {
+            return registrySpy;
+          });
+        } catch (CoreException e) {
+          // This shouldn't happen as the default was released.
+          throw new WrappedException(e);
+        }
       }
     }
   }

--- a/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/util/JobMatcher.java
+++ b/com.avaloq.tools.ddk.test.core/src/com/avaloq/tools/ddk/test/core/util/JobMatcher.java
@@ -134,6 +134,8 @@ public class JobMatcher extends JobChangeAdapter {
 
   }
 
+  private final Object lock = new Object();
+
   private final JobFinder finder;
   private final long waitTimeout;
 
@@ -183,17 +185,19 @@ public class JobMatcher extends JobChangeAdapter {
    *
    * @return the list of matching existing jobs
    */
-  public final synchronized List<Job> register() {
-    newJobs = Collections.synchronizedList(Lists.<Job> newArrayList());
-    jobQueue = new LinkedBlockingQueue<Job>();
-    Job.getJobManager().addJobChangeListener(this);
+  public final List<Job> register() {
+    synchronized (lock) {
+      newJobs = Collections.synchronizedList(Lists.<Job> newArrayList());
+      jobQueue = new LinkedBlockingQueue<Job>();
+      Job.getJobManager().addJobChangeListener(this);
 
-    // save list of existing jobs *after* adding job listener (in case jobs finish in the mean time)
-    existingJobs = ImmutableList.copyOf(finder.find());
-    finishedJobs = Collections.synchronizedList(Lists.<Job> newArrayList());
-    timeout = System.currentTimeMillis() + waitTimeout;
+      // save list of existing jobs *after* adding job listener (in case jobs finish in the mean time)
+      existingJobs = ImmutableList.copyOf(finder.find());
+      finishedJobs = Collections.synchronizedList(Lists.<Job> newArrayList());
+      timeout = System.currentTimeMillis() + waitTimeout;
 
-    return ImmutableList.copyOf(existingJobs);
+      return ImmutableList.copyOf(existingJobs);
+    }
   }
 
   /**
@@ -290,18 +294,22 @@ public class JobMatcher extends JobChangeAdapter {
   }
 
   @Override
-  public synchronized void scheduled(final IJobChangeEvent event) {
-    Job job = event.getJob();
-    if (finder.apply(job)) {
-      newJobs.add(job);
+  public void scheduled(final IJobChangeEvent event) {
+    synchronized (lock) {
+      Job job = event.getJob();
+      if (finder.apply(job)) {
+        newJobs.add(job);
+      }
     }
   }
 
   @Override
-  public synchronized void done(final IJobChangeEvent event) {
-    Job job = event.getJob();
-    if (finder.apply(job)) {
-      jobQueue.add(job);
+  public void done(final IJobChangeEvent event) {
+    synchronized (lock) {
+      Job job = event.getJob();
+      if (finder.apply(job)) {
+        jobQueue.add(job);
+      }
     }
   }
 }

--- a/ddk-configuration/findbugs/exclusion-filter.xml
+++ b/ddk-configuration/findbugs/exclusion-filter.xml
@@ -75,4 +75,8 @@
   <Match>
      <Class name="~.*Activator.*" />
   </Match>
+  <!-- Widening an override from protected to public is accepted, deliberate API design here. -->
+  <Match>
+     <Bug pattern="IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Prepares the codebase for SpotBugs 4.10 (#1410), which adds two detectors that flag existing code:

- **`USO_UNSAFE_*_SYNCHRONIZATION`** (4 findings, fixed for real): `JobMatcher` instances escape via the static `registerNewJob*Matcher` factories and `ExtensionRegistryMock`'s class literal is public, so both synchronized on locks that arbitrary code can contend on. Both now synchronize on private lock objects — the canonical fix, not a suppression.
- **`IAOM_DO_NOT_INCREASE_METHOD_ACCESSIBILITY`** (15 findings, excluded by policy): widening an inherited method from `protected` to `public` is deliberate API design in this codebase (e.g. `DelegatingScope.getAllLocalElements()`); narrowing them would be a breaking change. The detector is excluded in the SpotBugs filter with a comment stating the policy.

Once merged, #1410 (SpotBugs 4.9.8 → 4.10.2) goes green after a rebase, keeping the dependency bump itself a pure version change.

Verified locally with a full `mvn verify` including SpotBugs: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)