### PR TITLE
ci: add reusable headless Docker build environment

### DIFF
--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -475,6 +475,21 @@
       </properties>
     </profile>
     <profile>
+      <activation>
+        <os>
+          <name>linux</name>
+          <arch>aarch64</arch>
+          <family>unix</family>
+        </os>
+      </activation>
+      <id>64bit_linux_aarch64</id>
+      <properties>
+        <osgi.os>linux</osgi.os>
+        <osgi.ws>gtk</osgi.ws>
+        <osgi.arch>aarch64</osgi.arch>
+      </properties>
+    </profile>
+    <profile>
       <id>macosx</id>
       <activation>
         <os>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+ARG MAVEN_IMAGE=maven:3.9.16-eclipse-temurin-21-noble
+FROM ${MAVEN_IMAGE}
+
+# Eclipse 2026-06 uses SWT/GTK 3. GTK's package dependencies provide the
+# remaining native libraries. librsvg supplies GTK's SVG icon loader, and
+# libXtst is required by the JDK's X11 AWT library.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libgtk-3-0t64 \
+        librsvg2-common \
+        libxtst6 \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# Default working directory for mounted DDK workspace.
+WORKDIR /workspace

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,150 @@
+# DDK Docker build environment
+
+This image provides Maven 3.9, Eclipse Temurin 21, GTK 3, and Xvfb for
+consistent Linux builds and headless Eclipse/SWT tests. It works with Docker
+Desktop's Linux engine on Windows as well as with Docker Engine on Linux.
+
+## Build the image
+
+From the repository root:
+
+```bash
+docker build --pull -t ddk-build docker
+```
+
+The default base is `maven:3.9.16-eclipse-temurin-21-noble`. To use a registry
+mirror, override it without copying the Dockerfile:
+
+```bash
+docker build --build-arg MAVEN_IMAGE=<mirror>/maven:3.9.16-eclipse-temurin-21-noble \
+  -t ddk-build docker
+```
+
+## Run the full build on Windows
+
+Use PowerShell from a full clone's repository root:
+
+```powershell
+$ddkWorkspace = (Get-Location).Path
+docker volume create ddk-m2
+docker run --rm --init `
+  --mount "type=bind,source=$ddkWorkspace,target=/workspace" `
+  --mount "type=volume,source=ddk-m2,target=/root/.m2" `
+  --workdir /workspace `
+  ddk-build `
+  xvfb-run --auto-servernum --error-file=/dev/stderr `
+  -- `
+  mvn -T 3C clean verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check `
+    -f ./ddk-parent/pom.xml --batch-mode --fail-at-end
+```
+
+After Maven exits, verify that the expected Surefire report was actually
+created:
+
+```powershell
+docker run --rm `
+  --mount "type=bind,source=$ddkWorkspace,target=/workspace" `
+  --workdir /workspace `
+  ddk-build `
+  bash ./.github/scripts/check-surefire-reports.sh
+```
+
+Docker Desktop runs this command in Linux even though the source tree is on
+Windows. Tycho automatically selects the `64bit_linux` profile and resolves the
+Linux x86-64 SWT and launcher fragments.
+
+Quote Maven `-D` properties passed through `docker run` in PowerShell, for
+example `'-DskipTests'` or `'-Dtest.timeout=7200'`. Otherwise PowerShell may
+split a dotted property name before Docker receives it.
+
+## Run the full build on Linux or macOS
+
+```bash
+docker volume create ddk-m2
+docker run --rm --init \
+  --mount "type=bind,source=${PWD},target=/workspace" \
+  --mount "type=volume,source=ddk-m2,target=/root/.m2" \
+  --workdir /workspace \
+  ddk-build \
+  xvfb-run --auto-servernum --error-file=/dev/stderr \
+  -- \
+  mvn -T 3C clean verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check \
+    -f ./ddk-parent/pom.xml --batch-mode --fail-at-end
+```
+
+Then run `./.github/scripts/check-surefire-reports.sh` from the checkout.
+
+The named volume retains Maven and p2 downloads. Delete it with
+`docker volume rm ddk-m2` when a completely cold dependency cache is required.
+
+`--init` is required. Without an init process, `xvfb-run` becomes PID 1 and can
+wait indefinitely for Xvfb's readiness signal instead of starting Maven.
+`--auto-servernum` also prevents collisions when more than one container runs.
+
+The container runs as root, matching the upstream Maven image. This is harmless
+for Docker Desktop mounts, but a native Linux host may see root-owned build
+outputs in the checkout.
+
+## ARM64
+
+Build and run an ARM64 image explicitly:
+
+```bash
+docker build --platform linux/arm64 -t ddk-build:arm64 docker
+docker run --rm --init --platform linux/arm64 \
+  --mount "type=bind,source=${PWD},target=/workspace" \
+  --mount "type=volume,source=ddk-m2-arm64,target=/root/.m2" \
+  --workdir /workspace \
+  ddk-build:arm64 \
+  xvfb-run --auto-servernum --error-file=/dev/stderr \
+  -- \
+  mvn -T 3C clean verify -f ./ddk-parent/pom.xml --batch-mode --fail-at-end \
+    -Dtest.timeout=7200
+```
+
+Tycho automatically selects `64bit_linux_aarch64`. Docker Desktop can emulate
+ARM64 on an x86-64 Windows machine, but a native ARM64 runner is substantially
+faster. The example raises Tycho's test-runtime timeout from 1,800 to 7,200
+seconds for emulation; a native ARM64 host can normally omit that property.
+Keep separate Maven volumes for the two architectures so native p2 artifacts
+cannot be mixed.
+
+In PowerShell, reuse the Windows command above with
+`--platform linux/arm64`, image `ddk-build:arm64`, and volume
+`ddk-m2-arm64`; also add the quoted argument `'-Dtest.timeout=7200'`.
+
+## Linked Git worktrees
+
+Mount a full clone when possible. A linked worktree has a `.git` file pointing
+to metadata in the parent clone, normally outside the container mount. Tycho's
+JGit-based build qualifier then fails with `repository not found`.
+
+If a linked worktree is unavoidable, mount both the worktree and the parent
+clone at paths that preserve the `.git` file's reference. A standalone clone is
+usually simpler, especially on Windows.
+
+## TLS-intercepting networks
+
+Do not modify a running `--rm` container: the change disappears with the
+container. Build a local derived image containing the organization's root CA.
+For example, place `company-root-ca.crt` beside a local Dockerfile containing:
+
+```dockerfile
+ARG BASE_IMAGE=ddk-build
+FROM ${BASE_IMAGE}
+COPY company-root-ca.crt /usr/local/share/ca-certificates/company-root-ca.crt
+RUN update-ca-certificates \
+    && keytool -importcert -trustcacerts -cacerts \
+        -alias company-root-ca \
+        -file /usr/local/share/ca-certificates/company-root-ca.crt \
+        -storepass changeit -noprompt
+```
+
+Then build that directory with `docker build -t ddk-build:corporate .` and use
+`ddk-build:corporate` in the commands above. Keep private CA files out of Git.
+
+## Expected warnings
+
+Xvfb may print unresolved `XF86...` multimedia key symbols, and SWT may report
+that GNOME or Xfce session managers are unavailable. These are non-fatal in the
+headless test environment and do not justify installing a desktop session.


