### PR TITLE
chore(deps): bump checkstyle to 13.9.0

### DIFF
--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/CheckRuntimeModule.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/CheckRuntimeModule.java
@@ -83,6 +83,8 @@ public class CheckRuntimeModule extends com.avaloq.tools.ddk.check.AbstractCheck
   }
 
   /**
+   * Returns the Javadoc-like documentation provider binding.
+   *
    * @return a JavaDoc-like documentation provider
    */
   public Class<? extends IEObjectDocumentationProvider> bindIEObjectDocumentationProvider() {
@@ -99,7 +101,11 @@ public class CheckRuntimeModule extends com.avaloq.tools.ddk.check.AbstractCheck
     binder.bind(IScopeProvider.class).annotatedWith(Names.named(org.eclipse.xtext.scoping.impl.AbstractDeclarativeScopeProvider.NAMED_DELEGATE)).to(XImportSectionNamespaceScopeProvider.class);
   }
 
-  /** @return a strategy for selecting the objects to export in Index */
+  /**
+   * Returns the strategy for selecting objects to export in the index.
+   *
+   * @return a strategy for selecting the objects to export in Index
+   */
   @Override
   public Class<? extends org.eclipse.xtext.resource.IDefaultResourceDescriptionStrategy> bindIDefaultResourceDescriptionStrategy() {
     return CheckResourceDescriptionStrategy.class;

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/documentation/JavaDocCommentDocumentationProvider.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/documentation/JavaDocCommentDocumentationProvider.java
@@ -23,6 +23,8 @@ import com.google.inject.name.Named;
 
 
 /**
+ * Provides documentation extracted from Javadoc comments.
+ *
  * @author Christoph Kulla - Initial contribution and API
  */
 @SuppressWarnings("nls")

--- a/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/util/GrammarHelper.java
+++ b/com.avaloq.tools.ddk.check.core/src/com/avaloq/tools/ddk/check/util/GrammarHelper.java
@@ -61,6 +61,8 @@ public class GrammarHelper {
   }
 
   /**
+   * Returns a label for the grammar.
+   *
    * @return a text representation of the grammar in which the last segment
    *         appears first (like in content assist.)
    */

--- a/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/validation/ComposedCheckValidator.java
+++ b/com.avaloq.tools.ddk.check.runtime.core/src/com/avaloq/tools/ddk/check/runtime/validation/ComposedCheckValidator.java
@@ -19,6 +19,8 @@ import com.avaloq.tools.ddk.check.runtime.issue.ICheckValidatorImpl;
 
 
 /**
+ * Identifies a composed check validator.
+ *
  * @author Sebastian Zarnekow - Initial contribution and API
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/highlighting/CheckHighlightingConfiguration.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/highlighting/CheckHighlightingConfiguration.java
@@ -32,6 +32,8 @@ public class CheckHighlightingConfiguration extends XbaseHighlightingConfigurati
   }
 
   /**
+   * Returns the text style for Javadoc comments.
+   *
    * @return a bluish TextStyle for JavaDoc comments
    */
   public TextStyle javaDocCommentTextStyle() {

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/labeling/CheckImages.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/labeling/CheckImages.java
@@ -45,37 +45,65 @@ public class CheckImages {
   @Inject
   private IImageHelper imageHelper;
 
-  /** @return an image representing a Java package */
+  /**
+   * Returns an image representing a Java package.
+   *
+   * @return an image representing a Java package
+   */
   public Image forPackage() {
     return getJdtImage(JavaPluginImages.DESC_OBJS_PACKAGE);
   }
 
-  /** @return an image representing a Check resource */
+  /**
+   * Returns an image representing a Check resource.
+   *
+   * @return an image representing a Check resource
+   */
   public Image forResource() {
     return imageHelper.getImage(RESOURCE_IMAGE);
   }
 
-  /** @return an image representing a JDT import container. */
+  /**
+   * Returns an image representing a JDT import container.
+   *
+   * @return an image representing a JDT import container
+   */
   public Image forImportContainer() {
     return getJdtImage(JavaPluginImages.DESC_OBJS_IMPCONT);
   }
 
-  /** @return an image representing a Java import statement. */
+  /**
+   * Returns an image representing a Java import statement.
+   *
+   * @return an image representing a Java import statement
+   */
   public Image forImport() {
     return getJdtImage(JavaPluginImages.DESC_OBJS_IMPDECL);
   }
 
-  /** @return an image representing a Check catalog. */
+  /**
+   * Returns an image representing a Check catalog.
+   *
+   * @return an image representing a Check catalog
+   */
   public Image forCheckCatalog() {
     return forResource();
   }
 
-  /** @return an image representing a category. */
+  /**
+   * Returns an image representing a category.
+   *
+   * @return an image representing a category
+   */
   public Image forCategory() {
     return imageHelper.getImage(CATEGORY_IMAGE);
   }
 
-  /** @return an image representing a category. */
+  /**
+   * Returns an image representing a severity range.
+   *
+   * @return an image representing a severity range
+   */
   public Image forSeverityRange() {
     return imageHelper.getImage(SEVERITY_RANGE_IMAGE);
   }
@@ -100,7 +128,11 @@ public class CheckImages {
     }
   }
 
-  /** @return an image representing a Check context. */
+  /**
+   * Returns an image representing a Check context.
+   *
+   * @return an image representing a Check context
+   */
   public Image forContext() {
     return getJdtImage(JavaElementImageProvider.getTypeImageDescriptor(false, true, Flags.AccPublic, false));
   }

--- a/com.avaloq.tools.ddk.checkcfg.ui/src/com/avaloq/tools/ddk/checkcfg/ui/labeling/CheckCfgImages.java
+++ b/com.avaloq.tools.ddk.checkcfg.ui/src/com/avaloq/tools/ddk/checkcfg/ui/labeling/CheckCfgImages.java
@@ -33,17 +33,29 @@ public class CheckCfgImages {
   @Inject
   private IImageHelper imageHelper;
 
-  /** @return an image representing a Check Configuration resource */
+  /**
+   * Returns an image representing a Check Configuration resource.
+   *
+   * @return an image representing a Check Configuration resource
+   */
   public Image forResource() {
     return imageHelper.getImage(RESOURCE_IMAGE);
   }
 
-  /** @return an image representing a Check Configuration */
+  /**
+   * Returns an image representing a Check Configuration.
+   *
+   * @return an image representing a Check Configuration
+   */
   public Image forCheckConfiguration() {
     return forResource();
   }
 
-  /** @return an image representing a configured category */
+  /**
+   * Returns an image representing a configured category.
+   *
+   * @return an image representing a configured category
+   */
   public Image forConfiguredCatalog() {
     return imageHelper.getImage(CATEGORY_IMAGE);
   }

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/FixedDefaultWorkbench.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/FixedDefaultWorkbench.java
@@ -31,7 +31,11 @@ import org.eclipse.ui.PlatformUI;
  */
 class FixedDefaultWorkbench {
 
-  /** @see org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine#getLimboShell() */
+  /**
+   * Identifies the limbo shell.
+   *
+   * @see org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine#getLimboShell()
+   */
   @SuppressWarnings("restriction")
   private static final String LIMBO_SHELL = "PartRenderingEngine's limbo"; //$NON-NLS-1$
   private static final String QUIK_ACCESS_SHELL = "Quick Access"; //$NON-NLS-1$

--- a/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/common/GrammarRuleAnnotations.java
+++ b/com.avaloq.tools.ddk.xtext.generator/src/com/avaloq/tools/ddk/xtext/generator/parser/common/GrammarRuleAnnotations.java
@@ -138,8 +138,8 @@ public class GrammarRuleAnnotations {
   }
 
   /**
-   * Gated predicate: {condition}?=>
-   * Validating predicate: {condition message}?
+   * Gated predicate: {condition}?=>.
+   * Validating predicate: {condition message}?.
    */
   @EmfAdaptable
   public static class SemanticPredicate {

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/AbstractValidElementBase.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/AbstractValidElementBase.java
@@ -73,6 +73,8 @@ public abstract class AbstractValidElementBase {
   }
 
   /**
+   * Returns the identifier that distinguishes extension instances.
+   *
    * @return the id that tells one extension instance from another
    */
   public String getExtensionId() {
@@ -80,6 +82,8 @@ public abstract class AbstractValidElementBase {
   }
 
   /**
+   * Returns the name of the XML element that defines this class.
+   *
    * @return the name of the XML element that defines this class
    */
   public String getElementTypeName() {

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/ValidExtension.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/ValidExtension.java
@@ -41,6 +41,8 @@ public final class ValidExtension {
   }
 
   /**
+   * Returns the identifier that distinguishes extension instances.
+   *
    * @return the id that tells one extension instance from another
    */
   public String getExtensionId() {
@@ -48,6 +50,8 @@ public final class ValidExtension {
   }
 
   /**
+   * Returns the top-level elements of this extension point.
+   *
    * @return the top-level elements of this extension point
    */
   public ValidElement[] getTopLevelElements() {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/formatting/locators/IExtendedLocator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/formatting/locators/IExtendedLocator.java
@@ -16,6 +16,8 @@ package com.avaloq.tools.ddk.xtext.formatting.locators;
 public interface IExtendedLocator {
 
   /**
+   * Defines how locators are aggregated.
+   *
    * @see IExtendedLocator#getPrecedence().
    */
   enum AggregationPolicy {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/layered/IIssueStore.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/layered/IIssueStore.java
@@ -22,6 +22,8 @@ import com.google.common.collect.Multimap;
 public interface IIssueStore {
 
   /**
+   * Returns all stored issues.
+   *
    * @return all stored issues.
    */
   Multimap<URI, Issue> getIssues();

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/extensions/IResourceDescription2.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/extensions/IResourceDescription2.java
@@ -24,6 +24,8 @@ import org.eclipse.xtext.resource.IResourceDescription;
 public interface IResourceDescription2 extends IResourceDescription {
 
   /**
+   * Returns the imported names on which the described resource depends.
+   *
    * @return the map of names the described resource depends on and their types.
    */
   Map<QualifiedName, Set<EClass>> getImportedNamesTypes();

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ResourceLoadMode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ResourceLoadMode.java
@@ -84,7 +84,8 @@ public interface ResourceLoadMode {
   }
 
   /**
-   * Returns the load mode to be used to load the given resource:
+   * Returns the load mode to be used to load the given resource.
+   * The mode is determined as follows:
    * <ol>
    * <li>If the resource is not contained in any resource set this method will return {@link #PARSE}.</li>
    * <li>If the resource set's load options specify a load mode, that is returned.</li>

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AbstractRecursiveScope.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AbstractRecursiveScope.java
@@ -215,6 +215,8 @@ public abstract class AbstractRecursiveScope extends AbstractScope {
   }
 
   /**
+   * Returns the identifier of this scope.
+   *
    * @return the id
    */
   public String getId() {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AliasingEObjectDescription.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/AliasingEObjectDescription.java
@@ -42,6 +42,8 @@ public class AliasingEObjectDescription extends AbstractEObjectDescription {
   }
 
   /**
+   * Returns the original name by which this element can be accessed.
+   *
    * @return the original name, this element can be accessed by.
    */
   public QualifiedName getOriginalName() {
@@ -49,6 +51,8 @@ public class AliasingEObjectDescription extends AbstractEObjectDescription {
   }
 
   /**
+   * Returns the original qualified name of the element.
+   *
    * @return the original qualified name of the element.
    */
   public QualifiedName getOriginalQualifiedName() {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/DelegatingScope.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/scoping/DelegatingScope.java
@@ -46,6 +46,8 @@ public class DelegatingScope extends AbstractRecursiveScope {
   private static String stackOverflowScopeId;
 
   /**
+   * Identifies the description used when a stack overflow occurs.
+   *
    * @see #STACK_OVERFLOW_SCOPE
    */
   private static final IEObjectDescription STACK_OVERFLOW_EOBJECT_DESCRIPTION = new IEObjectDescription() {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/validation/AbstractDeclarativeValidValidator.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/validation/AbstractDeclarativeValidValidator.java
@@ -149,6 +149,8 @@ public abstract class AbstractDeclarativeValidValidator extends AbstractDeclarat
   }
 
   /**
+   * Returns the preference store for this validator.
+   *
    * @return the preference store (based on Scopes, but without UI) for that validator.
    */
   protected ValidPreferenceStore getValidPreferenceStore() {

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/validation/ValidPreferenceStore.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/validation/ValidPreferenceStore.java
@@ -251,6 +251,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Checks whether a current or default value exists for the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#contains(java.lang.String)
    * @param name
    *          the name of the preference
@@ -261,6 +263,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the boolean value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getBoolean(java.lang.String)
    * @param name
    *          the name of the preference
@@ -272,6 +276,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the default boolean value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getDefaultBoolean(java.lang.String)
    * @param name
    *          the name of the preference
@@ -282,6 +288,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the default double value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getDefaultDouble(java.lang.String)
    * @param name
    *          the name of the preference
@@ -292,6 +300,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the default float value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getDefaultFloat(java.lang.String)
    * @param name
    *          the name of the preference
@@ -302,6 +312,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the default integer value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getDefaultInt(java.lang.String)
    * @param name
    *          the name of the preference
@@ -312,6 +324,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the default long value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getDefaultLong(java.lang.String)
    * @param name
    *          the name of the preference
@@ -322,6 +336,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the default string value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getDefaultString(java.lang.String)
    * @param name
    *          the name of the preference
@@ -332,6 +348,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the double value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getDouble(java.lang.String)
    * @param name
    *          the name of the preference
@@ -364,6 +382,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the float value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getFloat(java.lang.String)
    * @param name
    *          the name of the preference
@@ -382,6 +402,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the integer value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getInt(java.lang.String)
    * @param name
    *          the name of the preference
@@ -400,6 +422,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the long value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getLong(java.lang.String)
    * @param name
    *          the name of the preference
@@ -418,6 +442,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Returns the string value of the preference.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#getString(java.lang.String)
    * @param name
    *          the name of the preference
@@ -429,6 +455,8 @@ public class ValidPreferenceStore {
   }
 
   /**
+   * Checks whether the preference has its default value.
+   *
    * @see org.eclipse.jface.preference.IPreferenceStore#isDefault(java.lang.String)
    * @param name
    *          the name of the preference

--- a/ddk-configuration/checkstyle/avaloq.xml
+++ b/ddk-configuration/checkstyle/avaloq.xml
@@ -89,7 +89,7 @@
       <property name="validateThrows" value="true"/>
     </module>
     <module name="JavadocType"/>
-    <module name="JavadocStyle"/>
+    <module name="SummaryJavadoc"/>
     <module name="LeftCurly"/>
     <module name="LocalFinalVariableName"/>
     <module name="LocalVariableName"/>

--- a/ddk-configuration/checkstyle/suppressions.xml
+++ b/ddk-configuration/checkstyle/suppressions.xml
@@ -10,7 +10,7 @@
     <suppress checks="RedundantModifier"
              files=".*"/>
     <suppress files=".*Test.*\.java|.*Bug.*\.java"
-              checks="AvoidStarImport|EmptyBlock|IllegalCatch|JavadocMethod|JavadocType|JavadocStyle|MagicNumber|MethodName"/>
+              checks="AvoidStarImport|EmptyBlock|IllegalCatch|JavadocMethod|JavadocType|SummaryJavadoc|MagicNumber|MethodName"/>
     <suppress files=".*FormatterTest.*\.java"
               checks="FileTabCharacter"/>
 </suppressions>

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -48,7 +48,7 @@
 
     <!-- maven plugin versions -->
     <checkstyle.plugin.version>3.6.0</checkstyle.plugin.version>
-    <checkstyle.version>13.8.0</checkstyle.version>
+    <checkstyle.version>13.9.0</checkstyle.version>
     <clean.version>3.5.0</clean.version>
     <deploy.version>3.1.4</deploy.version>
     <spotbugs.plugin.version>4.10.3.0</spotbugs.plugin.version>


### PR DESCRIPTION
## Summary

- bump Checkstyle from 13.8.0 to 13.9.0
- replace the removed JavadocStyle check with SummaryJavadoc
- add summary sentences required by the replacement check
- update the matching test-source suppression

This supersedes #1479, which only applies the dependency bump and therefore fails because Checkstyle 13.9.0 removed JavadocStyle.

## Verification

- mvn -T 3C checkstyle:checkstyle checkstyle:check -f ./ddk-parent/pom.xml --batch-mode --fail-at-end
- mvn -T 3C clean verify -f ./ddk-parent/pom.xml --batch-mode --fail-at-end