### PR TITLE
fix: satisfy PMD 7.26.0 across the reactor (visibility + assertEquals order)

### DIFF
--- a/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/BasicModelTest.java
+++ b/com.avaloq.tools.ddk.check.core.test/src/com/avaloq/tools/ddk/check/core/test/BasicModelTest.java
@@ -85,7 +85,7 @@ public class BasicModelTest {
   @Disabled("Fails because DocumentedImplCustom uses the null resource description provider to get the document provider")
   public void testInferingOfDescription() throws Exception {
     final Check check = util.getFirstInstanceOf(parser.parse(modelUtil.modelWithCheck()), Check.class);
-    assertEquals(check.getDescription(), "No documentation.");
+    assertEquals("No documentation.", check.getDescription());
   }
 
   /* Tests that Checks have an implicit name which matches the ID. */

--- a/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/quickfix/AbstractQuickFixTest.java
+++ b/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/quickfix/AbstractQuickFixTest.java
@@ -352,7 +352,7 @@ public abstract class AbstractQuickFixTest extends AbstractXtextEditorTest {
   private void assertQuickFixExistsAndSuccessful(final String issueCode, final String quickfixLabel, final String expectedContent, final boolean ignoreFormatting) {
     // Assert amount of quickfixes
     int resolutionCount = resolutionsFor(issueCode, quickfixLabel).size();
-    assertEquals(resolutionCount, 1, String.format("There must be exactly one quickfix with label '%s' for issue '%s', but found '%d'.", quickfixLabel, issueCode, resolutionCount));
+    assertEquals(1, resolutionCount, String.format("There must be exactly one quickfix with label '%s' for issue '%s', but found '%d'.", quickfixLabel, issueCode, resolutionCount));
     // Apply quickfix
     UiThreadDispatcher.dispatchAndWait(new Runnable() {
       @Override

--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorSupport.java
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorSupport.java
@@ -84,7 +84,7 @@ public final class ExportGeneratorSupport extends GeneratorSupport {
       })).toArray(new EPackage[0]);
       registerMetaModel(new EmfRegistryMetaModel() {
         @Override
-        public EPackage[] allPackages() {
+        protected EPackage[] allPackages() {
           return ePackages;
         }
 

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopingGeneratorUtil.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopingGeneratorUtil.java
@@ -117,7 +117,7 @@ public final class ScopingGeneratorUtil {
       final EPackage[] ePackages = Lists.newArrayList(Iterables.transform(EObjectUtil.getScopeProviderByEObject(model).getScope(model, ScopePackage.Literals.IMPORT__PACKAGE).getAllElements(), d -> (EPackage) EcoreUtil.resolve(d.getEObjectOrProxy(), model))).toArray(new EPackage[0]);
       registerMetaModel(new EmfRegistryMetaModel() {
         @Override
-        public EPackage[] allPackages() {
+        protected EPackage[] allPackages() {
           return ePackages;
         }
 

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/jupiter/AbstractValidationTest.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/jupiter/AbstractValidationTest.java
@@ -931,7 +931,7 @@ public abstract class AbstractValidationTest extends AbstractXtextMarkerBasedTes
    *          the diagnostic to check for issues
    */
   private void assertNoDiagnostics(final Diagnostic diagnostics) {
-    assertEquals(diagnostics.getCode(), Diagnostic.OK, "Diagnostics should be in OK state.");
+    assertEquals(Diagnostic.OK, diagnostics.getCode(), "Diagnostics should be in OK state.");
     assertTrue(diagnostics.getChildren().isEmpty(), "There should be no diagnostics. Instead found " + diagnostics.getChildren().size());
   }
 

--- a/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/linking/AbstractFragmentProviderTest.java
+++ b/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/linking/AbstractFragmentProviderTest.java
@@ -37,16 +37,16 @@ public class AbstractFragmentProviderTest {
     }
 
     @Override
-    // make method public for testing
+    // make method accessible for testing
     @SuppressWarnings("PMD.UselessOverridingMethod")
-    public void appendEscaped(final String text, final StringBuilder builder) {
+    protected void appendEscaped(final String text, final StringBuilder builder) {
       super.appendEscaped(text, builder);
     }
 
     @Override
-    // make method public for testing
+    // make method accessible for testing
     @SuppressWarnings("PMD.UselessOverridingMethod")
-    public String unescape(final String text) {
+    protected String unescape(final String text) {
       return super.unescape(text);
     }
   }
@@ -57,7 +57,7 @@ public class AbstractFragmentProviderTest {
   public void testEscape() {
     StringBuilder builder = new StringBuilder();
     fragmentProvider.appendEscaped("foo/bar#\\", builder);
-    assertEquals(builder.toString(), "foo\\/bar#\\\\", "Fragment not properly scaped");
+    assertEquals("foo\\/bar#\\\\", builder.toString(), "Fragment not properly scaped");
   }
 
   @Test

--- a/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookupTest.java
+++ b/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookupTest.java
@@ -210,7 +210,7 @@ public class QualifiedNameSegmentTreeLookupTest {
 
     URI noSuchValue = URI.createURI("scheme:/anotherHost");
     expected = lookup.getMappings(noSuchValue);
-    assertEquals(expected.size(), 0);
+    assertEquals(0, expected.size());
   }
 
   private QualifiedName name(final String str) {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookup.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/naming/QualifiedNameSegmentTreeLookup.java
@@ -142,7 +142,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
       final Collection<T> result = excludeDuplicates ? Sets.<T> newHashSet() : Lists.<T> newArrayList();
       Visitor visitor = new Visitor() {
         @Override
-        public void visit(final SegmentNode node) {
+        void visit(final SegmentNode node) {
           if (node.values != null) {
             for (Object value : node.values) {
               result.add((T) value);
@@ -406,7 +406,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
       final Set<Object[]> arrays = Sets.newHashSet();
       Visitor visitor = new Visitor() {
         @Override
-        public void visit(final SegmentNode node) {
+        void visit(final SegmentNode node) {
           if (node.values != null) {
             arrays.add(node.values);
           }
@@ -543,7 +543,7 @@ public class QualifiedNameSegmentTreeLookup<T> implements QualifiedNameLookup<T>
   public void removeMappings(final T value) {
     root.accept(new Visitor() {
       @Override
-      public void visit(final SegmentNode node) {
+      void visit(final SegmentNode node) {
         Object[] newValues = ArrayUtils.remove(node.values, value);
         if (newValues != node.values) {
           node.values = newValues;


### PR DESCRIPTION
## Summary

PMD 7.26.0 tightens two rules that now flag pre-existing code across the reactor, breaking the `maven-pmd-plugin` `check` goal. This clears every violation with real fixes — **no rule suppressions**.

### `PublicMemberInNonPublicType`
Drops the needless `public` on members declared in non-public (anonymous / nested) types, narrowing each to the minimum the override allows:
- **`QualifiedNameSegmentTreeLookup`** — three `visit(SegmentNode)` overrides → package-private (they override a package-private `Visitor.visit`).
- **`ScopingGeneratorUtil` / `ExportGeneratorSupport`** — the `allPackages()` overrides → `protected` (the framework's `EmfRegistryMetaModel.allPackages()` is itself `protected`; the migration had widened it).
- **`AbstractFragmentProviderTest`** — the `appendEscaped` / `unescape` test hooks → `protected` (same-package test access preserved).

### `AssertEqualsArgumentOrder`
Puts `expected` before `actual` in five `assertEquals` calls (`BasicModelTest`, `AbstractValidationTest`, `AbstractQuickFixTest`, `AbstractFragmentProviderTest`, `QualifiedNameSegmentTreeLookupTest`). Behaviour-preserving — only corrects the reported expected/actual order.

## Why now

Unblocks the Dependabot bump **#1449** (`pmd.version` 7.25.0 → 7.26.0). Landing this on `master` first lets #1449 rebase to a clean, green, bump-only PR.

## Verification

Full reactor build **with compilation** (so PMD has real type resolution), under the new version:

```
mvn clean verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check \
    -f ddk-parent/pom.xml -Dpmd.version=7.26.0 -DskipTests
```

→ **BUILD SUCCESS, 0 PMD violations, 64 modules.**

Note: a no-compile `pmd:check` under-reports type-resolution-dependent findings, so the compile step is required to reproduce CI's `maven-verify` job faithfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)