### PR TITLE
docs: add Javadoc to public and protected API

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/CheckRuntimeModule.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/CheckRuntimeModule.java
@@ -53,6 +53,11 @@ public class CheckRuntimeModule extends com.avaloq.tools.ddk.check.AbstractCheck
     return CheckBatchLinkableResource.class;
   }
 
+  /**
+   * Binds the resource storage facade.
+   *
+   * @return the resource storage facade class
+   */
   public Class<? extends IResourceStorageFacade> bindIResourceStorageFacade() {
     return CheckBatchLinkableResourceStorageFacade.class;
   }
@@ -153,10 +158,20 @@ public class CheckRuntimeModule extends com.avaloq.tools.ddk.check.AbstractCheck
     return CheckRewritableImportSectionFactory.class;
   }
 
+  /**
+   * Binds the formatter.
+   *
+   * @return the formatter class
+   */
   public Class<? extends org.eclipse.xtext.formatting2.IFormatter2> bindIFormatter2() {
     return com.avaloq.tools.ddk.check.formatting2.CheckFormatter.class;
   }
 
+  /**
+   * Configures the formatter preferences.
+   *
+   * @param binder the Guice binder
+   */
   public void configureFormatterPreferences(final com.google.inject.Binder binder) {
     binder.bind(IPreferenceValuesProvider.class).annotatedWith(org.eclipse.xtext.formatting2.FormatterPreferences.class).to(org.eclipse.xtext.formatting2.FormatterPreferenceValuesProvider.class);
   }

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/AbstractDispatchingCheckImpl.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/AbstractDispatchingCheckImpl.java
@@ -53,10 +53,23 @@ public abstract class AbstractDispatchingCheckImpl extends AbstractCheckImpl {
   protected static class DisabledMethodTracker {
     private final Map<String, Boolean> disabled = new ConcurrentHashMap<>();
 
+    /**
+     * Marks the given method as disabled.
+     *
+     * @param string
+     *          the method identifier
+     */
     public void setDisabled(final String string) {
       disabled.putIfAbsent(string, Boolean.TRUE);
     }
 
+    /**
+     * Returns whether the given method is disabled.
+     *
+     * @param string
+     *          the method identifier
+     * @return {@code true} if disabled
+     */
     public boolean isDisabled(final String string) {
       return disabled.getOrDefault(string, Boolean.FALSE);
     }
@@ -86,9 +99,27 @@ public abstract class AbstractDispatchingCheckImpl extends AbstractCheckImpl {
    * as required by {@link AbstractDispatchingCheckImpl}.
    */
   public interface DiagnosticCollector extends ValidationMessageAcceptor {
+    /**
+     * Records the check type of the subsequently executed checks.
+     *
+     * @param checkType
+     *          the check type
+     */
     void setCurrentCheckType(CheckType checkType);
   }
 
+  /**
+   * Validates the given object.
+   *
+   * @param checkMode
+   *          the check mode
+   * @param object
+   *          the object to validate
+   * @param diagnosticCollector
+   *          the diagnostic collector
+   * @param eventCollector
+   *          the event collector
+   */
   protected abstract void validate(CheckMode checkMode, EObject object, DiagnosticCollector diagnosticCollector, ResourceValidationRuleSummaryEvent.Collector eventCollector);
 
   /**

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/DispatchingCheckImpl.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/issue/DispatchingCheckImpl.java
@@ -50,10 +50,23 @@ public abstract class DispatchingCheckImpl extends AbstractCheckImpl {
   protected static class DisabledMethodTracker {
     private final Map<String, Boolean> disabled = new ConcurrentHashMap<>();
 
+    /**
+     * Marks the given method as disabled.
+     *
+     * @param string
+     *          the method identifier
+     */
     public void setDisabled(final String string) {
       disabled.putIfAbsent(string, Boolean.TRUE);
     }
 
+    /**
+     * Returns whether the given method is disabled.
+     *
+     * @param string
+     *          the method identifier
+     * @return {@code true} if disabled
+     */
     public boolean isDisabled(final String string) {
       return disabled.getOrDefault(string, Boolean.FALSE);
     }
@@ -99,6 +112,16 @@ public abstract class DispatchingCheckImpl extends AbstractCheckImpl {
     ResourceValidationRuleSummaryEvent.Collector getEventCollector();
   }
 
+  /**
+   * Validates the given object.
+   *
+   * @param checkMode
+   *          the check mode
+   * @param object
+   *          the object to validate
+   * @param diagnosticCollector
+   *          the diagnostic collector
+   */
   protected abstract void validate(CheckMode checkMode, EObject object, DiagnosticCollector diagnosticCollector);
 
   /**

--- a/com.avaloq.tools.ddk.checkcfg.core.test/src/com/avaloq/tools/ddk/checkcfg/util/CheckCfgModelUtil.java
+++ b/com.avaloq.tools.ddk.checkcfg.core.test/src/com/avaloq/tools/ddk/checkcfg/util/CheckCfgModelUtil.java
@@ -16,22 +16,48 @@ package com.avaloq.tools.ddk.checkcfg.util;
  */
 public class CheckCfgModelUtil {
 
+  /**
+   * Returns a basic model with the given name.
+   *
+   * @param name the model name
+   * @return the model string
+   */
   public String basicModel(final String name) {
     return "check configuration " + name + " {";
   }
 
+  /**
+   * Returns a basic model with the default name.
+   *
+   * @return the model string
+   */
   public String basicModel() {
     return basicModel("testing");
   }
 
+  /**
+   * Returns a basic model with a catalog.
+   *
+   * @return the model string
+   */
   public String basicModelWithCatalog() {
     return basicModel() + "catalog Sample {";
   }
 
+  /**
+   * Returns a basic model with a catalog and a test.
+   *
+   * @return the model string
+   */
   public String basicModelWithTest() {
     return basicModelWithCatalog() + "Test";
   }
 
+  /**
+   * Returns a basic model with a catalog and a disabled test.
+   *
+   * @return the model string
+   */
   public String basicModelWithDisabledTest() {
     return basicModelWithCatalog() + "ignore Test";
   }

--- a/com.avaloq.tools.ddk.checkcfg.core/src/com/avaloq/tools/ddk/checkcfg/generator/CheckCfgGenerator.java
+++ b/com.avaloq.tools.ddk.checkcfg.core/src/com/avaloq/tools/ddk/checkcfg/generator/CheckCfgGenerator.java
@@ -31,10 +31,21 @@ public class CheckCfgGenerator implements IGenerator {
   @Inject
   private CheckConfigurationPropertiesGenerator propertiesGenerator;
 
+  /**
+   * Returns the output path for generated files.
+   *
+   * @return the output path
+   */
   public String outputPath() {
     return ".settings";
   }
 
+  /**
+   * Returns the name of the file to generate for the given configuration.
+   *
+   * @param configuration the check configuration
+   * @return the file name
+   */
   @SuppressWarnings("PMD.UnusedFormalParameter") // parameter kept for API consistency
   public String fileName(final CheckConfiguration configuration) {
     return ICheckConfigurationStoreService.DEFAULT_CHECK_CONFIGURATION_NODE + ".prefs";
@@ -51,6 +62,12 @@ public class CheckCfgGenerator implements IGenerator {
     }
   }
 
+  /**
+   * Compiles the given check configuration into its properties representation.
+   *
+   * @param config the check configuration to compile
+   * @return the generated properties content
+   */
   public CharSequence compile(final CheckConfiguration config) {
     final Properties properties = propertiesGenerator.convertToProperties(config);
     final StringBuilder builder = new StringBuilder(512);

--- a/com.avaloq.tools.ddk.checkcfg.core/src/com/avaloq/tools/ddk/checkcfg/util/PropertiesInferenceHelper.java
+++ b/com.avaloq.tools.ddk.checkcfg.core/src/com/avaloq/tools/ddk/checkcfg/util/PropertiesInferenceHelper.java
@@ -50,6 +50,13 @@ public class PropertiesInferenceHelper {
   private static final String NUMBER_LIST = "List<java.lang.Integer>";
   private static final String BOOLEAN_LIST = "List<java.lang.Boolean>";
 
+  /**
+   * Collects all inferred properties for the given check configuration.
+   *
+   * @param checkConfiguration the check configuration
+   * @param properties the list to which inferred properties are added
+   * @return the populated list of properties
+   */
   public EList<FormalParameter> getProperties(final CheckConfiguration checkConfiguration, final EList<FormalParameter> properties) {
     final JvmTypeReferenceBuilder referenceBuilder = typeRefBuilderFactory.create(checkConfiguration.eResource().getResourceSet());
 
@@ -80,6 +87,13 @@ public class PropertiesInferenceHelper {
     return properties;
   }
 
+  /**
+   * Infers the type of the given property specification.
+   *
+   * @param contribution the property specification
+   * @param referenceBuilder the type reference builder
+   * @return the inferred type, or {@code null} if it cannot be inferred
+   */
   public JvmTypeReference inferType(final ICheckCfgPropertySpecification contribution, final JvmTypeReferenceBuilder referenceBuilder) {
     final ICheckCfgPropertySpecification.PropertyType type = contribution.getType();
     if (type == null) {
@@ -95,6 +109,13 @@ public class PropertiesInferenceHelper {
     };
   }
 
+  /**
+   * Infers the list type from the given list literal.
+   *
+   * @param newValue the list literal
+   * @param referenceBuilder the type reference builder
+   * @return the inferred list type, or {@code null} if it cannot be inferred
+   */
   public JvmTypeReference inferListType(final XListLiteral newValue, final JvmTypeReferenceBuilder referenceBuilder) {
     if (newValue.getElements().isEmpty()) {
       return null;
@@ -111,6 +132,13 @@ public class PropertiesInferenceHelper {
     }
   }
 
+  /**
+   * Infers the type of the given configured parameter.
+   *
+   * @param parameter the configured parameter
+   * @param referenceBuilder the type reference builder
+   * @return the inferred type, or {@code null} if it cannot be inferred
+   */
   public JvmTypeReference inferType(final ConfiguredParameter parameter, final JvmTypeReferenceBuilder referenceBuilder) {
     final XExpression newValue = parameter.getNewValue();
     if (newValue instanceof XBooleanLiteral) {
@@ -126,6 +154,13 @@ public class PropertiesInferenceHelper {
     }
   }
 
+  /**
+   * Infers a formal parameter from the given configured parameter.
+   *
+   * @param parameter the configured parameter
+   * @param referenceBuilder the type reference builder
+   * @return the inferred formal parameter, or {@code null} if it cannot be inferred
+   */
   public FormalParameter inferFormalParameter(final ConfiguredParameter parameter, final JvmTypeReferenceBuilder referenceBuilder) {
     if (parameter == null) {
       return null;
@@ -134,6 +169,13 @@ public class PropertiesInferenceHelper {
       inferType(parameter, referenceBuilder));
   }
 
+  /**
+   * Infers a formal parameter from the given property specification.
+   *
+   * @param contribution the property specification
+   * @param referenceBuilder the type reference builder
+   * @return the inferred formal parameter, or {@code null} if it cannot be inferred
+   */
   public FormalParameter inferFormalParameter(final ICheckCfgPropertySpecification contribution, final JvmTypeReferenceBuilder referenceBuilder) {
     if (contribution == null) {
       return null;
@@ -141,6 +183,13 @@ public class PropertiesInferenceHelper {
     return inferFormalParameter(contribution.getName(), inferType(contribution, referenceBuilder));
   }
 
+  /**
+   * Creates a formal parameter with the given name and type.
+   *
+   * @param name the parameter name
+   * @param type the parameter type
+   * @return the created formal parameter, or {@code null} if the type is {@code null}
+   */
   public FormalParameter inferFormalParameter(final String name, final JvmTypeReference type) {
     if (type == null) {
       return null;

--- a/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/CheckCfgIdeModule.java
+++ b/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/CheckCfgIdeModule.java
@@ -108,6 +108,11 @@ public class CheckCfgIdeModule extends AbstractCheckCfgIdeModule {
     return CheckCfgIdeContentProposalProvider.class;
   }
 
+  /**
+   * Configures the language label binding.
+   *
+   * @param binder the Guice binder
+   */
   public void configureLanguageLabel(final Binder binder) {
     binder.bind(String.class).annotatedWith(Names.named(LANGUAGE_LABEL)).toInstance("CheckCfg"); //$NON-NLS-1$
   }

--- a/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/contentassist/CheckCfgIdeContentProposalProvider.java
+++ b/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/contentassist/CheckCfgIdeContentProposalProvider.java
@@ -111,6 +111,13 @@ public class CheckCfgIdeContentProposalProvider extends XbaseIdeContentProposalP
     super._createProposals(keyword, context, acceptor);
   }
 
+  /**
+   * Creates content assist proposals for the available languages.
+   *
+   * @param model the model element
+   * @param context the content assist context
+   * @param acceptor the proposal acceptor
+   */
   @SuppressWarnings("PMD.UnusedFormalParameter")
   protected void completeLanguages(final EObject model, final ContentAssistContext context, final IIdeContentProposalAcceptor acceptor) {
     for (String language : checkCfgUtil.getAllLanguages()) {
@@ -123,6 +130,13 @@ public class CheckCfgIdeContentProposalProvider extends XbaseIdeContentProposalP
     }
   }
 
+  /**
+   * Creates content assist proposals for a parameter value.
+   *
+   * @param model the model element
+   * @param context the content assist context
+   * @param acceptor the proposal acceptor
+   */
   protected void completeParameterValue(final EObject model, final ContentAssistContext context, final IIdeContentProposalAcceptor acceptor) {
     FormalParameter parameter = ((ConfiguredParameter) model).getParameter();
     ICheckCfgPropertySpecification propertySpecification = null;

--- a/com.avaloq.tools.ddk.sample.helloworld.ide/src/com/avaloq/tools/ddk/sample/helloworld/ide/HelloWorldIdeModule.java
+++ b/com.avaloq.tools.ddk.sample.helloworld.ide/src/com/avaloq/tools/ddk/sample/helloworld/ide/HelloWorldIdeModule.java
@@ -14,9 +14,19 @@ import com.avaloq.tools.ddk.xtext.ide.contentAssist.AnnotationAwareFollowElement
  */
 public class HelloWorldIdeModule extends AbstractHelloWorldIdeModule {
 
+    /**
+     * Binds the follow element computer implementation.
+     *
+     * @return the follow element computer class
+     */
     public Class<? extends FollowElementComputer> bindFollowElementComputer() {
         return AnnotationAwareFollowElementComputer.class;
     }
+    /**
+     * Binds the follow element calculator implementation.
+     *
+     * @return the follow element calculator class
+     */
     public Class<? extends FollowElementCalculator> bindFollowElementCalculator() {
         return AnnotationAwareFollowElementCalculator.class;
     }

--- a/com.avaloq.tools.ddk.sample.helloworld.ui/src/com/avaloq/tools/ddk/sample/helloworld/ui/HelloWorldUiModule.java
+++ b/com.avaloq.tools.ddk.sample.helloworld.ui/src/com/avaloq/tools/ddk/sample/helloworld/ui/HelloWorldUiModule.java
@@ -36,9 +36,19 @@ public class HelloWorldUiModule extends AbstractHelloWorldUiModule {
         return CheckConfigurationStore.class;
     }
 
+    /**
+     * Binds the follow element computer implementation.
+     *
+     * @return the follow element computer type
+     */
     public Class<? extends FollowElementComputer> bindFollowElementComputer() {
         return AnnotationAwareFollowElementComputer.class;
     }
+    /**
+     * Binds the follow element calculator implementation.
+     *
+     * @return the follow element calculator type
+     */
     public Class<? extends FollowElementCalculator> bindFollowElementCalculator() {
         return AnnotationAwareFollowElementCalculator.class;
     }

--- a/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
+++ b/com.avaloq.tools.ddk.xtext.builder/src/com/avaloq/tools/ddk/xtext/builder/MonitoredClusteringBuilderState.java
@@ -735,6 +735,14 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
     }
   }
 
+  /**
+   * Stores the binary representation of the given resource.
+   *
+   * @param resource
+   *          the resource to store
+   * @param buildData
+   *          the build data
+   */
   protected void doStoreBinaryResource(final Resource resource, final BuildData buildData) {
     IResourceStorageFacade storageFacade = ((StorageAwareResource) resource).getResourceStorageFacade();
     final long maxTaskExecutionNanos = TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
@@ -1135,6 +1143,20 @@ public class MonitoredClusteringBuilderState extends ClusteringBuilderState
     return toBuild;
   }
 
+  /**
+   * Writes the new resource descriptions for the resources to be updated.
+   *
+   * @param buildData
+   *          the build data
+   * @param oldState
+   *          the old state
+   * @param newState
+   *          the new state
+   * @param newData
+   *          the new data
+   * @param monitor
+   *          the progress monitor
+   */
   protected void writeNewResourceDescriptions(final BuildData buildData, final IResourceDescriptions oldState, final CurrentDescriptions newState, final ResourceDescriptionsData newData, final IProgressMonitor monitor) {
     final List<List<URI>> toWriteGroups = phaseOneBuildSorter.sort(buildData.getToBeUpdated());
     final List<URI> toBuild = Lists.newLinkedList();

--- a/com.avaloq.tools.ddk.xtext.format.generator/src/com/avaloq/tools/ddk/xtext/format/generator/FormatFragment2.java
+++ b/com.avaloq.tools.ddk.xtext.format.generator/src/com/avaloq/tools/ddk/xtext/format/generator/FormatFragment2.java
@@ -62,6 +62,12 @@ public class FormatFragment2 extends AbstractStubGeneratingFragment {
     return generateFormatStub.get();
   }
 
+  /**
+   * Sets whether the format stub should be generated.
+   *
+   * @param generateStub
+   *          whether the format stub should be generated
+   */
   public void setGenerateFormatStub(final boolean generateStub) {
     generateFormatStub.set(generateStub);
   }
@@ -92,10 +98,22 @@ public class FormatFragment2 extends AbstractStubGeneratingFragment {
     return baseFormatterClassName;
   }
 
+  /**
+   * Returns the type reference of the formatter stub for the given grammar.
+   *
+   * @param grammar the grammar
+   * @return the formatter stub type reference
+   */
   protected TypeReference getFormatterStub(final Grammar grammar) {
     return new TypeReference(xtextGeneratorNaming.getRuntimeBasePackage(grammar) + ".formatting." + GrammarUtil.getSimpleName(grammar) + "Formatter");
   }
 
+  /**
+   * Returns the path of the format stub file for the given grammar.
+   *
+   * @param grammar the grammar
+   * @return the format stub file path
+   */
   protected String getFormatStub(final Grammar grammar) {
     final String formatter = getFormatterStub(grammar).getPath();
     return formatter.substring(0, formatter.lastIndexOf('/') + 1) + GrammarUtil.getSimpleName(grammar) + ".format";
@@ -131,6 +149,9 @@ public class FormatFragment2 extends AbstractStubGeneratingFragment {
     doGenerateStubFiles();
   }
 
+  /**
+   * Generates the configured stub files for the formatter.
+   */
   protected void doGenerateStubFiles() {
     if (!isGenerateStub()) {
       return;
@@ -155,6 +176,11 @@ public class FormatFragment2 extends AbstractStubGeneratingFragment {
   }
 
   // CHECKSTYLE:CONSTANTS-OFF
+  /**
+   * Creates the Xtend formatter stub file for the grammar.
+   *
+   * @return the Xtend stub file access
+   */
   protected XtendFileAccess doGetXtendStubFile() {
     final XtendFileAccess xtendFile = fileAccessFactory.createXtendFile(getFormatterStub(getGrammar()));
     xtendFile.setResourceSet(getLanguage().getResourceSet());
@@ -239,6 +265,11 @@ public class FormatFragment2 extends AbstractStubGeneratingFragment {
     return xtendFile;
   }
 
+  /**
+   * Creates the Java formatter stub file for the grammar.
+   *
+   * @return the Java stub file access
+   */
   protected JavaFileAccess doGetJavaStubFile() {
     final JavaFileAccess javaFile = fileAccessFactory.createJavaFile(getFormatterStub(getGrammar()));
     javaFile.setResourceSet(getLanguage().getResourceSet());
@@ -335,6 +366,11 @@ public class FormatFragment2 extends AbstractStubGeneratingFragment {
     return javaFile;
   }
 
+  /**
+   * Creates the format stub file for the grammar.
+   *
+   * @return the format stub file access
+   */
   protected TextFileAccess doGetFormatStubFile() {
     final TextFileAccess formatFile = fileAccessFactory.createTextFile(getFormatStub(getGrammar()));
 

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/ide/contentAssist/AnnotationAwareFollowElementComputer.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/ide/contentAssist/AnnotationAwareFollowElementComputer.java
@@ -44,6 +44,14 @@ public class AnnotationAwareFollowElementComputer extends FollowElementComputer 
     }
   }
 
+  /**
+   * Initialises the given calculator with an acceptor that also accepts keyword rule calls.
+   *
+   * @param calculator
+   *          the calculator to initialise
+   * @param followElementAcceptor
+   *          the acceptor for follow elements
+   */
   protected void initialiseCalculator(final FollowElementCalculator calculator, final IFollowElementAcceptor followElementAcceptor) {
     // copied from super class but calls to keyword rules are also accepted.
     calculator.setAcceptor(element -> {

--- a/com.avaloq.tools.ddk.xtext.ide/src/com/avaloq/tools/ddk/xtext/ide/contentAssist/AnnotationAwareFollowElementComputer.java
+++ b/com.avaloq.tools.ddk.xtext.ide/src/com/avaloq/tools/ddk/xtext/ide/contentAssist/AnnotationAwareFollowElementComputer.java
@@ -43,6 +43,12 @@ public class AnnotationAwareFollowElementComputer extends FollowElementComputer 
     }
   }
 
+  /**
+   * Initialises the given calculator with an acceptor that also accepts keyword rule calls.
+   *
+   * @param calculator the follow element calculator to initialise
+   * @param followElementAcceptor the acceptor for follow elements
+   */
   protected void initialiseCalculator(final FollowElementCalculator calculator, final IFollowElementAcceptor followElementAcceptor) {
     // copied from super class but calls to keyword rules are also accepted.
     calculator.setAcceptor(element -> {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/layered/DefaultXtextTargetPlatformManager.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/layered/DefaultXtextTargetPlatformManager.java
@@ -132,6 +132,9 @@ public class DefaultXtextTargetPlatformManager implements IXtextTargetPlatformMa
     listeners.remove(listener);
   }
 
+  /**
+   * Shuts the manager down, clearing all registered listeners.
+   */
   public void shutdown() {
     shutdownInProgress = true;
     listeners.clear();

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractResourceDescriptionStrategy.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/AbstractResourceDescriptionStrategy.java
@@ -205,6 +205,15 @@ public abstract class AbstractResourceDescriptionStrategy extends DefaultResourc
     return new ReferenceDescription(owner, target, eReference, exportedContainerURI, indexInList);
   }
 
+  /**
+   * Returns whether references held by the given object via the given feature should be indexed.
+   *
+   * @param from
+   *          the object holding the reference
+   * @param eReference
+   *          the reference feature to test
+   * @return {@code true} unless the reference is a containment or container reference
+   */
   @SuppressWarnings("PMD.UnusedFormalParameter")
   protected boolean isIndexable(final EObject from, final EReference eReference) {
     return !eReference.isContainment() && !eReference.isContainer();

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/PatternAwareEObjectDescriptionLookUp.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/PatternAwareEObjectDescriptionLookUp.java
@@ -85,6 +85,11 @@ public class PatternAwareEObjectDescriptionLookUp extends EObjectDescriptionLook
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Returns the lazily-initialized case-insensitive lookup of exported objects by qualified name.
+   *
+   * @return the name-to-objects lookup
+   */
   protected QualifiedNameLookup<IEObjectDescription> getNameToObjectsLookup() {
     QualifiedNameLookup<IEObjectDescription> localMap = nameToObjectsLookup;
     if (localMap == null) {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescriptionDelta.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceDescriptionDelta.java
@@ -156,6 +156,11 @@ public class ResourceDescriptionDelta extends AbstractResourceDescriptionDelta {
     oldDesc = null; // NOPMD
   }
 
+  /**
+   * Computes whether the new resource description differs from the old one.
+   *
+   * @return {@code true} if the resource is new, deleted, or its exported objects changed
+   */
   @SuppressWarnings({"PMD.CompareObjectsWithEquals", "PMD.NPathComplexity"})
   protected boolean internalHasChanges() {
     if (getNew() == null || oldDesc == null) {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceSetOptions.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/ResourceSetOptions.java
@@ -53,11 +53,26 @@ public final class ResourceSetOptions {
     resourceSet.getLoadOptions().put(INSTALL_DERIVED_STATE, installDerivedState);
   }
 
+  /**
+   * Returns whether model loading should be skipped for the given resource set.
+   *
+   * @param resourceSet
+   *          the resource set to query
+   * @return {@code true} if model loading is skipped; {@code false} by default
+   */
   public static boolean skipModel(final @NonNull ResourceSet resourceSet) {
     Object object = resourceSet.getLoadOptions().get(SKIP_MODEL);
     return object != null && (boolean) object; // default is false
   }
 
+  /**
+   * Sets whether model loading should be skipped for the given resource set.
+   *
+   * @param resourceSet
+   *          the resource set to configure
+   * @param skipModel
+   *          {@code true} to skip model loading
+   */
   public static void setSkipModel(final @NonNull ResourceSet resourceSet, final @Nullable Boolean skipModel) {
     resourceSet.getLoadOptions().put(SKIP_MODEL, skipModel);
   }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/extensions/ResourceDescriptions2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/extensions/ResourceDescriptions2.java
@@ -94,6 +94,15 @@ public class ResourceDescriptions2 implements IResourceDescriptions2 {
     return ResourceDescriptionsUtil.findReferencesToObjects(delegate, targetObjects);
   }
 
+  /**
+   * Not implemented.
+   *
+   * @param targetObjects
+   *          the descriptions whose referencing resources would be found
+   * @param matchImportedNames
+   *          whether to also match imported names
+   * @return always {@code null}; this operation is not implemented
+   */
   @SuppressWarnings("PMD.UnusedFormalParameter")
   public Iterable<IResourceDescription> findExactReferencingResources(final Set<IEObjectDescription> targetObjects, final boolean matchImportedNames) {
     return null;

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageWritable.java
@@ -237,6 +237,15 @@ public class DirectLinkingResourceStorageWritable extends ResourceStorageWritabl
 
   }
 
+  /**
+   * Writes the given number of the resource's contents to the output stream, starting at the given index.
+   *
+   * @param storageAwareResource the resource whose contents are written
+   * @param outputStream the output stream to write to
+   * @param startIndex the index of the first object to write
+   * @param objCount the number of objects to write
+   * @throws IOException if writing fails
+   */
   protected void writeSelectedContents(final StorageAwareResource storageAwareResource, final OutputStream outputStream, final int startIndex, final int objCount) throws IOException {
     SelectiveObjectOutputStream out = new SelectiveObjectOutputStream(storageAwareResource, outputStream, Collections.emptyMap());
     try {


### PR DESCRIPTION
## What

Documents the public and protected **methods** that a `MissingJavadocMethod` audit surfaced — **51 methods across 21 files**, grouped into four area commits (check, checkcfg, xtext, samples). The diff is **pure additions** (+327, 0 deletions): only Javadoc comments; no code or signatures touched.

The audit rule itself (`MissingJavadocMethod`, public+protected, methods only, trivial-accessor and `@Override`/`@Inject` exemptions) is **not enabled here** — checkstyle cannot see `.xtend` files, so the ongoing Xtend-to-Java migration exposes previously-invisible undocumented API with every merged wave, and the gate would go red after each one. Enablement is deferred to #1466, after the migration completes.

## How the docs were written

Each flagged method gets a **simple, accurate** Javadoc: a one-sentence summary plus the `@param`/`@return`/`@throws` tags the existing content rules require. Descriptions are terse and derived from the signature/obvious behaviour — no speculation, no boilerplate name-restatement. Example:
```java
/**
 * Returns whether references held by the given object via the given feature should be indexed.
 *
 * @param from
 *          the object holding the reference
 * @param eReference
 *          the reference feature to test
 * @return {@code true} unless the reference is a containment or container reference
 */
protected boolean isIndexable(final EObject from, final EReference eReference) { ... }
```

## Verification

- Full local gate (verify + checkstyle + pmd + cpd + spotbugs) green on current master.
- The added Javadoc is validated by the existing `JavadocMethod` content rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
