### PR TITLE
perf(target): add slim slicer-mode ddk-ci.target as opt-in alternative

### DIFF
--- a/com.avaloq.tools.ddk.xtext.test/pom.xml
+++ b/com.avaloq.tools.ddk.xtext.test/pom.xml
@@ -47,7 +47,32 @@
             <extraRequirements>
               <requirement>
                 <type>eclipse-feature</type>
-                <id>org.eclipse.xtext.sdk</id>
+                <id>org.eclipse.xtext.runtime</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.xtext.ui</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-feature</type>
+                <id>org.eclipse.xtext.xbase</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.xtext.xtext.ui</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.xtext.testing</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.xtext.ui.testing</id>
                 <versionRange>0.0.0</versionRange>
               </requirement>
               <requirement>

--- a/ddk-target/ddk-ci.target
+++ b/ddk-target/ddk-ci.target
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="DDK Target (CI, slim slicer)" sequenceNumber="30">
+<locations>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+  <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
+  <unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
+  <unit id="org.eclipse.swtbot.ide.feature.group" version="0.0.0"/>
+  <repository location="http://download.eclipse.org/technology/swtbot/releases/4.3.0/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+    <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.pde.core" version="0.0.0"/>
+    <unit id="org.eclipse.pde.build" version="0.0.0"/>
+    <unit id="org.eclipse.pde.launching" version="0.0.0"/>
+    <unit id="org.eclipse.pde.ds.core" version="0.0.0"/>
+    <unit id="org.eclipse.pde.bnd.ui" version="0.0.0"/>
+    <unit id="org.eclipse.ant.launching" version="0.0.0"/>
+    <unit id="org.eclipse.ant.core" version="0.0.0"/>
+    <unit id="org.apache.ant" version="0.0.0"/>
+    <unit id="org.eclipse.ant.ui" version="0.0.0"/>
+    <unit id="org.eclipse.pde.ui" version="0.0.0"/>
+    <unit id="org.eclipse.pde.ua.core" version="0.0.0"/>
+    <unit id="org.eclipse.pde.junit.runtime" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.junit.runtime" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.junit" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.junit.core" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
+    <unit id="com.jcraft.jsch" version="0.0.0"/>
+    <unit id="org.eclipse.ecf" version="0.0.0"/>
+    <unit id="org.eclipse.ecf.identity" version="0.0.0"/>
+    <unit id="org.eclipse.ecf.filetransfer" version="0.0.0"/>
+    <unit id="org.eclipse.ecf.provider.filetransfer" version="0.0.0"/>
+    <unit id="org.eclipse.ecf.provider.filetransfer.httpclient5" version="0.0.0"/>
+    <unit id="org.eclipse.ecf.provider.filetransfer.httpclientjava" version="0.0.0"/>
+    <unit id="org.apache.httpcomponents.client5.httpclient5" version="0.0.0"/>
+    <unit id="org.apache.httpcomponents.core5.httpcore5" version="0.0.0"/>
+    <unit id="org.apache.httpcomponents.core5.httpcore5-h2" version="0.0.0"/>
+    <unit id="com.sun.jna" version="0.0.0"/>
+    <unit id="com.sun.jna.platform" version="0.0.0"/>
+    <unit id="jakarta.annotation-api" version="0.0.0"/>
+    <unit id="jakarta.xml.bind-api" version="0.0.0"/>
+    <unit id="jakarta.activation-api" version="0.0.0"/>
+    <unit id="org.apache.batik.css" version="0.0.0"/>
+    <unit id="org.apache.batik.util" version="0.0.0"/>
+    <unit id="org.apache.batik.constants" version="0.0.0"/>
+    <unit id="org.apache.batik.i18n" version="0.0.0"/>
+    <unit id="org.apache.xmlgraphics" version="0.0.0"/>
+    <unit id="org.eclipse.orbit.xml-apis-ext" version="0.0.0"/>
+    <unit id="org.apache.commons.commons-io" version="0.0.0"/>
+    <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
+    <unit id="com.github.weisj.jsvg" version="0.0.0"/>
+    <unit id="org.apache.aries.spifly.dynamic.bundle" version="0.0.0"/>
+    <unit id="org.objectweb.asm" version="0.0.0"/>
+    <unit id="org.objectweb.asm.commons" version="0.0.0"/>
+    <unit id="org.objectweb.asm.tree" version="0.0.0"/>
+    <unit id="org.objectweb.asm.tree.analysis" version="0.0.0"/>
+    <unit id="org.objectweb.asm.util" version="0.0.0"/>
+    <unit id="org.apache.felix.scr" version="0.0.0"/>
+    <unit id="org.apache.felix.gogo.command" version="0.0.0"/>
+    <unit id="org.apache.felix.gogo.runtime" version="0.0.0"/>
+    <unit id="org.apache.felix.gogo.shell" version="0.0.0"/>
+    <unit id="org.eclipse.jetty.servlet-api" version="0.0.0"/>
+    <unit id="org.eclipse.equinox.http.servlet" version="0.0.0"/>
+    <unit id="org.eclipse.equinox.http.service.api" version="0.0.0"/>
+    <unit id="org.eclipse.equinox.http.registry" version="0.0.0"/>
+    <unit id="org.mortbay.jasper.mortbay-apache-jsp" version="0.0.0"/>
+    <unit id="org.mortbay.jasper.mortbay-apache-el" version="0.0.0"/>
+    <unit id="org.eclipse.equinox.jsp.jasper" version="0.0.0"/>
+    <unit id="org.eclipse.equinox.jsp.jasper.registry" version="0.0.0"/>
+    <unit id="org.apache.lucene.analysis-common" version="0.0.0"/>
+    <unit id="org.apache.lucene.core" version="0.0.0"/>
+    <unit id="org.apache.lucene.analysis-smartcn" version="0.0.0"/>
+    <unit id="org.eclipse.jetty.ee8.security" version="0.0.0"/>
+    <unit id="org.eclipse.jetty.ee8.server" version="0.0.0"/>
+    <unit id="org.eclipse.jetty.ee8.servlet" version="0.0.0"/>
+    <unit id="org.eclipse.jetty.http" version="0.0.0"/>
+    <unit id="org.eclipse.jetty.io" version="0.0.0"/>
+    <unit id="org.eclipse.jetty.security" version="0.0.0"/>
+    <unit id="org.eclipse.jetty.server" version="0.0.0"/>
+    <unit id="org.eclipse.jetty.session" version="0.0.0"/>
+    <unit id="org.eclipse.jetty.util" version="0.0.0"/>
+    <unit id="com.ibm.icu" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.core" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.core.compiler.batch" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.ui" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.launching" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.launching.macosx" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.debug" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.debug.ui" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.core.manipulation" version="0.0.0"/>
+    <unit id="org.eclipse.search.core" version="0.0.0"/>
+    <unit id="biz.aQute.bndlib" version="0.0.0"/>
+    <unit id="biz.aQute.bnd.util" version="0.0.0"/>
+    <unit id="biz.aQute.repository" version="0.0.0"/>
+    <unit id="biz.aQute.resolve" version="0.0.0"/>
+    <unit id="aQute.libg" version="0.0.0"/>
+    <unit id="org.bndtools.versioncontrol.ignores.manager" version="0.0.0"/>
+    <unit id="org.bndtools.versioncontrol.ignores.plugin.git" version="0.0.0"/>
+    <unit id="org.bndtools.headless.build.plugin.gradle" version="0.0.0"/>
+    <unit id="org.bndtools.headless.build.manager" version="0.0.0"/>
+    <unit id="bndtools.api" version="0.0.0"/>
+    <unit id="org.bndtools.templating" version="0.0.0"/>
+    <unit id="org.osgi.service.repository" version="0.0.0"/>
+    <unit id="org.osgi.service.coordinator" version="0.0.0"/>
+    <unit id="org.osgi.service.metatype" version="0.0.0"/>
+    <unit id="org.osgi.service.http.whiteboard" version="0.0.0"/>
+    <unit id="org.osgi.namespace.contract" version="0.0.0"/>
+    <unit id="org.osgi.namespace.extender" version="0.0.0"/>
+    <unit id="org.osgi.namespace.service" version="0.0.0"/>
+    <unit id="org.osgi.service.device" version="0.0.0"/>
+    <unit id="org.osgi.service.provisioning" version="0.0.0"/>
+    <unit id="org.osgi.service.upnp" version="0.0.0"/>
+    <unit id="org.osgi.service.useradmin" version="0.0.0"/>
+    <unit id="org.osgi.service.wireadmin" version="0.0.0"/>
+    <unit id="org.osgi.util.measurement" version="0.0.0"/>
+    <unit id="org.osgi.util.position" version="0.0.0"/>
+    <unit id="org.osgi.util.xml" version="0.0.0"/>
+    <unit id="org.commonmark" version="0.0.0"/>
+    <unit id="org.commonmark.ext-gfm-tables" version="0.0.0"/>
+    <unit id="bcpg" version="0.0.0"/>
+    <unit id="bcprov" version="0.0.0"/>
+    <unit id="bcutil" version="0.0.0"/>
+    <unit id="org.tukaani.xz" version="0.0.0"/>
+    <unit id="org.sat4j.core" version="0.0.0"/>
+    <unit id="org.sat4j.pb" version="0.0.0"/>
+    <unit id="org.osgi.service.component" version="0.0.0"/>
+    <unit id="org.osgi.util.promise" version="0.0.0"/>
+    <unit id="org.osgi.util.function" version="0.0.0"/>
+    <unit id="org.osgi.service.prefs" version="0.0.0"/>
+    <unit id="org.osgi.service.event" version="0.0.0"/>
+    <unit id="org.osgi.service.cm" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/releases/2026-06/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="false" type="InstallableUnit">
+  <unit id="org.eclipse.emf.feature.group" version="0.0.0"/>
+  <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.39.0/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="false" type="InstallableUnit">
+    <unit id="org.eclipse.xtend" version="0.0.0"/>
+    <unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
+    <unit id="org.eclipse.xtend.util.stdlib" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/modeling/m2t/xpand/updates/releases/R201605260315/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+    <unit id="org.eclipse.emf.mwe2.runtime" version="0.0.0"/>
+    <unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
+    <unit id="org.eclipse.emf.mwe.utils" version="0.0.0"/>
+    <unit id="org.eclipse.emf.mwe.core" version="0.0.0"/>
+    <unit id="org.apache.commons.cli" version="0.0.0"/>
+    <unit id="org.eclipse.emf.mwe2.language" version="0.0.0"/>
+    <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+    <unit id="org.eclipse.xtend.lib.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.runtime.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.ui.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.xbase.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.xbase.lib.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.xtext.generator" version="0.0.0"/>
+    <unit id="io.github.classgraph.classgraph" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.xtext.ui" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.xtext.wizard" version="0.0.0"/>
+    <unit id="org.kohsuke.args4j" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.testing" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.ui.testing" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.xbase.testing" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.xbase.ui.testing" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.43.0/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="false" type="InstallableUnit">
+    <repository location="https://download.eclipse.org/lsp4j/updates/releases/1.0.0/"/>
+    <unit id="org.eclipse.lsp4j" version="0.0.0"/>
+    <unit id="com.google.gson" version="0.0.0"/>
+    <unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="false" type="InstallableUnit">
+    <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.40.0"/>
+    <unit id="org.opentest4j" version="0.0.0"/>
+    <unit id="com.google.guava" version="0.0.0"/>
+    <unit id="com.google.guava.failureaccess" version="0.0.0"/>
+    <unit id="com.google.inject" version="0.0.0"/>
+    <unit id="jakarta.inject.jakarta.inject-api" version="0.0.0"/>
+    <unit id="org.aopalliance" version="0.0.0"/>
+    <unit id="net.bytebuddy.byte-buddy" version="1.18.8"/>
+    <unit id="net.bytebuddy.byte-buddy-agent" version="0.0.0"/>
+    <unit id="org.objenesis" version="3.5.0"/>
+    <unit id="org.mockito.mockito-core" version="5.23.0"/>
+    <unit id="org.hamcrest" version="3.0.0"/>
+    <unit id="org.hamcrest.library" version="0.0.0"/>
+    <unit id="org.hamcrest.core" version="0.0.0"/>
+    <unit id="slf4j.api" version="0.0.0"/>
+    <unit id="slf4j.simple" version="0.0.0"/>
+    <unit id="org.apache.commons.logging" version="1.2.0"/>
+    <unit id="org.apache.commons.text" version="1.15.0"/>
+    <unit id="org.apache.commons.lang3" version="3.20.0"/>
+    <unit id="org.apache.logging.log4j.core" version="2.26.0"/>
+    <unit id="org.apache.logging.log4j.api" version="2.26.0"/>
+    <unit id="org.apache.log4j" version="1.2.26"/> <!--use reload4j 1.2.26 for org.eclipse.xtext dependencies to log4j-->
+    <unit id="org.junit" version="0.0.0"/>
+    <unit id="junit-jupiter-api" version="6.1.0"/>
+    <unit id="junit-jupiter-engine" version="6.1.0"/>
+    <unit id="junit-jupiter-params" version="6.1.0"/>
+    <unit id="junit-platform-commons" version="6.1.0"/>
+    <unit id="junit-platform-engine" version="6.1.0"/>
+    <unit id="junit-platform-launcher" version="6.1.0"/>
+    <unit id="junit-platform-suite-api" version="6.1.0"/>
+    <unit id="junit-platform-suite-engine" version="6.1.0"/>
+  </location>
+</locations>
+</target>

