### PR TITLE
fix(format): guard against null members in FormatJvmModelInferrer.inferConstants

### DIFF
--- a/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/format/jvmmodel/FormatJvmModelInferrerTest.java
+++ b/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/format/jvmmodel/FormatJvmModelInferrerTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Group AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.format.jvmmodel;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.ResourceImpl;
+import org.eclipse.xtext.common.types.JvmGenericType;
+import org.eclipse.xtext.common.types.TypesFactory;
+import org.junit.jupiter.api.Test;
+
+import com.avaloq.tools.ddk.xtext.format.format.Constant;
+import com.avaloq.tools.ddk.xtext.format.format.FormatConfiguration;
+import com.avaloq.tools.ddk.xtext.format.format.FormatFactory;
+import com.avaloq.tools.ddk.xtext.test.format.util.FormatTestUtil;
+import com.avaloq.tools.ddk.xtext.test.jupiter.AbstractXtextTest;
+
+
+/**
+ * Regression test for {@link FormatJvmModelInferrer#inferConstants(FormatConfiguration, JvmGenericType)}.
+ *
+ * <p>A {@link Constant} without an {@code intValue} or a {@code stringValue} makes
+ * {@link FormatJvmModelInferrer#createConstant(FormatConfiguration, Constant)} return {@code null}. The inferrer must
+ * skip such {@code null} members instead of leaking them into the JVM model (mirroring the original Xtend {@code +=}
+ * null-skip), otherwise an {@code IllegalArgumentException: element: null} surfaces downstream.</p>
+ */
+@SuppressWarnings("nls")
+public class FormatJvmModelInferrerTest extends AbstractXtextTest {
+
+  private final FormatJvmModelInferrer inferrer = getXtextTestUtil().get(FormatJvmModelInferrer.class);
+
+  @Override
+  protected FormatTestUtil getXtextTestUtil() {
+    return FormatTestUtil.getInstance();
+  }
+
+  @Override
+  protected String getTestSourceFileName() {
+    return null; // the model is fabricated in-memory, no source file is loaded
+  }
+
+  /**
+   * A value-less constant must not leak a {@code null} member into the inferred type.
+   */
+  @Test
+  public void testInferConstantsSkipsValuelessConstant() {
+    final FormatConfiguration format = FormatFactory.eINSTANCE.createFormatConfiguration();
+    final Constant valuelessConstant = FormatFactory.eINSTANCE.createConstant();
+    valuelessConstant.setName("VALUELESS"); // name only, both intValue and stringValue stay null
+    format.getConstants().add(valuelessConstant);
+
+    final Resource resource = new ResourceImpl(URI.createURI("synthetic:/format/valueless.format"));
+    resource.getContents().add(format);
+
+    // createConstant returns null for a value-less constant.
+    assertNull(inferrer.createConstant(format, valuelessConstant), "value-less constant should yield no JVM member");
+
+    final JvmGenericType type = TypesFactory.eINSTANCE.createJvmGenericType();
+    assertDoesNotThrow(() -> inferrer.inferConstants(format, type), "inferConstants must not fail on a value-less constant");
+    assertFalse(type.getMembers().contains(null), "the inferred type must not contain a null member");
+  }
+}

--- a/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/test/format/FormatTestSuite.java
+++ b/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/test/format/FormatTestSuite.java
@@ -16,6 +16,7 @@ import org.junit.platform.suite.api.Suite;
 import com.avaloq.tools.ddk.xtext.format.FormatParsingTest;
 import com.avaloq.tools.ddk.xtext.format.builder.FormatBuilderParticipantTest;
 import com.avaloq.tools.ddk.xtext.format.formatting.FormatFormattingTest;
+import com.avaloq.tools.ddk.xtext.format.jvmmodel.FormatJvmModelInferrerTest;
 import com.avaloq.tools.ddk.xtext.format.scoping.FormatScopingTest;
 import com.avaloq.tools.ddk.xtext.format.validation.FormatValidationTest;
 
