### PR TITLE
PoC: resolve patched ANTLR generator from the target platform (Maven Central)

### DIFF
--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -1,7 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="DDK Target" sequenceNumber="29">
+<target name="DDK Target" sequenceNumber="30">
 <locations>
+  <!-- Patched ANTLR 3.2 generator (the ex-itemis toolrunner + fat ANTLR tool jar), donated to
+       Eclipse and published on Maven Central. Provides the org.antlr.Tool + AntlrToolRunner that the
+       Generate*.mwe2 grammar workflows need, without relying on the dead itemis p2 repository or a
+       binary jar committed to the repo. PDE wraps the non-OSGi jars as bundles (missingManifest). -->
+  <location includeDependencyDepth="none" includeSource="false" missingManifest="generate" type="Maven">
+    <dependencies>
+      <dependency>
+        <groupId>org.eclipse.xtext</groupId>
+        <artifactId>xtext-antlr-generator</artifactId>
+        <version>2.1.1</version>
+        <type>jar</type>
+      </dependency>
+      <dependency>
+        <groupId>org.xtext</groupId>
+        <artifactId>antlr-generator</artifactId>
+        <version>3.2.1</version>
+        <type>jar</type>
+      </dependency>
+    </dependencies>
+  </location>
   <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
   <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
   <unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>


### PR DESCRIPTION
## What

Proof of concept: make the patched ANTLR 3.2 generator used by the `Generate*.mwe2` grammar workflows resolvable **from the target platform** (Maven Central) instead of from the 1.4 MB binary jar committed to `com.avaloq.tools.ddk.workflow` in #1308.

Adds a single PDE/Tycho **Maven location** to `ddk-target/ddk.target`:

- `org.eclipse.xtext:xtext-antlr-generator:2.1.1` — the `AntlrToolRunner` toolrunner that Xtext's `AntlrToolFacade` invokes.
- `org.xtext:antlr-generator:3.2.1` — the fat patched-ANTLR-3.2 tool jar (provides `org.antlr.Tool`).

PDE wraps both non-OSGi jars as bundles (`missingManifest="generate"`). `includeDependencyDepth="none"` keeps it from dragging in a second log4j.

## Why this is low risk / low complexity

The generator we currently host **is** this Maven artifact — I verified the committed `antlr-generator-3.2.0-patch.jar` is itemis's patched ANTLR fat jar, and `org.eclipse.xtext:xtext-antlr-generator` (donated to Eclipse, on Central since 2014) carries the identical `de.itemis.xtext.antlr.toolrunner` classes and declares the fat jar as a transitive dependency. No repackaging, no building, no dead p2 repo — a declarative one-location target edit.

## How to test locally

1. Set `ddk-target/ddk.target` as the active target platform; reload it.
2. Confirm the two generated bundles (`xtext-antlr-generator`, `antlr-generator`) resolve in the target contents.
3. Optionally remove the `<classpathentry kind="lib" path="antlr-generator-3.2.0-patch.jar"/>` line from `com.avaloq.tools.ddk.workflow/.classpath` and re-run a `Generate*.mwe2` launch to prove the generator now resolves from the target.

## Scope

Purely additive — the committed jar is left in place so the branch stays green. If local testing confirms the target route works, the follow-up removes the committed jar + its provenance note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)