### PR TITLE
ci: in-process SpotBugs + changed-modules-only reactor in the spotbugs lane

### DIFF
--- a/.github/scripts/compute-spotbugs-skip.sh
+++ b/.github/scripts/compute-spotbugs-skip.sh
@@ -14,13 +14,35 @@
 # only trimmed ~17% of the goal vs ~88% for this per-module skip (measured on this
 # reactor). A small upstream SpotBugs early-exit (skip the run when no application class
 # matches the screener) would make onlyAnalyze competitive; if that ever lands, switch
-# to onlyAnalyze and delete this script.
+# to onlyAnalyze and delete this script (tracked in #1455 / spotbugs/spotbugs#3796).
+#
+# On top of the skips, the changed reactor modules are exported as SPOTBUGS_SCOPE_ARGS
+# ("-pl <changed> -am") so the lane builds only those modules plus their upstream
+# dependencies instead of the full reactor. The -am-pulled unchanged dependencies still
+# carry the injected skip: they compile (complete aux-classpath) but are not analysed.
 #
 # Run from the repository root.  Usage: compute-spotbugs-skip.sh <base-sha>
 set -euo pipefail
 base="${1:?base sha required}"
 
 changed=$(git diff --name-only --diff-filter=ACMR "${base}...HEAD")
+
+# Reactor module dirs from ddk-parent's <modules> (strip the leading ../), and the
+# subset that bears sources. ddk-parent is NOT in its own <modules>, so it can never be
+# skip-injected — which prevents an accidental inherited (global) skip. Both lists are
+# computed up front because the full-scan early-exit below needs the source-bearing set
+# for its report-presence gate.
+module_dirs=$(grep -oE '<module>\.\./[^<]+</module>' ddk-parent/pom.xml \
+  | sed -E 's#.*\.\./([^<]+)</module>#\1#')
+all_source_modules=""
+while IFS= read -r mod; do
+  [ -n "$mod" ] || continue
+  if [ -f "${mod}/META-INF/MANIFEST.MF" ] && [ -d "${mod}/src" ]; then
+    all_source_modules="${all_source_modules:+${all_source_modules} }${mod}"
+  fi
+done <<EOF
+${module_dirs}
+EOF
 
 # 1) A change to shared build/config can affect any module -> full scan (skip nothing).
 #    ddk-configuration holds the analyzers' rulesets and filters (e.g. the SpotBugs
