### PR TITLE
fix: accumulate all rows in CoreSwtbotTools.tableItems

### DIFF
--- a/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/CoreSwtbotTools.java
+++ b/com.avaloq.tools.ddk.test.ui/src/com/avaloq/tools/ddk/test/ui/swtbot/CoreSwtbotTools.java
@@ -346,7 +346,7 @@ public final class CoreSwtbotTools {
     waitForTableItem(bot, table);
     List<SWTBotTableItem> items = new ArrayList<SWTBotTableItem>();
     for (int i = 0; i < table.rowCount(); i++) {
-      items = new ArrayList<SWTBotTableItem>(Arrays.asList(table.getTableItem(i)));
+      items.add(table.getTableItem(i));
     }
     return items;
   }


### PR DESCRIPTION
## Summary

`CoreSwtbotTools.tableItems` has overwritten its result list on every loop iteration since the helper was added in 2017 (`d08ea194a`). A table with N rows returned a one-element list containing only the last row.

This is **test infrastructure** (`com.avaloq.tools.ddk.test.ui`), not product code. There are **no callers in this repo**; the method is still public API.

Independent of [#1515](https://github.com/dsldevkit/dsl-devkit/pull/1515) (PMD 7.27.0). That PR only changes the empty-table `null` init to an empty list and leaves this loop as-is.

## Change

```java
List<SWTBotTableItem> items = new ArrayList<SWTBotTableItem>();
for (int i = 0; i < table.rowCount(); i++) {
  items.add(table.getTableItem(i));
}
return items;
```

Empty tables return an empty list (javadoc already said never null). `test.ui` micro-bump 17.3.3 → 17.3.4 for Tycho baseline compare.

## Test

No in-repo caller and no existing SWT table fixture. Did not add a workbench harness for this unused helper.