--- a/ddk-target/pom.xml
+++ b/ddk-target/pom.xml
@@ -29,6 +29,11 @@
                   <type>target</type>
                   <classifier>ddk</classifier>
                 </artifact>
+                <artifact>
+                  <file>ddk-ci.target</file>
+                  <type>target</type>
+                  <classifier>ddk-ci</classifier>
+                </artifact>
               </artifacts>
             </configuration>
           </execution>


### PR DESCRIPTION
## Problem

The default `ddk.target` uses `includeMode="planner"`, which provisions a complete install closure. Cost per Eclipse workspace (and per CI cold start): **325 MB / 861 jars eagerly downloaded, 411 of them source bundles (105 MB)**. Setting `includeSource="false"` does not help: PDE's planner path runs its plan-in-source-bundles pass unconditionally (no `getIncludeSource()` check in `P2TargetUtils`), so sources are fetched for everything regardless of the flag.

## Change (opt-in; the default target is untouched)

- New `ddk-target/ddk-ci.target`: same 8 repositories, `includeMode="slicer"`, SDK features replaced by runtime features, and every requirement-only bundle listed explicitly. Attached with classifier `ddk-ci`; select with `-Dtarget.platform=ddk-ci`.
- `com.avaloq.tools.ddk.xtext.test`: the surefire runtime required the whole `org.eclipse.xtext.sdk` feature; replaced with the xtext runtime/ui/xbase features plus the bundles the tests actually use at runtime — including `org.eclipse.xtext.xtext.ui`, whose EMF resource-factory registration is required to load `.xtext` grammar resources (its absence was the cause of the first CI run's test failures). Resolvable under both targets.

Every unit in the new file is traceable to a concrete resolution error: the file was grown by an error-driven loop (`mvn clean package`/`verify` naming the missing capability each iteration), not copied from anywhere.

## Measured (local, macOS aarch64; medians of ≥3 runs where stated)

| | default `ddk.target` | `ddk-ci.target` |
|---|---|---|
| PDE cold workspace provisioning (resolve) | 34–47 s | **22–27 s** |
| bundle pool | 325 MB | **~205 MB (−37%)** |
| jars | 861 | **~440 (−49%)** |
| source jars | 411 | **30 (−93%)** |
| Tycho warm `validate` | ~10 s | ~10 s (unchanged — warm is not download-bound) |

## Verification

1. Full `mvn clean package` green (all modules), under both targets.
2. Tycho-surefire's install-grade runtime assembly green (this stricter resolution caught, and the target now includes, runtime-only needs such as `com.jcraft.jsch` and the ECF/httpclient5 transport stack).
3. **Full `mvn clean verify` green with zero test failures under BOTH the default target and `ddk-ci.target`** (357+ tests across 81 test classes).
4. Static audit of all 46 dropped binary bundles against the whole repo (manifests, poms, `.launch`, `.product`, `plugin.xml`, code): the only dynamic reference is `ddk-configuration/launches/devkit-run.launch`, which uses the automatic bundle set (`default=true`) and therefore adapts; it is not used by CI.

Known trade-offs: a workspace using `ddk-ci.target` has no source attachments (use the default target for source browsing), and the launched runtime workbench lacks IDE extras (xtend.ide, docs, examples). 30 source jars remain (embedded in the Xtext features' own feature.xml).

## CI numbers (added after workflow runs)

`verify` workflow, ubuntu runner: **10m39s** (green run on the current commit) vs recent master runs median **~13m25s** (n=8, range 11m49s–18m34s). Caveat: CI currently builds the **default** target, so this difference is likely cache warmth/runner variance rather than the change itself — the measured provisioning gains (−37% download, −93% source bundles, ~35–40% faster cold resolve) apply to workspace/CI environments that opt into `-Dtarget.platform=ddk-ci`. Switching CI to the slim target would be a follow-up once the team is comfortable.

---
Assisted by Claude.
