### PR TITLE
fix: baseline CPD duplications in migrated ANTLR generators

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareAntlrContentAssistGrammarGenerator.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareAntlrContentAssistGrammarGenerator.java
@@ -83,6 +83,8 @@ import com.google.inject.Inject;
 @SuppressWarnings({"PMD.UnusedFormalParameter", "nls"})
 public class AnnotationAwareAntlrContentAssistGrammarGenerator extends AbstractAnnotationAwareAntlrGrammarGenerator {
 
+  // CPD-OFF — migrated Xtend generator code, kept faithful
+
   @Inject
   private ContentAssistGrammarNaming naming;
 

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareAntlrGrammarGenerator.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareAntlrGrammarGenerator.java
@@ -81,6 +81,8 @@ import com.google.inject.Singleton;
 @SuppressWarnings({"checkstyle:MethodName", "PMD.UnusedFormalParameter", "nls"})
 public class AnnotationAwareAntlrGrammarGenerator extends AbstractAnnotationAwareAntlrGrammarGenerator {
 
+  // CPD-OFF — migrated Xtend generator code, kept faithful
+
   @Inject
   private GrammarNaming naming;
 

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareXtextAntlrGeneratorFragment2.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/antlr/AnnotationAwareXtextAntlrGeneratorFragment2.java
@@ -63,6 +63,8 @@ import com.google.inject.name.Names;
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods", "PMD.LocalVariableNamingConventions", "nls"})
 public class AnnotationAwareXtextAntlrGeneratorFragment2 extends XtextAntlrGeneratorFragment2 {
 
+  // CPD-OFF — migrated Xtend generator code, kept faithful
+
   private static final String ADDITIONAL_CA_REQUIRED_BUNDLE = "com.avaloq.tools.ddk.xtext";
 
   @Inject


### PR DESCRIPTION
## What

Baselines 4 CPD duplications in three migrated ANTLR generators with file-scoped `CPD-OFF` markers, restoring a green `cpd-check` on master.

- `AnnotationAwareAntlrContentAssistGrammarGenerator.java`
- `AnnotationAwareAntlrGrammarGenerator.java`
- `AnnotationAwareXtextAntlrGeneratorFragment2.java`

## Why master went red

Two recently-merged PRs interacted in a way neither's CI could see on its own:

- **#1397** enabled CPD (`pmd.cpd.min` 100000 → 100) and baselined the duplications that existed *on its branch*.
- **#1429** migrated the AnnotationAware ANTLR generators to Java. Its checks ran while CPD was still effectively disabled, so the new Java's duplications were never flagged.

Merged together, master has CPD enabled **and** #1429's un-baselined migrated Java, so the `snapshot` full scan fails at `cpd-check` with 4 intra-file duplications. Rebase-merge does not re-run a PR's CI, so the combination first surfaced on master.

## Approach

These are faithful Xtend→Java migrations (the duplicated structure is inherited from the original Xtend's polymorphic dispatch — parallel rule-emission methods differing only in rule type, argument order, or a literal). They are baselined with file-scoped `CPD-OFF`, consistent with the treatment of the analogous `FormatJvmModelInferrer` in #1397.

## Verification

Local, on `com.avaloq.tools.ddk.xtext.generator`: `pmd:cpd-check`, `checkstyle:check`, and `pmd:check` all green (CPD duplications 4 → 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)