### PR TITLE
refactor: migrate Xtend to Java - com.avaloq.tools.ddk.check.test.runtime

### DIFF
--- a/com.avaloq.tools.ddk.check.test.runtime/.classpath
+++ b/com.avaloq.tools.ddk.check.test.runtime/.classpath
@@ -6,11 +6,6 @@
       <attribute name="ignore_optional_problems" value="true"/>
     </attributes>
   </classpathentry>
-  <classpathentry kind="src" path="xtend-gen">
-    <attributes>
-      <attribute name="ignore_optional_problems" value="true"/>
-    </attributes>
-  </classpathentry>
   <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
   <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
   <classpathentry kind="output" path="bin"/>

--- a/com.avaloq.tools.ddk.check.test.runtime/.project
+++ b/com.avaloq.tools.ddk.check.test.runtime/.project
@@ -21,11 +21,6 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
 			<arguments>
 			</arguments>
@@ -44,7 +39,6 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
-		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 		<nature>net.sourceforge.pmd.eclipse.plugin.pmdNature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 		<nature>edu.umd.cs.findbugs.plugin.eclipse.findbugsNature</nature>

--- a/com.avaloq.tools.ddk.check.test.runtime/build.properties
+++ b/com.avaloq.tools.ddk.check.test.runtime/build.properties
@@ -1,6 +1,5 @@
 source.. = src/,\
-          src-gen/,\
-          xtend-gen/
+          src-gen/
 bin.includes = META-INF/,\
                .,\
                plugin.xml

--- a/com.avaloq.tools.ddk.check.test.runtime/src/com/avaloq/tools/ddk/check/generator/TestLanguageGenerator.java
+++ b/com.avaloq.tools.ddk.check.test.runtime/src/com/avaloq/tools/ddk/check/generator/TestLanguageGenerator.java
@@ -8,15 +8,17 @@
  * Contributors:
  *     Avaloq Group AG - initial API and implementation
  *******************************************************************************/
-package com.avaloq.tools.ddk.check.generator
+package com.avaloq.tools.ddk.check.generator;
 
-import org.eclipse.emf.ecore.resource.Resource
-import org.eclipse.xtext.generator.IGenerator
-import org.eclipse.xtext.generator.IFileSystemAccess
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.generator.IFileSystemAccess;
+import org.eclipse.xtext.generator.IGenerator;
 
-class TestLanguageGenerator implements IGenerator {
 
-	override void doGenerate(Resource resource, IFileSystemAccess fsa) {
-		//TODO implment me
-	}
+public class TestLanguageGenerator implements IGenerator {
+
+  @Override
+  public void doGenerate(final Resource resource, final IFileSystemAccess fsa) {
+    // TODO implement me
+  }
 }


### PR DESCRIPTION
## What

Migrates `TestLanguageGenerator` from Xtend to idiomatic Java 21 — the last `.xtend` in `com.avaloq.tools.ddk.check.test.runtime` — and removes the module's now-unused Xtend build infrastructure (xtend-gen from `.classpath`/`build.properties`, Xtext nature/builder from `.project`, the `xtend-gen/` dir).

## How

- Verified against the freshly built `xtend-gen/` ground truth: an empty `doGenerate` body. The `// TODO implement me` comment is retained (an empty body needs a comment).
- Behaviour preserved; `.xtend` deleted and `.java` added in one commit.

Local gate green: `compile + checkstyle:check + pmd:check + spotbugs:check` on the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)