### PR TITLE
fix: make isExtensionUpdateRequired uniformly public (widen over narrow)

### DIFF
--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/AbstractCheckExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/AbstractCheckExtensionHelper.java
@@ -143,7 +143,7 @@ public abstract class AbstractCheckExtensionHelper implements ICheckExtensionHel
    *         in.
    */
   @SuppressWarnings("PMD.UnusedFormalParameter")
-  protected boolean isExtensionUpdateRequired(final CheckCatalog catalog, final IPluginExtension extension, final Iterable<IPluginElement> elements) {
+  public boolean isExtensionUpdateRequired(final CheckCatalog catalog, final IPluginExtension extension, final Iterable<IPluginElement> elements) {
     return extension.getPoint().equals(getExtensionPointId()); // if points are different, given extension must not be updated
   }
 

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckMarkerHelpExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckMarkerHelpExtensionHelper.java
@@ -138,7 +138,7 @@ public class CheckMarkerHelpExtensionHelper extends AbstractCheckDocumentationEx
   }
 
   @Override
-  protected boolean isExtensionUpdateRequired(final CheckCatalog catalog, final IPluginExtension extension, final Iterable<IPluginElement> elements) {
+  public boolean isExtensionUpdateRequired(final CheckCatalog catalog, final IPluginExtension extension, final Iterable<IPluginElement> elements) {
     // TODO should check if this check is too expensive; consider rewriting contents instead
     if (!super.isExtensionUpdateRequired(catalog, extension, elements)) {
       return false;


### PR DESCRIPTION
## Problem

`AbstractCheckExtensionHelper.isExtensionUpdateRequired` is declared `protected` (a template-method hook, called only from the helper's own update flow), but five of its six subclasses have overridden it as `public` since the initial Check contribution (2016, `e78f8113a`) — Java permits an override to widen visibility, so the mismatch compiles silently. `CheckMarkerHelpExtensionHelper` is the lone `protected` override. The hierarchy carries two visibilities for one contract.

## The trade-off, and the choice made

Two consistent end states were possible:

- **Narrow** the `public` outliers to `protected`, matching the parent declaration. This is the textbook template-method shape — but `CheckTocExtensionTest` and `CheckContextsExtensionTest` have unit-tested the hook **directly on injected helper instances** since 2017, from a different bundle and package. Narrowing breaks those calls and forces test-only re-widening subclasses (~24 lines of scaffolding whose sole job is to undo the narrowing for tests).
- **Widen** the parent declaration and the one remaining `protected` override to `public`. Two lines, no scaffolding, and it ratifies how the hierarchy has actually been designed and used for nine years: the predicate was evidently meant to be white-box testable from day one.

**Widening was chosen** — direct testability of the hook is a long-standing, deliberate part of this hierarchy's design, and the project generally accepts `public` where tests require it.

## What this does

- `AbstractCheckExtensionHelper.isExtensionUpdateRequired`: `protected` → `public`.
- `CheckMarkerHelpExtensionHelper.isExtensionUpdateRequired`: `protected` → `public` (an override may not be narrower than its parent, so this follows necessarily).

Coordination note: #1397's helper refactor originally declared the two delegating overrides (`CheckValidatorExtensionHelper`, `CheckQuickfixExtensionHelper`) `protected`; it has been amended to keep them `public` so the build stays green in either merge order.

## Verification

- Repo-wide caller census: the only callers of `isExtensionUpdateRequired` are the parent's own update flow, `CheckMarkerHelpExtensionHelper`'s `super` call, and the two tests — no behavior change is possible; this is a visibility-only change.
- Full local gate (`clean verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check`): BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
