### PR TITLE
build: add Tycho environment profile for linux/aarch64

### DIFF
--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -475,6 +475,21 @@
       </properties>
     </profile>
     <profile>
+      <activation>
+        <os>
+          <name>linux</name>
+          <arch>aarch64</arch>
+          <family>unix</family>
+        </os>
+      </activation>
+      <id>arm64_linux</id>
+      <properties>
+        <osgi.os>linux</osgi.os>
+        <osgi.ws>gtk</osgi.ws>
+        <osgi.arch>aarch64</osgi.arch>
+      </properties>
+    </profile>
+    <profile>
       <id>macosx</id>
       <activation>
         <os>


### PR DESCRIPTION
## Summary

Adds an auto-activated `arm64_linux` profile to `ddk-parent/pom.xml` (`osgi.os=linux`, `osgi.ws=gtk`, `osgi.arch=aarch64`), alongside the existing `64bit_linux` (x86_64) profile.

Without it, the reactor cannot resolve a matching SWT/launcher environment on arm64 Linux hosts. The main motivation is developing on Apple Silicon Macs, where Linux containers (Docker Desktop, colima, CI runners) present `linux/aarch64`.

## Testing

The full reactor builds with this profile active on a linux/aarch64 container on an Apple Silicon Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)