### PR TITLE
fix: satisfy PMD 7.27.0 across the reactor

### DIFF
--- a/com.avaloq.tools.ddk.check.lib/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.check.lib/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.check.lib
 Bundle-SymbolicName: com.avaloq.tools.ddk.check.lib
-Bundle-Version: 17.3.1.qualifier
+Bundle-Version: 17.3.2.qualifier
 Bundle-Vendor: Avaloq Group AG
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext,

--- a/com.avaloq.tools.ddk.check.lib/pom.xml
+++ b/com.avaloq.tools.ddk.check.lib/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.1-SNAPSHOT</version>
+  <version>17.3.2-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.check.lib</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.check.lib/src/com/avaloq/tools/ddk/check/lib/internal/Index.java
+++ b/com.avaloq.tools.ddk.check.lib/src/com/avaloq/tools/ddk/check/lib/internal/Index.java
@@ -41,7 +41,7 @@ public final class Index implements IIndex {
   @Inject
   private IQualifiedNameConverter nameConverter;
 
-  protected Index() {
+  Index() {
     // Prevent explicit instantiations. To be used via injection.
   }
 
@@ -78,9 +78,8 @@ public final class Index implements IIndex {
      *          to use
      * @param type
      *          to look for
-     * @return a query object
      */
-    protected Query(final IDomain.Mapper mapper, final IQualifiedNameConverter nameConverter, final EClass type) {
+    private Query(final IDomain.Mapper mapper, final IQualifiedNameConverter nameConverter, final EClass type) {
       this.realQuery = ContainerQuery.newBuilder(mapper, type);
       this.nameConverter = nameConverter;
     }
@@ -155,7 +154,7 @@ public final class Index implements IIndex {
      * @param internalDescription
      *          to wrap
      */
-    protected Entry(final EObject context, final IQualifiedNameConverter nameConverter, final IEObjectDescription internalDescription) {
+    private Entry(final EObject context, final IQualifiedNameConverter nameConverter, final IEObjectDescription internalDescription) {
       this.context = context;
       this.nameConverter = nameConverter;
       this.delegate = internalDescription;

--- a/com.avaloq.tools.ddk.check.lib/src/com/avaloq/tools/ddk/check/lib/internal/PerResourceCache.java
+++ b/com.avaloq.tools.ddk.check.lib/src/com/avaloq/tools/ddk/check/lib/internal/PerResourceCache.java
@@ -28,7 +28,7 @@ import com.google.inject.Singleton;
 @Singleton
 public final class PerResourceCache implements IResourceCache {
 
-  protected PerResourceCache() {
+  PerResourceCache() {
     // Prevent explicit instantiations. All classes from this library shall be injected in check catalogs.
   }
 

--- a/com.avaloq.tools.ddk.check.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.check.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.check.ui
 Bundle-SymbolicName: com.avaloq.tools.ddk.check.ui;singleton:=true
-Bundle-Version: 17.3.2.qualifier
+Bundle-Version: 17.3.3.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Activator: com.avaloq.tools.ddk.check.ui.internal.Activator

--- a/com.avaloq.tools.ddk.check.ui/pom.xml
+++ b/com.avaloq.tools.ddk.check.ui/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.2-SNAPSHOT</version>
+  <version>17.3.3-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.check.ui</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckExtensionGenerator.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/CheckExtensionGenerator.java
@@ -230,7 +230,7 @@ class CheckExtensionGenerator {
      * A {@code PluginElement} that can be loaded from an xml file.
      */
     @SuppressWarnings("PMD.PublicMemberInNonPublicType") // Public methods needed for subclass access in other packages
-    protected class CheckPluginElement extends PluginElement {
+    class CheckPluginElement extends PluginElement {
 
       private static final long serialVersionUID = 1L;
 

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckMarkerHelpExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckMarkerHelpExtensionHelper.java
@@ -138,6 +138,7 @@ public class CheckMarkerHelpExtensionHelper extends AbstractCheckDocumentationEx
   }
 
   @Override
+  @SuppressWarnings("PMD.UnusedReturnValue") // Preserve the existing exception-based existence check.
   public boolean isExtensionUpdateRequired(final CheckCatalog catalog, final IPluginExtension extension, final Iterable<IPluginElement> elements) {
     // TODO should check if this check is too expensive; consider rewriting contents instead
     if (!super.isExtensionUpdateRequired(catalog, extension, elements)) {

--- a/com.avaloq.tools.ddk.checkcfg.ide/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.checkcfg.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.checkcfg.ide
 Bundle-SymbolicName: com.avaloq.tools.ddk.checkcfg.ide;singleton:=true
-Bundle-Version: 17.3.1.qualifier
+Bundle-Version: 17.3.2.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/com.avaloq.tools.ddk.checkcfg.ide/pom.xml
+++ b/com.avaloq.tools.ddk.checkcfg.ide/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.1-SNAPSHOT</version>
+  <version>17.3.2-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.checkcfg.ide</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/contentassist/CheckCfgIdeContentProposalProvider.java
+++ b/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/contentassist/CheckCfgIdeContentProposalProvider.java
@@ -304,6 +304,7 @@ public class CheckCfgIdeContentProposalProvider extends XbaseIdeContentProposalP
    *          the catalog
    * @return true, if is catalog configured
    */
+  @SuppressWarnings("PMD.UnusedReturnValue") // Preserve the existing exception-based existence check.
   private boolean isCatalogConfigured(final CheckConfiguration conf, final CheckCatalog catalog) {
     try {
       Iterables.find(conf.getLegacyCatalogConfigurations(), new Predicate<ConfiguredCatalog>() {

--- a/com.avaloq.tools.ddk.checkcfg.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.checkcfg.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.checkcfg.ui
 Bundle-SymbolicName: com.avaloq.tools.ddk.checkcfg.ui;singleton:=true
-Bundle-Version: 17.3.2.qualifier
+Bundle-Version: 17.3.3.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Activator: com.avaloq.tools.ddk.checkcfg.ui.internal.Activator

--- a/com.avaloq.tools.ddk.checkcfg.ui/pom.xml
+++ b/com.avaloq.tools.ddk.checkcfg.ui/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.2-SNAPSHOT</version>
+  <version>17.3.3-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.checkcfg.ui</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.checkcfg.ui/src/com/avaloq/tools/ddk/checkcfg/ui/templates/CheckCfgTemplateProposalProvider.java
+++ b/com.avaloq.tools.ddk.checkcfg.ui/src/com/avaloq/tools/ddk/checkcfg/ui/templates/CheckCfgTemplateProposalProvider.java
@@ -175,6 +175,7 @@ public class CheckCfgTemplateProposalProvider extends DefaultTemplateProposalPro
    *          the catalog
    * @return true, if is catalog configured
    */
+  @SuppressWarnings("PMD.UnusedReturnValue") // Preserve the existing exception-based existence check.
   private boolean isCatalogConfigured(final CheckConfiguration conf, final CheckCatalog catalog) {
     try {
       Iterables.find(conf.getLegacyCatalogConfigurations(), new Predicate<ConfiguredCatalog>() {

--- a/com.avaloq.tools.ddk.feature/feature.xml
+++ b/com.avaloq.tools.ddk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.avaloq.tools.ddk.feature"
       label="com.avaloq.tools.ddk.feature"
-      version="19.1.1.qualifier"
+      version="19.1.2.qualifier"
       provider-name="Avaloq Group AG">
 
    <description>

--- a/com.avaloq.tools.ddk.feature/pom.xml
+++ b/com.avaloq.tools.ddk.feature/pom.xml
@@ -7,7 +7,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>19.1.1-SNAPSHOT</version>
+  <version>19.1.2-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/com.avaloq.tools.ddk.runtime.feature/feature.xml
+++ b/com.avaloq.tools.ddk.runtime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.avaloq.tools.ddk.runtime.feature"
       label="com.avaloq.tools.ddk.runtime.feature"
-      version="19.1.0.qualifier"
+      version="19.1.1.qualifier"
       provider-name="Avaloq Group AG">
 
    <description>

--- a/com.avaloq.tools.ddk.runtime.feature/pom.xml
+++ b/com.avaloq.tools.ddk.runtime.feature/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>19.1.0-SNAPSHOT</version>
+  <version>19.1.1-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.runtime.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/CoreSwtbotTools.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/CoreSwtbotTools.java
@@ -344,7 +344,7 @@ public final class CoreSwtbotTools {
     Assert.isNotNull(bot, ARGUMENT_BOT);
     Assert.isNotNull(table, ARGUMENT_TABLE);
     waitForTableItem(bot, table);
-    List<SWTBotTableItem> items = null;
+    List<SWTBotTableItem> items = new ArrayList<SWTBotTableItem>();
     for (int i = 0; i < table.rowCount(); i++) {
       items = new ArrayList<SWTBotTableItem>(Arrays.asList(table.getTableItem(i)));
     }

--- a/com.avaloq.tools.ddk.xtext.expression/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.expression/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.xtext.expression
 Bundle-SymbolicName: com.avaloq.tools.ddk.xtext.expression;singleton:=true
-Bundle-Version: 17.3.2.qualifier
+Bundle-Version: 17.3.3.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.xtext,

--- a/com.avaloq.tools.ddk.xtext.expression/pom.xml
+++ b/com.avaloq.tools.ddk.xtext.expression/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.2-SNAPSHOT</version>
+  <version>17.3.3-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.xtext.expression</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.xtext.expression/src/com/avaloq/tools/ddk/xtext/expression/generator/GeneratorUtil.java
+++ b/com.avaloq.tools.ddk.xtext.expression/src/com/avaloq/tools/ddk/xtext/expression/generator/GeneratorUtil.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Sets;
  * These utility methods make of for shortcomings in the xtext generator framework and will hopefully find an adequate replacement
  * inside xtext.
  */
+@SuppressWarnings("PMD.InstantiableUtilityClass") // Preserve subclass compatibility for this exported API.
 public class GeneratorUtil {
 
   public static final String ISO_8859_1 = "ISO-8859-1"; //$NON-NLS-1$

--- a/com.avaloq.tools.ddk.xtext.test.core/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.test.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.xtext.test.core
 Bundle-SymbolicName: com.avaloq.tools.ddk.xtext.test.core;singleton:=true
-Bundle-Version: 17.3.2.qualifier
+Bundle-Version: 17.3.3.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: com.avaloq.tools.ddk.xtext,

--- a/com.avaloq.tools.ddk.xtext.test.core/pom.xml
+++ b/com.avaloq.tools.ddk.xtext.test.core/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.2-SNAPSHOT</version>
+  <version>17.3.3-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.xtext.test.core</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/jvmmodel/InferredJvmModelUtil.java
+++ b/com.avaloq.tools.ddk.xtext.test.core/src/com/avaloq/tools/ddk/xtext/test/jvmmodel/InferredJvmModelUtil.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 /**
  * Utility methods for inferred JVM models.
  */
+@SuppressWarnings("PMD.InstantiableUtilityClass") // Preserve subclass compatibility for this exported API.
 public class InferredJvmModelUtil {
 
   /**

--- a/com.avaloq.tools.ddk.xtext.test/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.xtext.test
 Bundle-SymbolicName: com.avaloq.tools.ddk.xtext.test;singleton:=true
-Bundle-Version: 17.3.1.qualifier
+Bundle-Version: 17.3.2.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/com.avaloq.tools.ddk.xtext.test/pom.xml
+++ b/com.avaloq.tools.ddk.xtext.test/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.1-SNAPSHOT</version>
+  <version>17.3.2-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.xtext.test</artifactId>
   <packaging>eclipse-test-plugin</packaging>

--- a/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/resource/AbstractSelectorFragmentProviderTest.java
+++ b/com.avaloq.tools.ddk.xtext.test/src/com/avaloq/tools/ddk/xtext/resource/AbstractSelectorFragmentProviderTest.java
@@ -121,19 +121,19 @@ public class AbstractSelectorFragmentProviderTest {
       return super.appendFragmentSegment(object, builder);
     }
 
-    protected boolean appendFragmentSegment(final Grammar obj, final StringBuilder builder) {
+    private boolean appendFragmentSegment(final Grammar obj, final StringBuilder builder) {
       return computeSelectorFragmentSegment(obj, XtextPackage.Literals.GRAMMAR__NAME, true, builder);
     }
 
-    protected boolean appendFragmentSegment(final AbstractRule obj, final StringBuilder builder) {
+    private boolean appendFragmentSegment(final AbstractRule obj, final StringBuilder builder) {
       return computeSelectorFragmentSegment(obj, XtextPackage.Literals.ABSTRACT_RULE__NAME, false, builder);
     }
 
-    protected boolean appendFragmentSegment(final AbstractElement obj, final StringBuilder builder) {
+    private boolean appendFragmentSegment(final AbstractElement obj, final StringBuilder builder) {
       return computeSelectorFragmentSegment(obj, XtextPackage.Literals.ABSTRACT_ELEMENT__CARDINALITY, false, builder);
     }
 
-    protected boolean appendFragmentSegment(final Keyword obj, final StringBuilder builder) {
+    private boolean appendFragmentSegment(final Keyword obj, final StringBuilder builder) {
       return computeSelectorFragmentSegment(obj, XtextPackage.Literals.KEYWORD__VALUE, false, builder);
     }
 

--- a/com.avaloq.tools.ddk.xtext.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.xtext.ui
 Bundle-SymbolicName: com.avaloq.tools.ddk.xtext.ui;singleton:=true
-Bundle-Version: 17.3.2.qualifier
+Bundle-Version: 17.3.3.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/com.avaloq.tools.ddk.xtext.ui/pom.xml
+++ b/com.avaloq.tools.ddk.xtext.ui/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.2-SNAPSHOT</version>
+  <version>17.3.3-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.xtext.ui</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/AbstractValidElementBase.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/AbstractValidElementBase.java
@@ -57,19 +57,15 @@ public abstract class AbstractValidElementBase {
    * @return the child elements of this element
    */
   public AbstractValidElementBase[] getChildElements() {
-    AbstractValidElementBase[] childElements = null;
-    if (childElements == null) {
-      IConfigurationElement[] ce = getConfigurationElement().getChildren();
-      List<AbstractValidElementBase> elements = new ArrayList<AbstractValidElementBase>();
-      for (IConfigurationElement element : ce) {
-        AbstractValidElementBase e = createChildElement(element);
-        if (e != null) {
-          elements.add(e);
-        }
+    IConfigurationElement[] ce = getConfigurationElement().getChildren();
+    List<AbstractValidElementBase> elements = new ArrayList<AbstractValidElementBase>();
+    for (IConfigurationElement element : ce) {
+      AbstractValidElementBase e = createChildElement(element);
+      if (e != null) {
+        elements.add(e);
       }
-      childElements = elements.toArray(new AbstractValidElementBase[elements.size()]);
     }
-    return childElements;
+    return elements.toArray(new AbstractValidElementBase[elements.size()]);
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/CategoryElement.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/CategoryElement.java
@@ -27,7 +27,7 @@ public final class CategoryElement extends AbstractValidElementBase {
   private final String label;
   private final String description;
 
-  protected CategoryElement(final IConfigurationElement ce) {
+  CategoryElement(final IConfigurationElement ce) {
     super(ce);
     name = getAttribute(ce, NAME, false);
     label = getAttribute(ce, LABEL, false);

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/RuleElement.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/RuleElement.java
@@ -31,7 +31,7 @@ public final class RuleElement extends AbstractValidElementBase {
   private final String severity;
   private final String evaluationMode;
 
-  protected RuleElement(final IConfigurationElement ce) {
+  RuleElement(final IConfigurationElement ce) {
     super(ce);
     final String bOptional = getAttribute(ce, OPTIONAL, false);
     optional = bOptional == null ? null : Boolean.valueOf(bOptional);

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/ValidElement.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/ValidElement.java
@@ -25,7 +25,7 @@ public final class ValidElement extends AbstractValidElementBase {
 
   private final String language;
 
-  protected ValidElement(final IConfigurationElement ce) {
+  ValidElement(final IConfigurationElement ce) {
     super(ce);
     language = getAttribute(ce, LANGUAGE, false);
   }

--- a/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/ValidExtension.java
+++ b/com.avaloq.tools.ddk.xtext.ui/src/com/avaloq/tools/ddk/xtext/ui/validation/ValidExtension.java
@@ -55,19 +55,14 @@ public final class ValidExtension {
    * @return the top-level elements of this extension point
    */
   public ValidElement[] getTopLevelElements() {
-    ValidElement[] topLevelElements = null;
-    if (topLevelElements == null) {
-      IConfigurationElement[] configurationElements = extension.getConfigurationElements();
-      List<ValidElement> elements = new ArrayList<ValidElement>();
-      for (IConfigurationElement ce : configurationElements) {
-        if (XML_TOP_ELEMENT_NAME.equals(ce.getName())) {
-          ValidElement e = new ValidElement(ce);
-          elements.add(e);
-        }
+    IConfigurationElement[] configurationElements = extension.getConfigurationElements();
+    List<ValidElement> elements = new ArrayList<ValidElement>();
+    for (IConfigurationElement ce : configurationElements) {
+      if (XML_TOP_ELEMENT_NAME.equals(ce.getName())) {
+        elements.add(new ValidElement(ce));
       }
-      topLevelElements = elements.toArray(new ValidElement[elements.size()]);
     }
-    return topLevelElements;
+    return elements.toArray(new ValidElement[elements.size()]);
   }
 
   /**

--- a/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.xtext
 Bundle-SymbolicName: com.avaloq.tools.ddk.xtext;singleton:=true
-Bundle-Version: 17.3.2.qualifier
+Bundle-Version: 17.3.3.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/com.avaloq.tools.ddk.xtext/pom.xml
+++ b/com.avaloq.tools.ddk.xtext/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.2-SNAPSHOT</version>
+  <version>17.3.3-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.xtext</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelUtil.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/modelinference/InferredModelUtil.java
@@ -24,6 +24,7 @@ import org.eclipse.xtext.resource.XtextResource;
 /**
  * Utility methods for inferred models.
  */
+@SuppressWarnings("PMD.InstantiableUtilityClass") // Preserve subclass compatibility for this exported API.
 public class InferredModelUtil {
 
   protected InferredModelUtil() { // No public constructor for utility class

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/XtextGMFResourceUtil.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/XtextGMFResourceUtil.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 /**
  * Utility class for combined Xtext-GMF resources.
  */
+@SuppressWarnings("PMD.InstantiableUtilityClass") // Preserve subclass compatibility for this exported API.
 public class XtextGMFResourceUtil {
 
   /** Class-wide logger. */

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
@@ -87,7 +87,7 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
     }
 
     @SuppressWarnings("PMD.UnusedFormalParameter")
-    protected void handleLoadEObject(final InternalEObject loaded, final BinaryResourceImpl.EObjectInputStream input) throws IOException {
+    private void handleLoadEObject(final InternalEObject loaded, final BinaryResourceImpl.EObjectInputStream input) throws IOException {
       if (modificationTrackingAdapter != null) {
         loaded.eAdapters().add(modificationTrackingAdapter);
       }

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/ProxyCompositeNode.java
@@ -109,6 +109,8 @@ public class ProxyCompositeNode implements ICompositeNode, BidiTreeIterable<INod
    *          resource, must not be {@code null}
    * @return original EObject ID map or {@code null} if no proxied node model was present
    */
+  // PMD 7.27+: null is a sentinel; caller fills a fresh map when no proxy was present
+  @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull")
   static List<EObject> uninstallProxyNodeModel(final Resource resource) {
     List<EObject> result = null;
     if (!resource.getContents().isEmpty()) {

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -54,7 +54,7 @@
     <spotbugs.plugin.version>4.10.4.0</spotbugs.plugin.version>
     <spotbugs.version>4.10.4</spotbugs.version>
     <pmd.plugin.version>3.28.0</pmd.plugin.version>
-    <pmd.version>7.26.0</pmd.version>
+    <pmd.version>7.27.0</pmd.version>
     <tycho.version>5.0.4</tycho.version>
     <xtend.version>2.43.0</xtend.version>
 

--- a/ddk-repository/category.xml
+++ b/ddk-repository/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.avaloq.tools.ddk.feature_19.1.1.qualifier.jar" id="com.avaloq.tools.ddk.feature" version="19.1.1.qualifier">
+   <feature url="features/com.avaloq.tools.ddk.feature_19.1.2.qualifier.jar" id="com.avaloq.tools.ddk.feature" version="19.1.2.qualifier">
       <category name="com.avaloq.tools.ddk.sdk"/>
    </feature>
-   <feature url="features/com.avaloq.tools.ddk.runtime.feature_19.1.0.qualifier.jar" id="com.avaloq.tools.ddk.runtime.feature" version="19.1.0.qualifier">
+   <feature url="features/com.avaloq.tools.ddk.runtime.feature_19.1.1.qualifier.jar" id="com.avaloq.tools.ddk.runtime.feature" version="19.1.1.qualifier">
       <category name="com.avaloq.tools.ddk.runtime"/>
    </feature>
    <category-def name="com.avaloq.tools.ddk.sdk" label="DSL Developer Kit"/>


### PR DESCRIPTION
## Summary

Upgrade PMD from 7.26.0 to 7.27.0 and address only the reproduced warnings, without optional refactoring. The version bump from Dependabot #1514 is included; close #1514 after this PR merges.

## Scope

The unfixed PR base with PMD 7.27 produces 24 violations across 19 Java files: 4 InstantiableUtilityClass, 13 ProtectedMemberInFinalClass, 4 ReturnEmptyCollectionRatherThanNull, and 3 UnusedReturnValue. Report generation across all modules was necessary because the normal fail-at-end check skips downstream modules after the initial failures.

- Preserve four exported utility classes' non-final declarations and protected constructors with targeted compatibility suppressions.
- Narrow non-overriding implementation members to private or package-private; preserve injection and same-package constructor access.
- Preserve the three existing exception-based existence searches with documented UnusedReturnValue suppressions. No lambda conversions, getter caching, or search-strategy changes are included.
- Remove redundant always-null local branches in the two validation-element collection methods. Preserve the meaningful proxy-node null sentinel with a targeted suppression.
- Initialize tableItems' result to an empty list, consistent with its documented non-null return contract. This warning-related change can replace a null result with an empty list if the table becomes empty after the wait. The pre-existing per-row overwrite bug remains separate in #1516.
- Retain the private loading helper; only its visibility changes.
- Include necessary plugin/feature version metadata. Remove Index's constructor `@return` tag because local Checkstyle rejects it; unrelated comment cleanup is excluded.

Optional simplifications and their behavioral tests are being submitted in a separate dependent draft PR. They are not prerequisites for merging this PMD update.

## Validation

The warning audit used Java 21 and CI's exact Maven PMD/CPD goals on macOS. The original five blocking CI findings reproduced, and report-only execution exposed all 24 findings across 62 PMD reports; 62 CPD reports contained no duplicates.

Full local verification and quality checks passed on head `296d03baa`: Maven verify, Checkstyle, PMD, CPD, and SpotBugs. The aggregate suite reported 354 tests, 0 failures, 0 errors, and 2 skipped. This was Java 21 on macOS, using the repository's macOS UI profile. Fresh remote checks are still required on this head; previous-head CI is not evidence for this revision.

Keep draft with no reviewer requests pending validation and review.
