### PR TITLE
style: collapse verbose string building in pre-existing classes

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/validation/ClasspathBasedChecks.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/validation/ClasspathBasedChecks.java
@@ -54,13 +54,8 @@ public class ClasspathBasedChecks extends AbstractDeclarativeValidator {
     Resource resource = catalog.eResource();
     URI resourceURI = resource.getURI();
     String packageName = catalog.getPackageName();
-    StringBuilder classpathURIBuilder = new StringBuilder(ClasspathUriUtil.CLASSPATH_SCHEME);
-    classpathURIBuilder.append(":/");
-    if (packageName != null) {
-      classpathURIBuilder.append(packageName.replace(DOT, SLASH)).append(SLASH);
-    }
-    classpathURIBuilder.append(resourceURI.lastSegment());
-    URI classpathURI = URI.createURI(classpathURIBuilder.toString());
+    String packagePath = packageName != null ? packageName.replace(DOT, SLASH) + SLASH : "";
+    URI classpathURI = URI.createURI(ClasspathUriUtil.CLASSPATH_SCHEME + ":/" + packagePath + resourceURI.lastSegment());
     URIConverter uriConverter = resource.getResourceSet().getURIConverter();
     try {
       URI normalizedClasspathURI = uriConverter.normalize(classpathURI);

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/CustomClassAwareEcoreGenerator.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/CustomClassAwareEcoreGenerator.java
@@ -51,8 +51,8 @@ public class CustomClassAwareEcoreGenerator extends EcoreGenerator {
 
   // CHECKSTYLE:OFF
   private boolean generateModel = true;
-  private boolean generateEdit = false;
-  private boolean generateEditor = false;
+  private boolean generateEdit;
+  private boolean generateEditor;
   // CHECKSTYLE:ON
   private ResourceSet resourceSet;
 

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/StandaloneSetup.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/util/StandaloneSetup.java
@@ -50,7 +50,7 @@ public class StandaloneSetup extends org.eclipse.emf.mwe.utils.StandaloneSetup {
       return Collections.<URI> emptyList();
     }
     String trimmed = input.trim();
-    if (trimmed.length() == 0) {
+    if (trimmed.isEmpty()) {
       return Collections.<URI> emptyList();
     }
     List<URI> result = Lists.newArrayList();

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/labeling/AbstractLabelProvider.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/labeling/AbstractLabelProvider.java
@@ -230,9 +230,7 @@ public abstract class AbstractLabelProvider extends DeclarativeLabelProvider {
           }
         }
         if (valueString != null && valueString.length() > MAX_FEATURE_VALUE_LENGTH) {
-          StringBuilder stringBuilder = new StringBuilder(valueString.substring(0, MAX_FEATURE_VALUE_LENGTH - CONTINUED.length()));
-          stringBuilder.append(CONTINUED);
-          valueString = stringBuilder.toString();
+          valueString = valueString.substring(0, MAX_FEATURE_VALUE_LENGTH - CONTINUED.length()) + CONTINUED;
         }
       }
       return assignmentStyledString(name, valueString);

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/AbstractValidElementBase.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/AbstractValidElementBase.java
@@ -109,11 +109,7 @@ public abstract class AbstractValidElementBase {
 
   @Override
   public String toString() {
-    StringBuilder b = new StringBuilder(this.getClass().getSimpleName());
-    b.append("(\""); //$NON-NLS-1$
-    b.append(getElementTypeName());
-    b.append("\")"); //$NON-NLS-1$
-    return b.toString();
+    return this.getClass().getSimpleName() + "(\"" + getElementTypeName() + "\")"; //$NON-NLS-1$ //$NON-NLS-2$
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/FixedCopiedResourceDescription.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/FixedCopiedResourceDescription.java
@@ -105,15 +105,7 @@ public class FixedCopiedResourceDescription extends AbstractResourceDescription 
 
   @Override
   public String toString() {
-    StringBuilder result = new StringBuilder(getClass().getName());
-    result.append('@');
-    result.append(Integer.toHexString(hashCode()));
-
-    result.append(" (URI: "); //$NON-NLS-1$
-    result.append(uri);
-    result.append(')');
-
-    return result.toString();
+    return String.format("%s@%s (URI: %s)", getClass().getName(), Integer.toHexString(hashCode()), uri); //$NON-NLS-1$
   }
 
   @Override

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
@@ -108,12 +108,9 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
         super.loadFeatureValue(internalEObject, eStructuralFeatureData);
         // CHECKSTYLE:OFF
       } catch (Exception e) {
-        StringBuilder infoMessage = new StringBuilder(100);
         // CHECKSTYLE:ON
-        infoMessage.append("Failed to load feature's value. Owner: ").append(internalEObject.eClass()); //$NON-NLS-1$
-        if (eStructuralFeatureData.eStructuralFeature != null) {
-          infoMessage.append(", feature name: ").append(eStructuralFeatureData.eStructuralFeature.getName()); //$NON-NLS-1$
-        }
+        String infoMessage = "Failed to load feature's value. Owner: " + internalEObject.eClass() //$NON-NLS-1$
+            + (eStructuralFeatureData.eStructuralFeature != null ? ", feature name: " + eStructuralFeatureData.eStructuralFeature.getName() : ""); //$NON-NLS-1$ //$NON-NLS-2$
         LOG.info(infoMessage);
         throw e;
       }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
@@ -178,16 +178,11 @@ public class ProxyCompositeNode implements ICompositeNode, BidiTreeIterable<INod
    * @return the string
    */
   private String toString(final EObject eObject) {
-    StringBuilder result = new StringBuilder(eObject.getClass().getName());
-    result.append('@');
-    result.append(Integer.toHexString(hashCode()));
-
+    String result = String.format("%s@%s", eObject.getClass().getName(), Integer.toHexString(hashCode())); //$NON-NLS-1$
     if (eObject.eIsProxy() && eObject instanceof InternalEObject internal) {
-      result.append(" (eProxyURI: "); //$NON-NLS-1$
-      result.append(internal.eProxyURI());
-      result.append(')');
+      result += " (eProxyURI: " + internal.eProxyURI() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
     }
-    return result.toString();
+    return result;
   }
 
   @Override

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AbstractRecursiveScope.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AbstractRecursiveScope.java
@@ -229,20 +229,12 @@ public abstract class AbstractRecursiveScope extends AbstractScope {
   @SuppressWarnings("nls")
   @Override
   public String toString() {
-    final StringBuilder result = new StringBuilder(getClass().getName());
-    result.append('@');
-    result.append(Integer.toHexString(hashCode()));
-
-    result.append(" (id: ");
-    result.append(getId());
-    result.append(')');
-
+    String result = String.format("%s@%s (id: %s)", getClass().getName(), Integer.toHexString(hashCode()), getId());
     final IScope outerScope = getParent();
     if (outerScope != IScope.NULLSCOPE) {
-      result.append("\n  >> ");
-      result.append(outerScope.toString().replaceAll("\\\n", "\n  "));
+      result += "\n  >> " + outerScope.toString().replaceAll("\\\n", "\n  ");
     }
-    return result.toString();
+    return result;
   }
 
 }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/ContainerBasedScope.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/ContainerBasedScope.java
@@ -135,26 +135,11 @@ public class ContainerBasedScope extends AbstractRecursiveScope {
   @SuppressWarnings("nls")
   @Override
   public String toString() {
-    final StringBuilder result = new StringBuilder(getClass().getName());
-    result.append('@');
-    result.append(Integer.toHexString(hashCode()));
-
-    result.append(" (id: ");
-    result.append(getId());
-
-    result.append(", query: ");
-    result.append(criteria);
-
-    result.append(", container: ");
-    result.append(container);
-
-    result.append(')');
-
+    String result = String.format("%s@%s (id: %s, query: %s, container: %s)", getClass().getName(), Integer.toHexString(hashCode()), getId(), criteria, container);
     final IScope parent = getParent();
     if (parent != IScope.NULLSCOPE) {
-      result.append("\n  >> ");
-      result.append(parent.toString().replaceAll("\\\n", "\n  "));
+      result += "\n  >> " + parent.toString().replaceAll("\\\n", "\n  ");
     }
-    return result.toString();
+    return result;
   }
 }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/DelegatingScope.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/DelegatingScope.java
@@ -267,26 +267,13 @@ public class DelegatingScope extends AbstractRecursiveScope {
   @SuppressWarnings("nls")
   @Override
   public String toString() {
-    final StringBuilder result = new StringBuilder(getClass().getName());
-    result.append('@');
-    result.append(Integer.toHexString(hashCode()));
-
-    result.append(" (id: ");
-    result.append(getId());
-
     final Iterable<IScope> delegateScopes = getDelegates();
-    if (delegateScopes != null && !Iterables.isEmpty(delegateScopes)) {
-      result.append(", delegates: ");
-      result.append(Iterables.toString(delegateScopes));
-    }
-    result.append(')');
-
+    String delegatesSuffix = delegateScopes != null && !Iterables.isEmpty(delegateScopes) ? ", delegates: " + Iterables.toString(delegateScopes) : "";
+    String result = String.format("%s@%s (id: %s%s)", getClass().getName(), Integer.toHexString(hashCode()), getId(), delegatesSuffix);
     final IScope outerScope = getParent();
     if (outerScope != IScope.NULLSCOPE) {
-      result.append("\n  >> ");
-      result.append(outerScope.toString().replaceAll("\\\n", "\n  "));
+      result += "\n  >> " + outerScope.toString().replaceAll("\\\n", "\n  ");
     }
-
-    return result.toString();
+    return result;
   }
 }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/PrefixedContainerBasedScope.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/PrefixedContainerBasedScope.java
@@ -134,29 +134,11 @@ public class PrefixedContainerBasedScope extends ContainerBasedScope {
   @SuppressWarnings("nls")
   @Override
   public String toString() {
-    final StringBuilder result = new StringBuilder(getClass().getName());
-    result.append('@');
-    result.append(Integer.toHexString(hashCode()));
-
-    result.append(" (id: ");
-    result.append(getId());
-
-    result.append(", prefix: ");
-    result.append(prefix);
-
-    result.append(", query: ");
-    result.append(criteria);
-
-    result.append(", container: ");
-    result.append(container);
-
-    result.append(')');
-
+    String result = String.format("%s@%s (id: %s, prefix: %s, query: %s, container: %s)", getClass().getName(), Integer.toHexString(hashCode()), getId(), prefix, criteria, container);
     final IScope parent = getParent();
     if (parent != IScope.NULLSCOPE) {
-      result.append("\n  >> ");
-      result.append(parent.toString().replaceAll("\\\n", "\n  "));
+      result += "\n  >> " + parent.toString().replaceAll("\\\n", "\n  ");
     }
-    return result.toString();
+    return result;
   }
 }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/ScopeTrace.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/ScopeTrace.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.scoping;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -47,20 +46,7 @@ public class ScopeTrace {
   @SuppressWarnings("nls")
   @Override
   public String toString() {
-    final StringBuilder builder = new StringBuilder(getClass().getName());
-    builder.append('@');
-    builder.append(Integer.toHexString(hashCode()));
-    builder.append(" [");
-
-    for (final Iterator<String> i = elements.iterator(); i.hasNext();) {
-      builder.append(i.next());
-      if (i.hasNext()) {
-        builder.append(" >> ");
-      }
-    }
-
-    builder.append(']');
-    return builder.toString();
+    return String.format("%s@%s [%s]", getClass().getName(), Integer.toHexString(hashCode()), String.join(" >> ", elements));
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/util/EObjectUtil.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/util/EObjectUtil.java
@@ -242,13 +242,8 @@ public final class EObjectUtil {
     // CHECKSTYLE:CHECK-OFF MagicNumber
     String path = uri.isPlatform() ? '/' + String.join("/", uri.segmentsList().subList(3, uri.segmentCount())) : uri.path(); //$NON-NLS-1$
     // CHECKSTYLE:CHECK-ON MagicNumber
-    StringBuilder result = new StringBuilder(path);
     final ICompositeNode node = NodeModelUtils.getNode(object);
-    if (node != null) {
-      result.append(':').append(node.getStartLine());
-    }
-
-    return result.toString();
+    return node != null ? path + ":" + node.getStartLine() : path; //$NON-NLS-1$
   }
 
 }


### PR DESCRIPTION
Behavior-identical readability tidy-ups across 14 pre-existing Java classes — mostly collapsing `StringBuilder` chains in `toString()` methods into plain concatenation or formatted strings, folding manual join loops into joins, and dropping redundant boolean field initializers and length checks. No logic changes anywhere.

These changes were flagged in #1274 review as unrelated to the Xtend migration (correctly so) and are proposed here on their own so they can be judged on their own merits.

Verified with a full `mvn verify` including Checkstyle and PMD: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)