@@ -24,7 +25,7 @@ import com.avaloq.tools.ddk.xtext.format.validation.FormatValidationTest;
  * Empty class serving only as holder for JUnit5 annotations.
  */
 @Suite
-@SelectClasses({FormatParsingTest.class, FormatFormattingTest.class, FormatValidationTest.class, FormatScopingTest.class, FormatBuilderParticipantTest.class})
+@SelectClasses({FormatParsingTest.class, FormatFormattingTest.class, FormatValidationTest.class, FormatScopingTest.class, FormatBuilderParticipantTest.class, FormatJvmModelInferrerTest.class})
 public class FormatTestSuite {
 
 }

--- a/com.avaloq.tools.ddk.xtext.format/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.format/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.xtext.format
 Bundle-SymbolicName: com.avaloq.tools.ddk.xtext.format;singleton:=true
-Bundle-Version: 17.3.1.qualifier
+Bundle-Version: 17.3.2.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/com.avaloq.tools.ddk.xtext.format/pom.xml
+++ b/com.avaloq.tools.ddk.xtext.format/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.1-SNAPSHOT</version>
+  <version>17.3.2-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.xtext.format</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/jvmmodel/FormatJvmModelInferrer.java
+++ b/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/jvmmodel/FormatJvmModelInferrer.java
@@ -211,7 +211,10 @@ public class FormatJvmModelInferrer extends AbstractModelInferrer {
   public void inferConstants(final FormatConfiguration format, final JvmGenericType it) {
     if (!FormatGeneratorUtil.getAllConstants(format).isEmpty()) {
       for (final Constant c : FormatGeneratorUtil.getAllConstants(format)) {
-        it.getMembers().add(createConstant(format, c));
+        final JvmMember member = createConstant(format, c);
+        if (member != null) { // createConstant returns null for a value-less constant; the original Xtend += (operator_add) skipped nulls
+          it.getMembers().add(member);
+        }
       }
     }
   }


### PR DESCRIPTION
## The bug

`FormatJvmModelInferrer.inferConstants` adds `createConstant(format, c)` to the inferred JVM model **unconditionally**:

```java
for (final Constant c : FormatGeneratorUtil.getAllConstants(format)) {
  it.getMembers().add(createConstant(format, c));   // createConstant can return null
}
```

`createConstant` returns `null` for a **value-less constant** (its `if (stringValue) … else if (intValue) … return null` fall-through — reachable for a constant in an incomplete/error state during editing). Adding that null to the `JvmMember` `EList` throws `IllegalArgumentException: The 'no null' constraint is violated`.

## Root cause — a migration regression

The original Xtend was `members += allConstants.map[createConstant]`, which compiles to `JvmTypesBuilder.operator_add`, and **`operator_add` silently skips null elements**. The Xtend→Java migration translated `+=` to a bare loop-`add`, which does not skip nulls — so the null-skip semantics were lost. The sibling `inferRules` in the same file kept the null-skip, making this an inconsistent one-off.

## The fix

Guard the add (equivalent to `operator_add`'s null-skip / an `IterableExtensions.filterNull`):

```java
final JvmMember member = createConstant(format, c);
if (member != null) {
  it.getMembers().add(member);
}
```

## Verification

- New `FormatJvmModelInferrerTest` pins the behaviour: a value-less `Constant` must not yield a null member or throw.
- **A/B proven** through the full test harness: the test **fails on the pre-fix code** (`IllegalArgumentException: The 'no null' constraint is violated`) and **passes with the guard**. Full local gate: BUILD SUCCESS, 359 tests / 0 failures, all static analysis clean.

Found by an archaeology audit of the merged Xtend→Java migrations. The skill rule that prevents this class of defect is added in a separate PR (#1473, `rules/10 §10.5` — `operator_add` skips nulls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)