### PR TITLE
fix: correct directive group numbering in FormatJvmModelInferrer

### DIFF
--- a/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/jvmmodel/FormatJvmModelInferrer.xtend
+++ b/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/jvmmodel/FormatJvmModelInferrer.xtend
@@ -38,7 +38,6 @@ import com.avaloq.tools.ddk.xtext.formatting.AbstractExtendedFormatter
 import com.avaloq.tools.ddk.xtext.formatting.ExtendedFormattingConfig
 import com.avaloq.tools.ddk.xtext.formatting.locators.LocatorActivator
 import com.avaloq.tools.ddk.xtext.formatting.locators.LocatorParameterCalculator
-import com.google.common.collect.Iterables
 import com.google.inject.Inject
 import java.util.List
 import java.util.Map
@@ -472,7 +471,7 @@ class FormatJvmModelInferrer extends AbstractModelInferrer {
   // getDirectiveName dispatch
   def dispatch String getDirectiveName(GroupBlock directive) {
     val GrammarRule grammarRule = EcoreUtil2::getContainerOfType(directive, typeof(GrammarRule))
-    val directives = newArrayList(Iterables.filter(grammarRule.directives, GroupBlock));
+    val directives = grammarRule.directives.filter(GroupBlock).toList
     "Group" + String.valueOf(directives.indexOf(directive) + 1)
   }
   def dispatch String getDirectiveName(SpecificDirective directive) {


### PR DESCRIPTION
## Problem

`FormatJvmModelInferrer.getDirectiveName(GroupBlock)` numbers group directives via:

```xtend
val directives = newArrayList(Iterables.filter(grammarRule.directives, GroupBlock))
"Group" + String.valueOf(directives.indexOf(directive) + 1)
```

`newArrayList(Iterable)` binds to the `CollectionLiterals.newArrayList(T...)` varargs overload, so the filtered `Iterable<GroupBlock>` is stored as a *single element* (`ArrayList<Iterable<GroupBlock>>`) instead of being copied into the list. `indexOf(directive)` then never matches and returns `-1`, so **every** group block is named `Group0` instead of `Group1`, `Group2`, …

## Fix

Build a real `List<GroupBlock>` with `grammarRule.directives.filter(GroupBlock).toList`, so `indexOf` resolves correctly. The now-unused `com.google.common.collect.Iterables` import is removed.

## Impact

Generated formatter names for grammars with grouped format directives change from `Group0` to `Group1/2/3`. No committed generated artifacts contain the old `Group0` names, so this only affects newly generated formatters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
