### PR TITLE
fix: drop redundant synchronized on CheckXtextTestUtil.getInstance() (SpotBugs 4.10)

### DIFF
--- a/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/util/CheckXtextTestUtil.java
+++ b/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/util/CheckXtextTestUtil.java
@@ -38,7 +38,7 @@ public final class CheckXtextTestUtil extends AbstractXtextTestUtil {
     }
   }
 
-  public static synchronized CheckXtextTestUtil getInstance() {
+  public static CheckXtextTestUtil getInstance() {
     return InstanceHolder.get();
   }
 


### PR DESCRIPTION
SpotBugs 4.10 flags `CheckXtextTestUtil.getInstance()` with `USO_UNSAFE_STATIC_METHOD_SYNCHRONIZATION` / `USO_UNSAFE_METHOD_SYNCHRONIZATION` — it synchronizes on the class's intrinsic lock, which is exposed to untrusted code.

The `synchronized` keyword is redundant: `getInstance()` only delegates to an initialize-on-demand `InstanceHolder`, which is already thread-safe via JVM class-initialization semantics. Removing it resolves the finding with no behavioural change.

This unblocks the SpotBugs 4.9.8 → 4.10.2 bump (#1410): the finding was masked in that PR's first run by the `--fail-at-end` cascade-skip behind the upstream findings fixed in #1411. Verified locally with a full-reactor `spotbugs:check -Dspotbugs.version=4.10.2` → BUILD SUCCESS, zero bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)