### PR TITLE
test: deflake bulk quickfix synchronization in the Problems view

### DIFF
--- a/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/quickfix/CheckQuickfixTest.java
+++ b/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/quickfix/CheckQuickfixTest.java
@@ -10,12 +10,14 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.check.ui.test.quickfix;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -23,6 +25,7 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.common.util.WrappedException;
+import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.eclipse.xtext.diagnostics.Diagnostic;
@@ -47,7 +50,6 @@ import com.avaloq.tools.ddk.xtext.test.XtextTestSource;
 public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
 
   private static final String PACKAGE_NAME = "com.avaloq.test";
-  private static final long ASYNC_UI_TIMEOUT = 60000;
 
   private final SwtWorkbenchBot bot = new SwtWorkbenchBot();
   private boolean oldAutoBuildState;
@@ -174,6 +176,9 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
     ProblemsViewTestUtil.showAllErrors(bot);
     ProblemsViewTestUtil.groupByNone(bot);
 
+    // Disable autobuilding before creating the sources so that the explicit build below is the only pre-action build.
+    getTestProjectManager().setAutobuild(false);
+
     // Add catalogs containing multiple instances of the same quickfixable marker
     final List<XtextTestSource> catalogSources = catalogNames.stream().map(catalogName -> createTestSource(getTestSourceFileName(catalogName), """
           package %s
@@ -196,17 +201,15 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
     waitForWorkspaceMarkers(catalogSources, expectedMarkers);
     final SWTBotTree markersTreeBot = ProblemsViewTestUtil.getMarkersTree(bot);
     final Set<String> sourceFileNames = catalogSources.stream().map(source -> source.getiFile().getName()).collect(Collectors.toSet());
-    Predicate<? super SWTBotTreeItem> checkResourceFilter = item -> sourceFileNames.contains(item.row().get(1));
+    final int resourceColumnIndex = markersTreeBot.columns().indexOf(ProblemsViewTestUtil.RESOURCE_COLUMN_NAME);
+    assertTrue(resourceColumnIndex >= 0, "Problems view has no Resource column.");
+    Predicate<? super SWTBotTreeItem> checkResourceFilter = item -> sourceFileNames.contains(item.cell(resourceColumnIndex));
     waitForProblemsViewMarkers(markersTreeBot, checkResourceFilter, expectedMarkers, "Not all expected markers appeared in the Problems view.");
 
     // ACT
-    // Disable autobuilding, to avoid losing focus while selecting markers
-    getTestProjectManager().setAutobuild(false);
-    getTestProjectManager().build();
-
     // Bulk-apply quickfixes on all markers, ensuring that all markers remain selected
     ProblemsViewTestUtil.bulkApplyQuickfix(bot, Messages.CheckQuickfixProvider_ADD_ID_LABEL, Arrays.stream(markersTreeBot.getAllItems()).filter(checkResourceFilter).toArray(SWTBotTreeItem[]::new));
-    bot.waitUntil(new WaitForEquals<>("Not all markers are still selected.", () -> expectedMarkers, () -> markersTreeBot.selectionCount()), ASYNC_UI_TIMEOUT);
+    bot.waitUntil(new WaitForEquals<>("Not all markers are still selected.", () -> expectedMarkers, () -> markersTreeBot.selectionCount()), ProblemsViewTestUtil.ASYNC_UPDATE_TIMEOUT);
 
     // Save all modified files and build the catalogs
     bot.editors().forEach(editor -> editor.save());
@@ -220,7 +223,16 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
   }
 
   private void waitForWorkspaceMarkers(final List<XtextTestSource> catalogSources, final int expectedMarkers) {
-    bot.waitUntil(new WaitForEquals<>("Workspace marker count did not reach the expected value.", () -> expectedMarkers, () -> countWorkspaceMarkers(catalogSources)), ASYNC_UI_TIMEOUT);
+    final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(ProblemsViewTestUtil.ASYNC_UPDATE_TIMEOUT);
+    int markerCount;
+    do {
+      markerCount = countWorkspaceMarkers(catalogSources);
+      if (markerCount == expectedMarkers) {
+        return;
+      }
+      bot.sleep(SWTBotPreferences.DEFAULT_POLL_DELAY);
+    } while (System.nanoTime() < deadline);
+    assertEquals(expectedMarkers, markerCount, "Workspace marker count did not reach the expected value.");
   }
 
   private int countWorkspaceMarkers(final List<XtextTestSource> catalogSources) {
@@ -240,7 +252,7 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
   }
 
   private void waitForProblemsViewMarkers(final SWTBotTree markersTreeBot, final Predicate<? super SWTBotTreeItem> markerFilter, final int expectedMarkers, final String failureMessage) {
-    bot.waitUntil(new WaitForEquals<>(failureMessage, () -> expectedMarkers, () -> Arrays.stream(markersTreeBot.getAllItems()).filter(markerFilter).toList().size()), ASYNC_UI_TIMEOUT);
+    bot.waitUntil(new WaitForEquals<>(failureMessage, () -> expectedMarkers, () -> Arrays.stream(markersTreeBot.getAllItems()).filter(markerFilter).toList().size()), ProblemsViewTestUtil.ASYNC_UPDATE_TIMEOUT);
   }
 }
 // CHECKSTYLE:CONSTANTS-ON

--- a/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/quickfix/CheckQuickfixTest.java
+++ b/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/quickfix/CheckQuickfixTest.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -49,7 +50,9 @@ import com.avaloq.tools.ddk.xtext.test.XtextTestSource;
 // CHECKSTYLE:CONSTANTS-OFF
 public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
 
+  private static final long ASYNC_UPDATE_TIMEOUT = 30000;
   private static final String PACKAGE_NAME = "com.avaloq.test";
+  private static final String RESOURCE_COLUMN_NAME = "Resource";
 
   private final SwtWorkbenchBot bot = new SwtWorkbenchBot();
   private boolean oldAutoBuildState;
@@ -176,7 +179,7 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
     ProblemsViewTestUtil.showAllErrors(bot);
     ProblemsViewTestUtil.groupByNone(bot);
 
-    // Disable autobuilding before creating the sources so that the explicit build below is the only pre-action build.
+    // Disable autobuilding so source creation cannot trigger a build before the explicit incremental build below.
     getTestProjectManager().setAutobuild(false);
 
     // Add catalogs containing multiple instances of the same quickfixable marker
@@ -201,15 +204,15 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
     waitForWorkspaceMarkers(catalogSources, expectedMarkers);
     final SWTBotTree markersTreeBot = ProblemsViewTestUtil.getMarkersTree(bot);
     final Set<String> sourceFileNames = catalogSources.stream().map(source -> source.getiFile().getName()).collect(Collectors.toSet());
-    final int resourceColumnIndex = markersTreeBot.columns().indexOf(ProblemsViewTestUtil.RESOURCE_COLUMN_NAME);
+    final int resourceColumnIndex = markersTreeBot.columns().indexOf(RESOURCE_COLUMN_NAME);
     assertTrue(resourceColumnIndex >= 0, "Problems view has no Resource column.");
     Predicate<? super SWTBotTreeItem> checkResourceFilter = item -> sourceFileNames.contains(item.cell(resourceColumnIndex));
-    waitForProblemsViewMarkers(markersTreeBot, checkResourceFilter, expectedMarkers, "Not all expected markers appeared in the Problems view.");
+    final SWTBotTreeItem[] checkMarkers = waitForProblemsViewMarkers(markersTreeBot, checkResourceFilter, expectedMarkers, "Not all expected markers appeared in the Problems view.");
 
     // ACT
     // Bulk-apply quickfixes on all markers, ensuring that all markers remain selected
-    ProblemsViewTestUtil.bulkApplyQuickfix(bot, Messages.CheckQuickfixProvider_ADD_ID_LABEL, Arrays.stream(markersTreeBot.getAllItems()).filter(checkResourceFilter).toArray(SWTBotTreeItem[]::new));
-    bot.waitUntil(new WaitForEquals<>("Not all markers are still selected.", () -> expectedMarkers, () -> markersTreeBot.selectionCount()), ProblemsViewTestUtil.ASYNC_UPDATE_TIMEOUT);
+    ProblemsViewTestUtil.bulkApplyQuickfix(bot, Messages.CheckQuickfixProvider_ADD_ID_LABEL, checkMarkers);
+    bot.waitUntil(new WaitForEquals<>("Not all markers are still selected.", () -> expectedMarkers, () -> markersTreeBot.selectionCount()), ASYNC_UPDATE_TIMEOUT);
 
     // Save all modified files and build the catalogs
     bot.editors().forEach(editor -> editor.save());
@@ -222,8 +225,11 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
     waitForProblemsViewMarkers(markersTreeBot, checkResourceFilter, 0, "Some markers were not removed from the Problems view.");
   }
 
+  /**
+   * Waits until the exact expected number of relevant workspace markers exists.
+   */
   private void waitForWorkspaceMarkers(final List<XtextTestSource> catalogSources, final int expectedMarkers) {
-    final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(ProblemsViewTestUtil.ASYNC_UPDATE_TIMEOUT);
+    final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(ASYNC_UPDATE_TIMEOUT);
     int markerCount;
     do {
       markerCount = countWorkspaceMarkers(catalogSources);
@@ -235,6 +241,9 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
     assertEquals(expectedMarkers, markerCount, "Workspace marker count did not reach the expected value.");
   }
 
+  /**
+   * Counts the relevant problem markers attached directly to the given source files.
+   */
   private int countWorkspaceMarkers(final List<XtextTestSource> catalogSources) {
     int markerCount = 0;
     try {
@@ -251,8 +260,17 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
     }
   }
 
-  private void waitForProblemsViewMarkers(final SWTBotTree markersTreeBot, final Predicate<? super SWTBotTreeItem> markerFilter, final int expectedMarkers, final String failureMessage) {
-    bot.waitUntil(new WaitForEquals<>(failureMessage, () -> expectedMarkers, () -> Arrays.stream(markersTreeBot.getAllItems()).filter(markerFilter).toList().size()), ProblemsViewTestUtil.ASYNC_UPDATE_TIMEOUT);
+  /**
+   * Waits for, captures, and returns the exact expected set of Problems view marker items.
+   */
+  private SWTBotTreeItem[] waitForProblemsViewMarkers(final SWTBotTree markersTreeBot, final Predicate<? super SWTBotTreeItem> markerFilter, final int expectedMarkers, final String failureMessage) {
+    final AtomicReference<SWTBotTreeItem[]> matchingMarkers = new AtomicReference<>();
+    bot.waitUntil(new WaitForEquals<>(failureMessage, () -> expectedMarkers, () -> {
+      final SWTBotTreeItem[] items = Arrays.stream(markersTreeBot.getAllItems()).filter(markerFilter).toArray(SWTBotTreeItem[]::new);
+      matchingMarkers.set(items);
+      return items.length;
+    }), ASYNC_UPDATE_TIMEOUT);
+    return matchingMarkers.get();
   }
 }
 // CHECKSTYLE:CONSTANTS-ON

--- a/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/quickfix/CheckQuickfixTest.java
+++ b/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/quickfix/CheckQuickfixTest.java
@@ -11,21 +11,24 @@
 package com.avaloq.tools.ddk.check.ui.test.quickfix;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
-import org.eclipse.swtbot.swt.finder.widgets.TimeoutException;
 import org.eclipse.xtext.diagnostics.Diagnostic;
 import org.eclipse.xtext.validation.Issue;
 import org.junit.jupiter.api.Test;
 
-import com.avaloq.tools.ddk.check.CheckConstants;
 import com.avaloq.tools.ddk.check.ui.quickfix.Messages;
 import com.avaloq.tools.ddk.check.validation.IssueCodes;
 import com.avaloq.tools.ddk.test.core.jupiter.BugTest;
@@ -44,6 +47,7 @@ import com.avaloq.tools.ddk.xtext.test.XtextTestSource;
 public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
 
   private static final String PACKAGE_NAME = "com.avaloq.test";
+  private static final long ASYNC_UI_TIMEOUT = 60000;
 
   private final SwtWorkbenchBot bot = new SwtWorkbenchBot();
   private boolean oldAutoBuildState;
@@ -171,8 +175,7 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
     ProblemsViewTestUtil.groupByNone(bot);
 
     // Add catalogs containing multiple instances of the same quickfixable marker
-    for (final String catalogName : catalogNames) {
-      createTestSource(getTestSourceFileName(catalogName), """
+    final List<XtextTestSource> catalogSources = catalogNames.stream().map(catalogName -> createTestSource(getTestSourceFileName(catalogName), """
           package %s
 
           catalog %s
@@ -186,14 +189,15 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
             message "%s" {
             }
           }
-          """.formatted(PACKAGE_NAME, catalogName, label1, label1, label2, label2));
-    }
+          """.formatted(PACKAGE_NAME, catalogName, label1, label1, label2, label2))).toList();
 
     // Build the catalogs, and wait for the expected markers to appear
     getTestProjectManager().build();
+    waitForWorkspaceMarkers(catalogSources, expectedMarkers);
     final SWTBotTree markersTreeBot = ProblemsViewTestUtil.getMarkersTree(bot);
-    Predicate<? super SWTBotTreeItem> checkResourceFilter = i -> i.row().get(1).endsWith('.' + CheckConstants.FILE_EXTENSION);
-    bot.waitUntil(new WaitForEquals<>("Not all expected markers appeared.", () -> expectedMarkers, () -> Arrays.stream(markersTreeBot.getAllItems()).filter(checkResourceFilter).toList().size()));
+    final Set<String> sourceFileNames = catalogSources.stream().map(source -> source.getiFile().getName()).collect(Collectors.toSet());
+    Predicate<? super SWTBotTreeItem> checkResourceFilter = item -> sourceFileNames.contains(item.row().get(1));
+    waitForProblemsViewMarkers(markersTreeBot, checkResourceFilter, expectedMarkers, "Not all expected markers appeared in the Problems view.");
 
     // ACT
     // Disable autobuilding, to avoid losing focus while selecting markers
@@ -202,7 +206,7 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
 
     // Bulk-apply quickfixes on all markers, ensuring that all markers remain selected
     ProblemsViewTestUtil.bulkApplyQuickfix(bot, Messages.CheckQuickfixProvider_ADD_ID_LABEL, Arrays.stream(markersTreeBot.getAllItems()).filter(checkResourceFilter).toArray(SWTBotTreeItem[]::new));
-    bot.waitUntil(new WaitForEquals<>("Not all markers are still selected.", () -> expectedMarkers, () -> markersTreeBot.selectionCount()));
+    bot.waitUntil(new WaitForEquals<>("Not all markers are still selected.", () -> expectedMarkers, () -> markersTreeBot.selectionCount()), ASYNC_UI_TIMEOUT);
 
     // Save all modified files and build the catalogs
     bot.editors().forEach(editor -> editor.save());
@@ -211,11 +215,32 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
 
     // ASSERT
     // Check that all markers are fixed
+    waitForWorkspaceMarkers(catalogSources, 0);
+    waitForProblemsViewMarkers(markersTreeBot, checkResourceFilter, 0, "Some markers were not removed from the Problems view.");
+  }
+
+  private void waitForWorkspaceMarkers(final List<XtextTestSource> catalogSources, final int expectedMarkers) {
+    bot.waitUntil(new WaitForEquals<>("Workspace marker count did not reach the expected value.", () -> expectedMarkers, () -> countWorkspaceMarkers(catalogSources)), ASYNC_UI_TIMEOUT);
+  }
+
+  private int countWorkspaceMarkers(final List<XtextTestSource> catalogSources) {
+    int markerCount = 0;
     try {
-      bot.waitUntil(new WaitForEquals<>("Some markers were not quickfixed.", () -> 0, () -> Arrays.stream(markersTreeBot.getAllItems()).filter(checkResourceFilter).toList().size()));
-    } catch (TimeoutException exception) {
-      fail(exception.getMessage());
+      for (XtextTestSource source : catalogSources) {
+        for (IMarker marker : source.getiFile().findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO)) {
+          if (IssueCodes.MISSING_ID_ON_CHECK.equals(marker.getAttribute(Issue.CODE_KEY))) {
+            markerCount++;
+          }
+        }
+      }
+      return markerCount;
+    } catch (CoreException e) {
+      throw new WrappedException("Could not read workspace markers.", e);
     }
+  }
+
+  private void waitForProblemsViewMarkers(final SWTBotTree markersTreeBot, final Predicate<? super SWTBotTreeItem> markerFilter, final int expectedMarkers, final String failureMessage) {
+    bot.waitUntil(new WaitForEquals<>(failureMessage, () -> expectedMarkers, () -> Arrays.stream(markersTreeBot.getAllItems()).filter(markerFilter).toList().size()), ASYNC_UI_TIMEOUT);
   }
 }
 // CHECKSTYLE:CONSTANTS-ON

--- a/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/quickfix/CheckQuickfixTest.java
+++ b/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/quickfix/CheckQuickfixTest.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -50,12 +51,11 @@ import com.avaloq.tools.ddk.xtext.test.XtextTestSource;
 // CHECKSTYLE:CONSTANTS-OFF
 public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
 
-  private static final long ASYNC_UPDATE_TIMEOUT = 30000;
   private static final String PACKAGE_NAME = "com.avaloq.test";
   private static final String RESOURCE_COLUMN_NAME = "Resource";
 
   private final SwtWorkbenchBot bot = new SwtWorkbenchBot();
-  private boolean oldAutoBuildState;
+  private final AtomicBoolean oldAutoBuildState = new AtomicBoolean();
 
   public String getTestSourceFileName(final String catalogName) {
     return PACKAGE_NAME.replace(".", "/") + '/' + catalogName + '.' + getXtextTestUtil().getFileExtension();
@@ -78,13 +78,13 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
   @Override
   protected void beforeEachTest() {
     super.beforeEachTest();
-    oldAutoBuildState = getTestProjectManager().setAutobuild(true);
+    oldAutoBuildState.set(getTestProjectManager().setAutobuild(true));
     cleanUp();
   }
 
   @Override
   protected void afterEachTest() {
-    getTestProjectManager().setAutobuild(oldAutoBuildState);
+    getTestProjectManager().setAutobuild(oldAutoBuildState.get());
     cleanUp();
     super.afterEachTest();
   }
@@ -212,7 +212,7 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
     // ACT
     // Bulk-apply quickfixes on all markers, ensuring that all markers remain selected
     ProblemsViewTestUtil.bulkApplyQuickfix(bot, Messages.CheckQuickfixProvider_ADD_ID_LABEL, checkMarkers);
-    bot.waitUntil(new WaitForEquals<>("Not all markers are still selected.", () -> expectedMarkers, () -> markersTreeBot.selectionCount()), ASYNC_UPDATE_TIMEOUT);
+    bot.waitUntil(new WaitForEquals<>("Not all markers are still selected.", () -> expectedMarkers, () -> markersTreeBot.selectionCount()), ProblemsViewTestUtil.ASYNC_UPDATE_TIMEOUT);
 
     // Save all modified files and build the catalogs
     bot.editors().forEach(editor -> editor.save());
@@ -229,7 +229,7 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
    * Waits until the exact expected number of relevant workspace markers exists.
    */
   private void waitForWorkspaceMarkers(final List<XtextTestSource> catalogSources, final int expectedMarkers) {
-    final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(ASYNC_UPDATE_TIMEOUT);
+    final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(ProblemsViewTestUtil.ASYNC_UPDATE_TIMEOUT);
     int markerCount;
     do {
       markerCount = countWorkspaceMarkers(catalogSources);
@@ -269,7 +269,7 @@ public class CheckQuickfixTest extends AbstractCheckQuickfixTest {
       final SWTBotTreeItem[] items = Arrays.stream(markersTreeBot.getAllItems()).filter(markerFilter).toArray(SWTBotTreeItem[]::new);
       matchingMarkers.set(items);
       return items.length;
-    }), ASYNC_UPDATE_TIMEOUT);
+    }), ProblemsViewTestUtil.ASYNC_UPDATE_TIMEOUT);
     return matchingMarkers.get();
   }
 }

--- a/com.avaloq.tools.ddk.test.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.test.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.test.ui
 Bundle-SymbolicName: com.avaloq.tools.ddk.test.ui;singleton:=true
-Bundle-Version: 17.3.2.qualifier
+Bundle-Version: 17.3.3.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Activator: com.avaloq.tools.ddk.test.ui.Activator

--- a/com.avaloq.tools.ddk.test.ui/pom.xml
+++ b/com.avaloq.tools.ddk.test.ui/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.2-SNAPSHOT</version>
+  <version>17.3.3-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.test.ui</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/ProblemsViewTestUtil.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/ProblemsViewTestUtil.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.waits.WaitForObjectCondition;
-import org.eclipse.swtbot.swt.finder.widgets.SWTBotButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTableItem;
@@ -40,7 +39,8 @@ import com.avaloq.tools.ddk.test.ui.swtbot.condition.WaitForEquals;
  * Utility class with handy methods for testing Problems view.
  */
 public final class ProblemsViewTestUtil {
-  private static final long ASYNC_UI_TIMEOUT = 60000;
+  /** Maximum time to wait for asynchronous Problems view and Quick Fix dialog updates. */
+  public static final long ASYNC_UPDATE_TIMEOUT = 30000;
 
   public static final String GROUP_BY = "&Group By"; //$NON-NLS-1$
   public static final String NONE = "&None"; //$NON-NLS-1$
@@ -52,6 +52,7 @@ public final class ProblemsViewTestUtil {
   public static final String SELECT_A_FIX_TABLE_LABEL = "Select a fix:"; //$NON-NLS-1$
   public static final String PROBLEMS_TABLE_LABEL = "Problems:"; //$NON-NLS-1$
   public static final String LOCATION_COLUMN_NAME = "Location"; //$NON-NLS-1$
+  public static final String RESOURCE_COLUMN_NAME = "Resource"; //$NON-NLS-1$
   public static final String FINISH_BUTTON_LABEL = "Finish"; //$NON-NLS-1$
 
   /**
@@ -148,37 +149,39 @@ public final class ProblemsViewTestUtil {
     // Open the Quick Fix dialog
     final SWTBotTree markersTreeBot = getMarkersTree(bot);
     DynamicContextActionUiTestUtil.clickContextMenu(() -> {
-      // Select markers. Keep retrying if focus is lost at an inopportune moment.
-      do {
+      // Select markers. Keep retrying for a bounded time if focus is lost at an inopportune moment.
+      bot.waitUntil(new WaitForEquals<>("Could not select all markers in the Problems view.", () -> markers.length, () -> {
         markersTreeBot.select(markers);
-      } while (markersTreeBot.selectionCount() != markers.length);
+        return markersTreeBot.selectionCount();
+      }), ASYNC_UPDATE_TIMEOUT);
     }, markersTreeBot, DynamicMenuPredicate.ALWAYS_WAITING, QUICK_FIX_CONTEXT_MENU_ITEM_LABEL);
-    bot.waitUntil(Conditions.shellIsActive(QUICK_FIX_DIALOG_TEXT), ASYNC_UI_TIMEOUT);
+    bot.waitUntil(Conditions.shellIsActive(QUICK_FIX_DIALOG_TEXT), ASYNC_UPDATE_TIMEOUT);
     final SWTBotShell quickFixShell = bot.shell(QUICK_FIX_DIALOG_TEXT);
     final SWTBot quickFixBot = quickFixShell.bot();
 
     // Select the quickfix
     final SWTBotTable selectFixTable = waitForTable(bot, quickFixShell, SELECT_A_FIX_TABLE_LABEL);
-    bot.waitUntil(new WaitForEquals<>("Quick Fix dialog did not list the requested fix.", () -> true, () -> selectFixTable.containsItem(quickfixLabel)), ASYNC_UI_TIMEOUT); //$NON-NLS-1$
+    bot.waitUntil(new WaitForEquals<>("Quick Fix dialog did not list the requested fix.", () -> true, () -> selectFixTable.containsItem(quickfixLabel)), ASYNC_UPDATE_TIMEOUT); //$NON-NLS-1$
     selectFixTable.select(quickfixLabel);
 
     // Selecting the fix repopulates the Problems table asynchronously; tick every expected row and retry until all are
     // checked, tolerating the transient table resizes that happen while the table is still being repopulated.
     final int locationColumnIndex = markersTreeBot.columns().indexOf(LOCATION_COLUMN_NAME);
+    if (locationColumnIndex < 0) {
+      throw new IllegalStateException("Problems view has no Location column."); //$NON-NLS-1$
+    }
     final Set<String> markerLocations = Stream.of(markers).map(marker -> marker.cell(locationColumnIndex)).collect(Collectors.toSet());
     final SWTBotTable tableBot = waitForTable(bot, quickFixShell, PROBLEMS_TABLE_LABEL);
-    bot.waitUntil(new WaitForEquals<>("Quick Fix dialog did not list all expected markers.", () -> markers.length, () -> checkMatchingRows(tableBot, markerLocations)), ASYNC_UI_TIMEOUT); //$NON-NLS-1$
+    bot.waitUntil(new WaitForEquals<>("Quick Fix dialog did not list all expected markers.", () -> markers.length, () -> checkMatchingRows(tableBot, markerLocations)), ASYNC_UPDATE_TIMEOUT); //$NON-NLS-1$
 
-    final SWTBotButton finishButton = quickFixBot.button(FINISH_BUTTON_LABEL);
-    bot.waitUntil(Conditions.widgetIsEnabled(finishButton), ASYNC_UI_TIMEOUT);
-    finishButton.click();
+    bot.clickButton(quickFixBot.button(FINISH_BUTTON_LABEL), ASYNC_UPDATE_TIMEOUT);
     // Block until the wizard has actually closed, so callers do not save/build while the resolution is still being applied.
-    bot.waitUntil(Conditions.shellCloses(quickFixShell), ASYNC_UI_TIMEOUT);
+    bot.waitUntil(Conditions.shellCloses(quickFixShell), ASYNC_UPDATE_TIMEOUT);
   }
 
   private static SWTBotTable waitForTable(final SwtWorkbenchBot bot, final SWTBotShell shell, final String label) {
     final WaitForObjectCondition<Table> tableAppears = Conditions.waitForWidget(allOf(widgetOfType(Table.class), withLabel(label)), shell.widget);
-    bot.waitUntil(tableAppears, ASYNC_UI_TIMEOUT);
+    bot.waitUntil(tableAppears, ASYNC_UPDATE_TIMEOUT);
     return new SWTBotTable(tableAppears.get(0));
   }
 

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/ProblemsViewTestUtil.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/ProblemsViewTestUtil.java
@@ -39,7 +39,8 @@ import com.avaloq.tools.ddk.test.ui.swtbot.condition.WaitForEquals;
  * Utility class with handy methods for testing Problems view.
  */
 public final class ProblemsViewTestUtil {
-  private static final long ASYNC_UPDATE_TIMEOUT = 30000;
+  /** Maximum time to wait for asynchronous Problems view and Quick Fix dialog updates. */
+  public static final long ASYNC_UPDATE_TIMEOUT = 30000;
 
   public static final String GROUP_BY = "&Group By"; //$NON-NLS-1$
   public static final String NONE = "&None"; //$NON-NLS-1$

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/ProblemsViewTestUtil.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/ProblemsViewTestUtil.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.swt.widgets.Table;
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.waits.WaitForObjectCondition;
@@ -28,7 +29,6 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTableItem;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
-import org.eclipse.swt.widgets.Table;
 
 import com.avaloq.tools.ddk.test.ui.swtbot.CoreSwtbotTools;
 import com.avaloq.tools.ddk.test.ui.swtbot.SwtWorkbenchBot;
@@ -39,8 +39,7 @@ import com.avaloq.tools.ddk.test.ui.swtbot.condition.WaitForEquals;
  * Utility class with handy methods for testing Problems view.
  */
 public final class ProblemsViewTestUtil {
-  /** Maximum time to wait for asynchronous Problems view and Quick Fix dialog updates. */
-  public static final long ASYNC_UPDATE_TIMEOUT = 30000;
+  private static final long ASYNC_UPDATE_TIMEOUT = 30000;
 
   public static final String GROUP_BY = "&Group By"; //$NON-NLS-1$
   public static final String NONE = "&None"; //$NON-NLS-1$
@@ -52,7 +51,6 @@ public final class ProblemsViewTestUtil {
   public static final String SELECT_A_FIX_TABLE_LABEL = "Select a fix:"; //$NON-NLS-1$
   public static final String PROBLEMS_TABLE_LABEL = "Problems:"; //$NON-NLS-1$
   public static final String LOCATION_COLUMN_NAME = "Location"; //$NON-NLS-1$
-  public static final String RESOURCE_COLUMN_NAME = "Resource"; //$NON-NLS-1$
   public static final String FINISH_BUTTON_LABEL = "Finish"; //$NON-NLS-1$
 
   /**
@@ -179,6 +177,9 @@ public final class ProblemsViewTestUtil {
     bot.waitUntil(Conditions.shellCloses(quickFixShell), ASYNC_UPDATE_TIMEOUT);
   }
 
+  /**
+   * Waits for the table with the given label inside the given shell.
+   */
   private static SWTBotTable waitForTable(final SwtWorkbenchBot bot, final SWTBotShell shell, final String label) {
     final WaitForObjectCondition<Table> tableAppears = Conditions.waitForWidget(allOf(widgetOfType(Table.class), withLabel(label)), shell.widget);
     bot.waitUntil(tableAppears, ASYNC_UPDATE_TIMEOUT);

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/ProblemsViewTestUtil.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/util/ProblemsViewTestUtil.java
@@ -11,18 +11,25 @@
 
 package com.avaloq.tools.ddk.test.ui.swtbot.util;
 
+import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.widgetOfType;
+import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.withLabel;
 import static org.eclipse.ui.IPageLayout.ID_PROBLEM_VIEW;
+import static org.hamcrest.Matchers.allOf;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.waits.WaitForObjectCondition;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotButton;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTableItem;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.eclipse.swt.widgets.Table;
 
 import com.avaloq.tools.ddk.test.ui.swtbot.CoreSwtbotTools;
 import com.avaloq.tools.ddk.test.ui.swtbot.SwtWorkbenchBot;
@@ -33,6 +40,8 @@ import com.avaloq.tools.ddk.test.ui.swtbot.condition.WaitForEquals;
  * Utility class with handy methods for testing Problems view.
  */
 public final class ProblemsViewTestUtil {
+  private static final long ASYNC_UI_TIMEOUT = 60000;
+
   public static final String GROUP_BY = "&Group By"; //$NON-NLS-1$
   public static final String NONE = "&None"; //$NON-NLS-1$
   public static final String SHOW = "&Show"; //$NON-NLS-1$
@@ -144,22 +153,33 @@ public final class ProblemsViewTestUtil {
         markersTreeBot.select(markers);
       } while (markersTreeBot.selectionCount() != markers.length);
     }, markersTreeBot, DynamicMenuPredicate.ALWAYS_WAITING, QUICK_FIX_CONTEXT_MENU_ITEM_LABEL);
-    bot.waitUntil(Conditions.shellIsActive(QUICK_FIX_DIALOG_TEXT));
+    bot.waitUntil(Conditions.shellIsActive(QUICK_FIX_DIALOG_TEXT), ASYNC_UI_TIMEOUT);
     final SWTBotShell quickFixShell = bot.shell(QUICK_FIX_DIALOG_TEXT);
+    final SWTBot quickFixBot = quickFixShell.bot();
 
     // Select the quickfix
-    bot.tableWithLabel(SELECT_A_FIX_TABLE_LABEL).select(quickfixLabel);
+    final SWTBotTable selectFixTable = waitForTable(bot, quickFixShell, SELECT_A_FIX_TABLE_LABEL);
+    bot.waitUntil(new WaitForEquals<>("Quick Fix dialog did not list the requested fix.", () -> true, () -> selectFixTable.containsItem(quickfixLabel)), ASYNC_UI_TIMEOUT); //$NON-NLS-1$
+    selectFixTable.select(quickfixLabel);
 
     // Selecting the fix repopulates the Problems table asynchronously; tick every expected row and retry until all are
     // checked, tolerating the transient table resizes that happen while the table is still being repopulated.
     final int locationColumnIndex = markersTreeBot.columns().indexOf(LOCATION_COLUMN_NAME);
     final Set<String> markerLocations = Stream.of(markers).map(marker -> marker.cell(locationColumnIndex)).collect(Collectors.toSet());
-    final SWTBotTable tableBot = bot.tableWithLabel(PROBLEMS_TABLE_LABEL);
-    bot.waitUntil(new WaitForEquals<>("Quick Fix dialog did not list all expected markers.", () -> markers.length, () -> checkMatchingRows(tableBot, markerLocations))); //$NON-NLS-1$
+    final SWTBotTable tableBot = waitForTable(bot, quickFixShell, PROBLEMS_TABLE_LABEL);
+    bot.waitUntil(new WaitForEquals<>("Quick Fix dialog did not list all expected markers.", () -> markers.length, () -> checkMatchingRows(tableBot, markerLocations)), ASYNC_UI_TIMEOUT); //$NON-NLS-1$
 
-    bot.clickButton(FINISH_BUTTON_LABEL);
+    final SWTBotButton finishButton = quickFixBot.button(FINISH_BUTTON_LABEL);
+    bot.waitUntil(Conditions.widgetIsEnabled(finishButton), ASYNC_UI_TIMEOUT);
+    finishButton.click();
     // Block until the wizard has actually closed, so callers do not save/build while the resolution is still being applied.
-    bot.waitUntil(Conditions.shellCloses(quickFixShell));
+    bot.waitUntil(Conditions.shellCloses(quickFixShell), ASYNC_UI_TIMEOUT);
+  }
+
+  private static SWTBotTable waitForTable(final SwtWorkbenchBot bot, final SWTBotShell shell, final String label) {
+    final WaitForObjectCondition<Table> tableAppears = Conditions.waitForWidget(allOf(widgetOfType(Table.class), withLabel(label)), shell.widget);
+    bot.waitUntil(tableAppears, ASYNC_UI_TIMEOUT);
+    return new SWTBotTable(tableAppears.get(0));
   }
 
   /*


### PR DESCRIPTION
## Summary

- disable autobuild before creating the test sources, then run one explicit synchronous incremental build before observing markers
- wait for the exact workspace issue markers and Problems view rows belonging to the files created by the test
- capture the matching Problems view items inside the bounded wait and use that captured set for the bulk quickfix
- resolve Problems view columns by name and fail clearly when required columns are absent
- bound marker selection and asynchronous Quick Fix dialog transitions at 30 seconds through one shared utility timeout
- retain the repository's hardened button click and wait for the dialog to close before saving and rebuilding
- verify marker removal independently in the workspace and Problems view
- bump the published test UI bundle from 17.3.2 to 17.3.3 because its compiled shared utility changes

## Why

The test crossed Eclipse workspace-marker, Problems-view, and Quick-Fix-dialog asynchronous boundaries while relying on SWTBot's default five-second waits. In [PR #1504's relevant failed Maven attempt](https://github.com/dsldevkit/dsl-devkit/actions/runs/33170809721/job/99280058783), `testBulkApplyingQuickfix` expected four marker rows but observed none after five seconds. A subsequent attempt passed unchanged, identifying this as an intermittent synchronization failure rather than an Xtend update failure.

The revised flow removes the build-and-refresh window between observing marker rows and selecting them. Source creation cannot trigger an early autobuild; `XtextTestProjectManager.build()` delegates to Xtext 2.43's `IResourcesSetupUtil.waitForBuild(...)`, which explicitly invokes `workspace.build(INCREMENTAL_BUILD, monitor)`. The test then waits for the exact workspace markers and captures the corresponding Problems view items inside the same bounded observation used to establish readiness.

The 30-second ceilings are bounds, not fixed delays or retries: every wait returns as soon as its state is reached. The timeout remains a documented public constant on the exported `ProblemsViewTestUtil` so both bundles use one value; the test UI bundle's micro bump records the compiled output change. Bounded SWTBot waits now retain their native timeout classification instead of being converted to generic assertion failures.

## Local validation

- full CI-equivalent clean reactor on `a7fad50bf`, including Checkstyle, PMD/CPD, and SpotBugs: passed across all 64 modules
- aggregate suite: 354 tests, 0 failures, 0 errors; target test 7.047 s
- controlled repetition harness on upstream `master`: 20/20 bulk-quickfix repetitions passed
- identical controlled repetition harness on this revision: 20/20 bulk-quickfix repetitions passed

The controlled runs establish no local regression, but they do not statistically prove a lower flake rate: the intermittent CI failure did not reproduce in the local environment on either baseline or revision.

## Remote validation

- [current-head workflow for `a7fad50bf`](https://github.com/dsldevkit/dsl-devkit/actions/runs/33338584426): passed
- Maven verification: 354 tests, 0 failures, 0 errors, 2 skipped; target test 7.660 s; SpotBugs clean
- PMD: passed
- Checkstyle: passed
- line endings: passed
