### PR TITLE
feat(build): remove sequenceNumber in *.target files

### DIFF
--- a/ddk-target/ddk.target
+++ b/ddk-target/ddk.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="DDK Target" sequenceNumber="30">
+<target name="DDK Target">
 <locations>
   <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
   <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>


### PR DESCRIPTION
In modern Eclipse/Tycho .target files, sequenceNumber is generally not advisable or necessary.'

It is legacy PDE metadata used to distinguish revisions of a target definition without changing its name. Current PDE and Tycho resolve the target from its actual contents, so changing locations, repositories, or included units is sufficient. Keeping it has no meaningful effect on dependency resolution and creates a manually maintained value that is easy to forget.