### PR TITLE
build: bump ddk.feature to 19.1.1 (content changed vs 19.1.0 baseline)

### DIFF
--- a/com.avaloq.tools.ddk.feature/feature.xml
+++ b/com.avaloq.tools.ddk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.avaloq.tools.ddk.feature"
       label="com.avaloq.tools.ddk.feature"
-      version="19.1.0.qualifier"
+      version="19.1.1.qualifier"
       provider-name="Avaloq Group AG">
 
    <description>

--- a/com.avaloq.tools.ddk.feature/pom.xml
+++ b/com.avaloq.tools.ddk.feature/pom.xml
@@ -7,7 +7,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>19.1.0-SNAPSHOT</version>
+  <version>19.1.1-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/ddk-repository/category.xml
+++ b/ddk-repository/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.avaloq.tools.ddk.feature_19.1.0.qualifier.jar" id="com.avaloq.tools.ddk.feature" version="19.1.0.qualifier">
+   <feature url="features/com.avaloq.tools.ddk.feature_19.1.1.qualifier.jar" id="com.avaloq.tools.ddk.feature" version="19.1.1.qualifier">
       <category name="com.avaloq.tools.ddk.sdk"/>
    </feature>
    <feature url="features/com.avaloq.tools.ddk.runtime.feature_19.1.0.qualifier.jar" id="com.avaloq.tools.ddk.runtime.feature" version="19.1.0.qualifier">


### PR DESCRIPTION
## What

Post-release aftercare for 19.1.0: bumps `com.avaloq.tools.ddk.feature` to `19.1.1` (feature.xml + pom.xml, with `ddk-repository/category.xml` following). `com.avaloq.tools.ddk.runtime.feature` stays at 19.1.0 — none of its contained bundles changed since the release.

## Why

Release 19.1.0 published `ddk.feature` at 19.1.0, so the feature's version now equals the baseline. Tycho aggregates the feature qualifier from its contained plugins, so the first post-release change to any contained bundle (d2af76764, `xtext.format`) moved the feature's qualifier past the released one at the same x.y.z — exactly what `compare-version-with-baselines` forbids. Master's snapshot build is currently red with:

```
Only qualifier changed for (com.avaloq.tools.ddk.feature.feature.jar/19.1.0.v20260825-2141).
Expected to have bigger x.y.z than what is available in baseline (19.1.0.v20260825-1344)
```

(run 32902330639). Until this lands, every PR that rebuilds the feature inherits the same failure, and no p2 snapshots publish.

Mirrors the 19.0.1 aftercare precedent (4772c8562).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
