### PR TITLE
perf(build): pin target-platform executionEnvironment to JavaSE-21

### DIFF
--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="DDK Target" sequenceNumber="29">
+<target name="DDK Target" sequenceNumber="30">
 <locations>
   <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
   <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
@@ -65,4 +65,5 @@
     <unit id="junit-platform-suite-engine" version="6.1.0"/>
   </location>
 </locations>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 </target>


### PR DESCRIPTION
## Problem

`target-platform-configuration` in `ddk-parent/pom.xml` declares no `<executionEnvironment>`. Tycho then adds the profile of the JDK running Maven (e.g. JavaSE-26) alongside the bundles' BREE — all 60 plugins declare `JavaSE-21` — and resolves the target definition once per profile, on every build:

```
Resolving target definition ... execution environment=...'JavaSE-26'...
Resolving target definition ... execution environment=...'JavaSE-21'...
```

The resolution result (and therefore the build) also silently varies with whichever JDK happens to run Maven.

## Change

Pin `<executionEnvironment>JavaSE-21</executionEnvironment>`, matching the BREE all bundles declare.

## Measured (local, macOS aarch64, JDK 26 running Maven)

- Target resolutions per build: 2 → 1 (log- and probe-verified).
- Wall time: within noise (~0.1–0.7 s marginal saving; the removed resolution's apparent 1.5 s cost was mostly one-time repository loading that moves into the surviving resolution). The primary value is determinism: resolution no longer depends on the JDK running the build.
- Gates: full `mvn clean package` green; compiled class-file major version unchanged (65 / Java 21).

## CI numbers (added after workflow runs)

`verify` workflow, ubuntu runner: **13m16s** (green, first run) vs recent master runs median **~13m25s** (n=8, range 11m49s–18m34s) — parity, as expected: the pin removes a redundant resolution whose marginal cost is sub-second; its value is determinism, not CI wall time.

---
Assisted by Claude.