@@ -31,6 +53,16 @@ while IFS= read -r f; do
   [ -n "$f" ] || continue
   case "$f" in
     pom.xml | ddk-parent/* | .mvn/* | *.target | ddk-target/* | .github/* | ddk-configuration/* | *[Ss]pot[Bb]ugs*[Ee]xclude*)
+      # KEPT must be set on every path: in a workflow `if:` an unset env var is
+      # null, which coerces to 0 and compares EQUAL to '0' — wrongly skipping
+      # the build. "all" marks the full-scan case (only "0" relaxes the gate).
+      # EXPECT_REPORTS lists every source-bearing module so the gate verifies a
+      # full scan analysed all of them (not just >=1) — a mojo death swallowed by
+      # --fail-never can't pass as long as one sibling reported.
+      if [ -n "${GITHUB_ENV:-}" ]; then
+        echo "SPOTBUGS_KEPT=all" >> "$GITHUB_ENV"
+        echo "SPOTBUGS_EXPECT_REPORTS=${all_source_modules}" >> "$GITHUB_ENV"
+      fi
       echo "Build/config change ($f) -> full SpotBugs scan (no skips)."
       exit 0
       ;;
@@ -44,13 +76,7 @@ EOF
 #    grep's no-match exit would otherwise kill the script under pipefail.
 changed_mods=$(printf '%s\n' "${changed}" | { grep '/' || true; } | cut -d/ -f1 | sort -u)
 
-# 3) Reactor module dirs from ddk-parent's <modules> (strip the leading ../).
-#    ddk-parent is NOT in its own <modules>, so it can never be skip-injected — which
-#    is what prevents an accidental inherited (global) skip.
-module_dirs=$(grep -oE '<module>\.\./[^<]+</module>' ddk-parent/pom.xml \
-  | sed -E 's#.*\.\./([^<]+)</module>#\1#')
-
-# 4) Idempotently inject the skip property; handle poms with and without <properties>.
+# 3) Idempotently inject the skip property; handle poms with and without <properties>.
 #    sed -i.bak + rm is portable across GNU (CI) and BSD (local) sed.
 inject_skip() {
   local pom="$1/pom.xml"
@@ -64,13 +90,23 @@ inject_skip() {
   rm -f "$pom.bak"
 }
 
-# 5) Skip every reactor module that was not touched by this PR.
+# 4) Skip every reactor module that was not touched by this PR. Kept modules with a
+#    bundle MANIFEST are expected to produce an analysis report — the gate checks this
+#    so a swallowed resolution/compile failure can never pass as "nothing to scan".
 kept=0
 skipped=0
+kept_pl=""
+expect_reports=""
 while IFS= read -r mod; do
   [ -n "$mod" ] || continue
   if printf '%s\n' "${changed_mods}" | grep -qx "$mod"; then
     kept=$((kept + 1))
+    kept_pl="${kept_pl:+${kept_pl},}../${mod}"
+    # Only bundles with sources reliably emit a report (a source-less bundle,
+    # e.g. pure branding, has nothing for the analyzer to write a SARIF about).
+    if [ -f "${mod}/META-INF/MANIFEST.MF" ] && [ -d "${mod}/src" ]; then
+      expect_reports="${expect_reports:+${expect_reports} }${mod}"
+    fi
   else
     inject_skip "$mod"
     skipped=$((skipped + 1))
@@ -81,9 +117,38 @@ EOF
 
 # The gate's presence check needs to distinguish "all modules skip-injected"
 # (zero reports is the expected state) from "the analysis silently died".
+# If the only changed modules are source-less (feature / target / repository — nothing
+# any analyzer can report), fold into the docs-only no-op: export KEPT=0 so the lane
+# skips the Maven step, gate, and upload instead of failing the merged-report presence
+# check on output that could never exist.
+if [ "$kept" -eq 0 ] || [ -z "$expect_reports" ]; then
+  effective_kept=0
+else
+  effective_kept=$kept
+fi
 if [ -n "${GITHUB_ENV:-}" ]; then
-  echo "SPOTBUGS_KEPT=${kept}" >> "$GITHUB_ENV"
+  echo "SPOTBUGS_KEPT=${effective_kept}" >> "$GITHUB_ENV"
 fi
 
-echo "SpotBugs scope: scanning ${kept} changed module(s), skipping ${skipped} unchanged."
+# 5) Scope the reactor to the changed modules + their upstream dependencies. ddk-target
+#    is always kept in the -pl list: the target-definition artifact is referenced by
+#    target-platform-configuration, not by any MANIFEST, so -am never pulls it — without
+#    it in the reactor Tycho falls back to a local-repository copy, which fails on a
+#    cold cache and can silently resolve a stale target definition on a warm one.
+#    With no analysable changed module (docs-only, or source-less-only) no scope args
+#    are exported; the workflow skips the Maven step entirely on SPOTBUGS_KEPT=0.
+if [ "$effective_kept" -gt 0 ] && [ -n "${GITHUB_ENV:-}" ]; then
+  echo "SPOTBUGS_SCOPE_ARGS=-pl ../ddk-target,${kept_pl} -am" >> "$GITHUB_ENV"
+  echo "SPOTBUGS_EXPECT_REPORTS=${expect_reports}" >> "$GITHUB_ENV"
+fi
+
+echo "SpotBugs scope: scanning ${effective_kept} changed module(s), skipping ${skipped} unchanged."
 echo "Changed modules: ${changed_mods:-<none>}"
+if [ "$kept" -gt 0 ] && [ "$effective_kept" -eq 0 ]; then
+  echo "Only source-less modules changed (no analysable sources) -> no-op (KEPT=0)."
+fi
+if [ "$effective_kept" -gt 0 ]; then
+  echo "Reactor scope args: -pl ../ddk-target,${kept_pl} -am"
+else
+  echo "Reactor scope args: <full reactor>"
+fi

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -171,11 +171,15 @@ jobs:
         # working tree is dirty here; this job releases nothing, so we tell Tycho's jgit
         # build-qualifier to use the last commit's timestamp instead of failing (the
         # repo keeps jgit.dirtyWorkingTree=error for maven-verify / releases).
+        # spotbugs.fork=false analyses in the Maven JVM instead of forking a fresh 2 GB
+        # JVM per module (59 forks); the shared heap is governed by MAVEN_OPTS above
+        # (the plugin's maxHeap applies to forks only).
         run: |
           mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-never \
             compile \
             spotbugs:spotbugs \
             -Dspotbugs.sarifOutput=true \
+            -Dspotbugs.fork=false \
             -Djgit.dirtyWorkingTree=ignore
 
       - name: Merge per-module SpotBugs SARIFs

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -159,10 +159,11 @@ jobs:
           restore-keys: ${{ runner.os }}-maven-publish-
 
       - name: Scope SpotBugs to the PR's changed modules
-        # Injects <spotbugs.skip>true> into unchanged module poms so the per-module
-        # SpotBugs fork is skipped for them (the lever that actually scopes the cost).
-        # Full compile is preserved (correct aux-classpath); a build/config change ->
-        # full scan. pull_request only; master/snapshot run a full scan.
+        # Injects <spotbugs.skip>true> into unchanged module poms so their analysis is
+        # skipped, and exports SPOTBUGS_SCOPE_ARGS (-pl <changed> -am) so only the
+        # changed modules and their upstream deps build at all (skip-injected deps
+        # compile for the aux-classpath but are not analysed). A build/config change ->
+        # full scan, full reactor. pull_request only; master/snapshot run a full scan.
         run: bash .github/scripts/compute-spotbugs-skip.sh "${{ github.event.pull_request.base.sha }}"
 
       - name: SpotBugs report (SARIF)
@@ -174,8 +175,12 @@ jobs:
         # spotbugs.fork=false analyses in the Maven JVM instead of forking a fresh 2 GB
         # JVM per module (59 forks); the shared heap is governed by MAVEN_OPTS above
         # (the plugin's maxHeap applies to forks only).
+        # Skipped entirely when the scope step kept no modules (e.g. a docs-only
+        # PR): every module would carry spotbugs.skip, so the compile output
+        # would be unused. The gate below relaxes on the same condition.
+        if: env.SPOTBUGS_KEPT != '0'
         run: |
-          mvn -T 2C -f ./ddk-parent/pom.xml --batch-mode --fail-never \
+          mvn -T 2C -f ./ddk-parent/pom.xml ${SPOTBUGS_SCOPE_ARGS:-} --batch-mode --fail-never \
             compile \
             spotbugs:spotbugs \
             -Dspotbugs.sarifOutput=true \
@@ -206,12 +211,20 @@ jobs:
         # suppresses even compile/resolution failures) — never a clean pass.
         # Exception: the scope step skip-injected every module (no reactor module
         # changed, e.g. a docs-only PR), where zero reports is the expected state.
+        # Each scanned source-bearing module must additionally have produced its
+        # own SARIF, so a partially-dead scoped build cannot hide either.
         run: |
           set -eu
           if [ "${SPOTBUGS_KEPT:-}" = "0" ]; then
             echo "All modules skip-injected (no reactor module changed) — nothing to scan."
             exit 0
           fi
+          for mod in ${SPOTBUGS_EXPECT_REPORTS:-}; do
+            if [ ! -s "${mod}/target/spotbugsSarif.json" ]; then
+              echo "::error::${mod} was scanned but produced no SpotBugs SARIF — a build failure was swallowed by --fail-never."
+              exit 1
+            fi
+          done
           if [ ! -s .sarif-merged/spotbugs.sarif ]; then
             echo "::error::No SpotBugs SARIF produced — the analysis silently failed."
             exit 1

--- a/docs/ci-static-analysis-design.md
+++ b/docs/ci-static-analysis-design.md
@@ -91,9 +91,14 @@ the count-gate *stricter* than `:check` (over-fail, never under-fail), each guar
 
 ## Two operational rules
 
-- **`compile` must be full-reactor** (`-f ddk-parent/pom.xml`, no `-pl`). PMD's
-  type-resolving rules need the complete aux-classpath; a `-pl` subset produces
-  false positives (the trailing-`Throwable` case).
+- **A changed module must compile against its complete aux-classpath**, or PMD's
+  type-resolving rules false-positive (the trailing-`Throwable` case). A bare `-pl <module>`
+  subset breaks this, but `-pl <changed> -am` does not: `--also-make` restores the module's
+  full **Maven** dependency closure, which compiles for the classpath even though those deps
+  carry the analysis skip. Caveat: OSGi `Require-Bundle` siblings are *not* Maven dependencies,
+  so `-am` never pulls them — they resolve from the restored `~/.m2` p2 cache; `ddk-target` is
+  the one edge with no MANIFEST reference at all, so it is pinned explicitly into every scoped
+  reactor (a cold cache without it fails loudly rather than resolving a stale target).
 - **Merge SARIFs from SARIF files only.** Code Scanning accepts one run per category,
   so per-module SARIFs are merged (jq) before upload. The `ddk-parent` aggregator emits
   plain-XML `checkstyle-result.xml`; the merge must filter to JSON-parseable files.


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #1400.** Earlier commits belong to #1399/#1396/#1400; review only the last two commits here.

Two reductions to the `spotbugs` lane, the verify pipeline's critical path (~8.5 min full scan):

1. **`-Dspotbugs.fork=false`** — the plugin forks a fresh 2 GB JVM per module by default (59 forks per full scan). Analysis now runs inside the Maven JVM; the lane's `MAVEN_OPTS: -Xmx4g` governs the shared heap. Findings are identical (59 module SARIFs, same result count).
2. **Scoped reactor with a pinned target definition and presence-gated results** — `compute-spotbugs-skip.sh` additionally exports `SPOTBUGS_SCOPE_ARGS` (`-pl ../ddk-target,<changed modules> -am`), so a scoped run builds only the PR's changed modules plus their upstream dependencies instead of the full 64-module reactor; the `-am`-pulled unchanged dependencies keep the injected `spotbugs.skip` (they compile for the aux-classpath but are not analysed). `ddk-target` is pinned into every scoped reactor because the target-definition artifact is referenced by `target-platform-configuration`, not by any MANIFEST — without the pin, Tycho falls back to a local-repository copy of the `.target`, which fails on a cold cache and can silently resolve a *stale* target definition on a warm one (observed: an installed June copy of the same `sequenceNumber` still pointed at the 2026-03 release train). The gate verifies every scanned source-bearing module produced its SARIF (plus any-SARIF on full scans): `--fail-never` swallows even target-resolution failures, so without the presence check a dead build counts zero violations and passes vacuously. When no reactor module changed at all (e.g. a docs-only PR) the lane skips the Maven invocation and the SARIF upload entirely (`SPOTBUGS_KEPT=0`); the fail-safe full-scan path exports `KEPT=all`, because an *unset* variable coerces equal to `'0'` in the workflow `if:` expression and would wrongly skip the build. Fail-safes otherwise unchanged: build/config changes and master/snapshot builds get a full reactor and full scan.

## Measurements

| Regime | Before | After | Δ |
|---|---|---|---|
| Full scan, warm cache (this PR's runs vs the same-base #1396/#1400 runs) | 492–553s / 548–553s same-base | 307–401s across runs (latest same-base: 307s vs 548s) | ~−30–45% |
| Scoped run, one changed module, cold cache (fork probes, ddk-target pinned, analysis verified present) | 165s (skip-only) | 97–135s across runs (final-SHA runs 97–110s) | −18–41% |
| Docs-only PR, no reactor module changed (fork probe) | 165s (skip-only full compile) | 9–13s | −92% |

Local (clean tree, JDK 21, warm cache): full scan 75s vs 95s; scoped 34s vs 75s with the pinned reactor resolving the current platform (jdt.core 3.46.0). An earlier probe's 40s scoped figure was **vacuous** — the run had silently failed target resolution and analysed nothing, which is exactly the hole the presence gate closes.

## Tycho `-pl`/`-am` verification (local, exhaustive)

- **Reactor closure**: for each of the 59 non-pom modules, the `-pl <module> -am` reactor was compared against a MANIFEST-derived ground-truth closure (Require-Bundle + Fragment-Host + Import-Package→Export-Package). 59/59 covered, including the four test fragments and the Import-Package-wired test bundle.
- **Loud failure by construction**: `ddk.target` contains no DDK p2 repository, so a missing `-am` edge cannot be satisfied by a stale published DDK bundle — resolution fails hard (and the presence gate catches even a swallowed failure).
- **Behavioral equivalence**: for the deepest modules (`xtext.test`, `check.ui.test`, `xtext.format`), SpotBugs' `FindBugsSummary` (analyzed/referenced classes, size, packages) is identical between full-reactor and scoped runs; with the `ddk-target` pin the resolved third-party platform-bundle versions match exactly as well.

**Merge chain:** ~~#1399~~ (merged) → #1396 → #1400 → ***#1456 (this PR)*** → #1457 → #1397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