### PR DESCRIPTION
Adds a reusable Docker image for building and testing DSL DevKit headlessly in a Linux container, plus the Tycho target-environment profile required on Linux ARM64.

This supersedes #1501: the first commit contains the ARM64 profile from that PR, and the second adds the tested container environment and documentation.

## What it adds

- `64bit_linux_aarch64` Maven profile with `osgi.os=linux`, `osgi.ws=gtk`, and `osgi.arch=aarch64`.
- A Maven 3.9.16 / Eclipse Temurin 21 Noble image with the minimal practical GTK 3, SVG loader, Xvfb, and XTest runtime dependencies.
- Tested instructions for Windows with Docker Desktop, Linux/macOS, ARM64, Maven/p2 caching, linked Git worktrees, registry mirrors, and TLS-intercepting networks.
- A `MAVEN_IMAGE` build argument, replacing the previous copied `Dockerfile.local` workaround.

## Local verification

All Maven invocations used `-T 3C`.

### Linux AMD64 on Windows

- Docker Desktop Linux engine on an x86-64 Windows host.
- Full 64-module CI-equivalent build completed successfully under Xvfb.
- Checkstyle, PMD, CPD, and SpotBugs completed with no violations.
- Surefire aggregate: 333 tests, 0 failures, 0 errors, 2 skipped; 348 concrete `<testcase>` elements.
- The repository's Surefire report validator completed successfully.

### Linux ARM64 on Windows

- Built and executed with `--platform linux/arm64` under Docker Desktop emulation.
- Maven activated `64bit_linux_aarch64` and Tycho launched the Eclipse test runtime as `linux/gtk/aarch64`.
- All 64 modules and the complete headless Eclipse/SWT test suite completed successfully.
- Surefire aggregate: 333 tests, 0 failures, 0 errors, 2 skipped; report validation succeeded.
- The reactor took about 1h35m under QEMU. Tycho's default 1,800-second test-runtime timeout is therefore insufficient for emulation; the documented ARM command uses `-Dtest.timeout=7200`. Native ARM64 should be substantially faster.

The exact final AMD64 and ARM64 images also launched an SWT `Display` and `Shell` under Xvfb.

## Image cleanup

The original Dockerfile explicitly requested 20 packages, including redundant transitive dependencies and unused GTK4/ALSA fallback packages. The final image explicitly installs four:

- `libgtk-3-0t64`
- `librsvg2-common`
- `libxtst6`
- `xvfb`

Compared with the original image, this reduces the AMD64 image by 13.35 MiB and the ARM64 image by 14.70 MiB while retaining the required SWT/GTK behavior.
