### PR TITLE
chore(oomph): pin the workspace line delimiter to LF

### DIFF
--- a/ddk-configuration/oomph-setup/DDKEclipse.setup
+++ b/ddk-configuration/oomph-setup/DDKEclipse.setup
@@ -97,6 +97,10 @@
           <value>record</value>
         </detail>
         <detail
+            key="/instance/org.eclipse.core.runtime/line.separator">
+          <value>record</value>
+        </detail>
+        <detail
             key="/instance/org.eclipse.pde.ui/Preferences.MainPage.showTargetStatus">
           <value>record</value>
         </detail>
@@ -128,6 +132,14 @@
             xsi:type="setup:PreferenceTask"
             key="/instance/org.eclipse.core.resources/missingNatureMarkerSeverity"
             value="0"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.core.runtime">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.core.runtime/line.separator"
+            value="&#xA;"/>
       </setupTask>
       <setupTask
           xsi:type="setup:CompoundTask"


### PR DESCRIPTION
## What

Adds one Oomph `PreferenceTask` to the DDK Eclipse product setup: `/instance/org.eclipse.core.runtime/line.separator` = LF, so every provisioned workspace starts with a Unix line delimiter workspace-wide. (The value is an XML character reference, `&#xA;`, so XML attribute normalization preserves the newline.)

## Why

This closes the last platform-dependent line-ending default. The repo already enforces LF at every other layer: `.gitattributes` + the line-endings CI check (storage/checkout), project-scoped `line.separator` settings linked from `ddk-configuration` (#1413), LF from the MWE2 code-generation workflows (#1413), and deterministic LF from the headless generation pipelines (#1477). The remaining hole: on a fresh **Windows** workspace the Eclipse *workspace* preference falls back to the platform separator (CRLF) — so files created outside the project-scoped settings, and IDE-side Xtext generation resolving the workspace preference, can still be written CRLF and churn against the LF checkout (rewrites → rebuild pressure → the Windows build-performance symptoms).

With this task, a fresh Oomph-provisioned DDK workspace is LF end-to-end: storage, checkout, headless generation, IDE generation, and new files.

## Verification

- `xmllint --noout` passes on the edited setup.
- The task follows the existing per-node `CompoundTask` structure in `DDKEclipse.setup` (same pattern as the `org.eclipse.core.resources` and `org.eclipse.ui.editors` tasks).
- Configuration-only change; no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)