### PR TITLE
fix: tolerate an unresolvable grammar in export model generation

### DIFF
--- a/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorXTest.java
+++ b/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorXTest.java
@@ -11,10 +11,15 @@
 package com.avaloq.tools.ddk.xtext.export.generator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.xtext.Grammar;
+import org.eclipse.xtext.XtextFactory;
 import org.junit.jupiter.api.Test;
 
 import com.avaloq.tools.ddk.xtext.export.export.ExportFactory;
@@ -32,6 +37,7 @@ public class ExportGeneratorXTest extends AbstractXtextTest {
   private static final String DERIVED_PACKAGE_PROVIDER = "com.avaloq.naming.fooExportedNamesProvider";
   private static final String PROJECT_FALLBACK_PROVIDER = "MyProject.naming.fooExportedNamesProvider";
   private static final String DEFAULT_FALLBACK_PROVIDER = "generated.naming.fooExportedNamesProvider";
+  private static final String NO_SIBLING_URI = "platform:/resource/TEST/NoSibling.export";
 
   private final ExportGeneratorX exportGeneratorX = getXtextTestUtil().get(ExportGeneratorX.class);
 
@@ -64,6 +70,26 @@ public class ExportGeneratorXTest extends AbstractXtextTest {
   @Test
   public void testSingleSegmentUriFallsBackToDefaultPackage() {
     assertEquals(DEFAULT_FALLBACK_PROVIDER, exportedNamesProviderFor("foo.export"));
+  }
+
+  @Test
+  public void testGetGrammarReturnsNullWithoutResolvableGrammar() {
+    final ExportModel detached = ExportFactory.eINSTANCE.createExportModel();
+    assertNull(exportGeneratorX.getGrammar(detached), "model without a resource");
+
+    final ExportModel withoutResourceSet = ExportFactory.eINSTANCE.createExportModel();
+    new ResourceImpl(URI.createURI(NO_SIBLING_URI)).getContents().add(withoutResourceSet);
+    assertNull(exportGeneratorX.getGrammar(withoutResourceSet), "resource without a resource set");
+
+    final ExportModel withoutSibling = ExportFactory.eINSTANCE.createExportModel();
+    final Resource resource = new ResourceSetImpl().createResource(URI.createURI(NO_SIBLING_URI));
+    resource.getContents().add(withoutSibling);
+    assertNull(exportGeneratorX.getGrammar(withoutSibling), "missing sibling grammar must not throw");
+
+    final Grammar proxy = XtextFactory.eINSTANCE.createGrammar();
+    ((InternalEObject) proxy).eSetProxyURI(URI.createURI("platform:/resource/TEST/Unresolved.xtext#/"));
+    withoutSibling.setTargetGrammar(proxy);
+    assertNull(exportGeneratorX.getGrammar(withoutSibling), "unresolved targetGrammar proxy");
   }
 
   private String exportedNamesProviderFor(final String uri) {

--- a/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorXTest.java
+++ b/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorXTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Group AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.export.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
+import org.junit.jupiter.api.Test;
+
+import com.avaloq.tools.ddk.xtext.export.export.ExportFactory;
+import com.avaloq.tools.ddk.xtext.export.export.ExportModel;
+import com.avaloq.tools.ddk.xtext.test.export.util.ExportTestUtil;
+import com.avaloq.tools.ddk.xtext.test.jupiter.AbstractXtextTest;
+
+
+/**
+ * Regression tests for URI-based package derivation in {@link ExportGeneratorX}.
+ */
+@SuppressWarnings("nls")
+public class ExportGeneratorXTest extends AbstractXtextTest {
+
+  private static final String DERIVED_PACKAGE_PROVIDER = "com.avaloq.naming.fooExportedNamesProvider";
+  private static final String PROJECT_FALLBACK_PROVIDER = "MyProject.naming.fooExportedNamesProvider";
+  private static final String DEFAULT_FALLBACK_PROVIDER = "generated.naming.fooExportedNamesProvider";
+
+  private final ExportGeneratorX exportGeneratorX = getXtextTestUtil().get(ExportGeneratorX.class);
+
+  @Override
+  protected ExportTestUtil getXtextTestUtil() {
+    return ExportTestUtil.getInstance();
+  }
+
+  @Override
+  protected String getTestSourceFileName() {
+    return null; // all tests fabricate synthetic resource URIs
+  }
+
+  @Test
+  public void testNestedSourceFolderUrisKeepDerivedPackage() {
+    assertEquals(DERIVED_PACKAGE_PROVIDER, exportedNamesProviderFor("platform:/resource/MyProject/src/com/avaloq/foo.export"));
+    assertEquals(DERIVED_PACKAGE_PROVIDER, exportedNamesProviderFor("platform:/resource/MyProject/src-gen/com/avaloq/foo.export"));
+    assertEquals("main.java.com.avaloq.naming.fooExportedNamesProvider", exportedNamesProviderFor("platform:/resource/MyProject/src/main/java/com/avaloq/foo.export"));
+    assertEquals("com.naming.fooExportedNamesProvider", exportedNamesProviderFor("platform:/resource/MyProject/src/com/foo.export")); // 5 segments: derivation boundary
+  }
+
+  @Test
+  public void testShortUrisFallBackToValidPackage() {
+    assertEquals(PROJECT_FALLBACK_PROVIDER, exportedNamesProviderFor("platform:/resource/MyProject/foo.export"));
+    assertEquals(PROJECT_FALLBACK_PROVIDER, exportedNamesProviderFor("platform:/resource/MyProject/src/foo.export"));
+    assertEquals(DEFAULT_FALLBACK_PROVIDER, exportedNamesProviderFor("platform:/resource/1My-Project/foo.export"));
+    assertEquals(DEFAULT_FALLBACK_PROVIDER, exportedNamesProviderFor("MyProject/foo.export")); // 2 segments: below the project-name fallback
+  }
+
+  @Test
+  public void testSingleSegmentUriFallsBackToDefaultPackage() {
+    assertEquals(DEFAULT_FALLBACK_PROVIDER, exportedNamesProviderFor("foo.export"));
+  }
+
+  private String exportedNamesProviderFor(final String uri) {
+    final Resource resource = new ResourceImpl(URI.createURI(uri));
+    final ExportModel model = ExportFactory.eINSTANCE.createExportModel();
+    resource.getContents().add(model);
+    return exportGeneratorX.getExportedNamesProvider(model);
+  }
+}

--- a/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/test/export/ExportTestSuite.java
+++ b/com.avaloq.tools.ddk.xtext.export.test/src/com/avaloq/tools/ddk/xtext/test/export/ExportTestSuite.java
@@ -13,6 +13,7 @@ package com.avaloq.tools.ddk.xtext.test.export;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
 
+import com.avaloq.tools.ddk.xtext.export.generator.ExportGeneratorXTest;
 import com.avaloq.tools.ddk.xtext.export.exporting.ExportExportingTest;
 import com.avaloq.tools.ddk.xtext.export.formatting.ExportFormattingTest;
 import com.avaloq.tools.ddk.xtext.export.scoping.ExportScopingTest;
@@ -24,6 +25,6 @@ import com.avaloq.tools.ddk.xtext.export.validation.ExportValidationTest;
  * Empty class serving only as holder for JUnit 5 suite annotations.
  */
 @Suite
-@SelectClasses({ExportFormattingTest.class, ExportValidationTest.class, ExportValidationOkTest.class, ExportScopingTest.class, ExportExportingTest.class})
+@SelectClasses({ExportFormattingTest.class, ExportValidationTest.class, ExportValidationOkTest.class, ExportScopingTest.class, ExportExportingTest.class, ExportGeneratorXTest.class})
 public class ExportTestSuite {
 }

--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorX.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorX.xtend
@@ -24,6 +24,7 @@ import com.google.inject.Inject
 import java.util.Collection
 import java.util.List
 import java.util.Map
+import javax.lang.model.SourceVersion
 import org.eclipse.emf.ecore.EAttribute
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EClassifier
@@ -53,11 +54,15 @@ class ExportGeneratorX {
 
   def List<String> getPrefix(URI uri) {
     // TODO we still need to add a package to the models. Extension models already have a name in contrast to cases above
-    if (uri.segmentsList().size > 3) {
-      return uri.segmentsList().subList(3, uri.segmentCount() - 1);      
-    } else {
-      return uri.segmentsList().subList(uri.segmentCount() - 2, uri.segmentCount() - 1);
+    val segments = uri.segmentsList
+    if (segments.size > 4) {
+      return segments.subList(3, segments.size - 1)
     }
+    // shorter shapes have no package segments: fall back to a valid package name
+    if (segments.size > 2 && SourceVersion.isName(segments.get(1))) {
+      return #[segments.get(1)]
+    }
+    return #['generated']
   }
 
   def String getExportedNamesProvider(ExportModel model) {

--- a/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorX.xtend
+++ b/com.avaloq.tools.ddk.xtext.export/src/com/avaloq/tools/ddk/xtext/export/generator/ExportGeneratorX.xtend
@@ -43,13 +43,22 @@ class ExportGeneratorX {
   }
 
   def Grammar getGrammar(ExportModel model) {
-    val uri = model.eResource.URI
     // Grammar should be set correctly for export extensions, not yet for normal export sources
-    if(model.targetGrammar !== null) {
+    if (model.targetGrammar !== null && !model.targetGrammar.eIsProxy) {
       return model.targetGrammar;
     }
-    val grammarResource = model.eResource.resourceSet.getResource(uri.trimSegments(1).appendSegment(uri.trimFileExtension.lastSegment + '.xtext'), true)
-    return grammarResource?.contents.head as Grammar
+    val resource = model.eResource
+    if (resource?.resourceSet === null) {
+      return null
+    }
+    val uri = resource.URI
+    try {
+      val grammarResource = resource.resourceSet.getResource(uri.trimSegments(1).appendSegment(uri.trimFileExtension.lastSegment + '.xtext'), true)
+      return grammarResource?.contents.head as Grammar
+    } catch (RuntimeException e) {
+      // no resolvable sibling grammar; all generators tolerate a null grammar
+      return null
+    }
   }
 
   def List<String> getPrefix(URI uri) {

--- a/com.avaloq.tools.ddk.xtext.expression/src/com/avaloq/tools/ddk/xtext/expression/generator/GeneratorUtil.java
+++ b/com.avaloq.tools.ddk.xtext.expression/src/com/avaloq/tools/ddk/xtext/expression/generator/GeneratorUtil.java
@@ -55,7 +55,9 @@ public class GeneratorUtil {
    */
   public static Set<EClass> allInstantiatedTypes(final Grammar grammar) {
     Set<EClass> result = Sets.newLinkedHashSet();
-    collectInstantiatedTypes(grammar, result);
+    if (grammar != null) { // no grammar -> no parser-instantiated subtypes
+      collectInstantiatedTypes(grammar, result);
+    }
     return result;
   }
 


### PR DESCRIPTION
Stacked on #1281.

## Summary
`ExportGeneratorX.getGrammar` demand-loads the sibling `<name>.xtext` next to an export model (`resourceSet.getResource(..., true)`). For any model without such a sibling — every test `.export` file, models built via ParseHelper — the load **throws**, so the Xtext builder participant logs `Error during compilation of '<file>'` with a full stack trace and silently aborts generation for that file. Every full test run carries dozens of these ERROR entries, and the generator's main path never actually executes over the test fixtures.

This makes grammar resolution defensive: guard a missing resource/resource set, reject unresolved `targetGrammar` proxies, catch the demand-load failure — return null. Downstream, `GeneratorUtil.allInstantiatedTypes` treats a null grammar as "no parser-instantiated subtypes" (one guard covering both `typeMap` and `canContain` — exercising generation past the resolver for the first time exposed this second latent NPE), and the remaining call sites already tolerate a null grammar (`grammar?.name ?: …` in `ExportedNamesProviderGenerator`; explicit null check in `ResourceDescriptionManagerGenerator`). Export model generation now degrades gracefully (direct type mappings, no subtype expansion) instead of aborting.

Phase 0 of #1458 (role-aware package identity): resolution failure must select the fallback, never fail generation.

## Verification
- New `testGetGrammarReturnsNullWithoutResolvableGrammar` covers the resolver matrix: detached model, resource without resource set, missing sibling grammar, unresolved `targetGrammar` proxy.
- Full local gate: `mvn -T 3C clean verify pmd:check checkstyle:check spotbugs:check` → BUILD SUCCESS; `Error during compilation` entries for export fixtures gone from the AllTests log (baseline: ~25 per run).
- CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
