### PR TITLE
refactor: simplify existence checks and object-loading helper

### DIFF
--- a/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/builder/CheckMarkerHelpExtensionTest.java
+++ b/com.avaloq.tools.ddk.check.ui.test/src/com/avaloq/tools/ddk/check/ui/test/builder/CheckMarkerHelpExtensionTest.java
@@ -11,6 +11,7 @@
 package com.avaloq.tools.ddk.check.ui.test.builder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -71,6 +72,62 @@ public class CheckMarkerHelpExtensionTest {
 
   @Inject
   private IWorkspace workspace;
+
+  @Test
+  public void testMatchingMarkerHelpNeedsNoUpdate() throws Exception {
+    CheckCatalog catalog = parser.parse(CATALOG_WITH_FIRST_CHECK_LIVE);
+    IPluginExtension extension = createMarkerHelpExtension(catalog);
+    IPluginElement element = (IPluginElement) extension.getChildren()[0];
+    catalog.getChecks().get(0).setKind(null);
+    assertFalse(markerUtil.isExtensionUpdateRequired(catalog, extension, List.of(element)), "Matching marker help and default kind need no update");
+  }
+
+  @Test
+  public void testMissingContextWithEqualIssueCountNeedsUpdate() throws Exception {
+    CheckCatalog catalog = parser.parse(CATALOG_WITH_FIRST_CHECK_LIVE);
+    IPluginExtension extension = createMarkerHelpExtension(catalog);
+    IPluginElement element = (IPluginElement) extension.getChildren()[0];
+    element.setAttribute(CheckMarkerHelpExtensionHelper.CONTEXT_ID_ATTRIBUTE_TAG, "null.c_missing");
+    assertTrue(markerUtil.isExtensionUpdateRequired(catalog, extension, List.of(element)), "An equal-sized entry for another context must not match");
+  }
+
+  @Test
+  public void testWrongMarkerTypeNeedsUpdate() throws Exception {
+    CheckCatalog catalog = parser.parse(CATALOG_WITH_FIRST_CHECK_LIVE);
+    IPluginExtension extension = createMarkerHelpExtension(catalog);
+    IPluginElement element = (IPluginElement) extension.getChildren()[0];
+    element.setAttribute(CheckMarkerHelpExtensionHelper.MARKERTYPE_ATTRIBUTE_TAG, MARKERTYPE_EXPENSIVE);
+    assertTrue(markerUtil.isExtensionUpdateRequired(catalog, extension, List.of(element)), "The issue code alone must not match a different marker type");
+  }
+
+  @Test
+  public void testWrongIssueCodeNeedsUpdate() throws Exception {
+    CheckCatalog catalog = parser.parse(CATALOG_WITH_FIRST_CHECK_LIVE);
+    IPluginExtension extension = createMarkerHelpExtension(catalog);
+    IPluginElement element = (IPluginElement) extension.getChildren()[0];
+    IPluginElement attribute = (IPluginElement) element.getChildren()[0];
+    attribute.setAttribute(CheckMarkerHelpExtensionHelper.ATTRIBUTE_VALUE_TAG, "wrong.issue.code");
+    assertTrue(markerUtil.isExtensionUpdateRequired(catalog, extension, List.of(element)), "The marker type alone must not match a different issue code");
+  }
+
+  @Test
+  public void testNullMarkerTypeNeedsUpdate() throws Exception {
+    CheckCatalog catalog = parser.parse(CATALOG_WITH_FIRST_CHECK_LIVE);
+    IPluginExtension extension = createMarkerHelpExtension(catalog);
+    IPluginElement element = (IPluginElement) extension.getChildren()[0];
+    element.getAttribute(CheckMarkerHelpExtensionHelper.MARKERTYPE_ATTRIBUTE_TAG).setValue(null);
+    assertTrue(markerUtil.isExtensionUpdateRequired(catalog, extension, List.of(element)), "A null marker type must be treated as a non-match");
+  }
+
+  @Test
+  public void testNullIssueCodeNeedsUpdate() throws Exception {
+    CheckCatalog catalog = parser.parse(CATALOG_WITH_FIRST_CHECK_LIVE);
+    IPluginExtension extension = createMarkerHelpExtension(catalog);
+    IPluginElement element = (IPluginElement) extension.getChildren()[0];
+    IPluginElement attribute = (IPluginElement) element.getChildren()[0];
+    attribute.getAttribute(CheckMarkerHelpExtensionHelper.ATTRIBUTE_VALUE_TAG).setValue(null);
+    assertTrue(markerUtil.isExtensionUpdateRequired(catalog, extension, List.of(element)), "A null issue code must be treated as a non-match");
+  }
 
   /**
    * Tests if the marker help extension is correctly created.

--- a/com.avaloq.tools.ddk.check.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.check.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.check.ui
 Bundle-SymbolicName: com.avaloq.tools.ddk.check.ui;singleton:=true
-Bundle-Version: 17.3.3.qualifier
+Bundle-Version: 17.3.4.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Activator: com.avaloq.tools.ddk.check.ui.internal.Activator

--- a/com.avaloq.tools.ddk.check.ui/pom.xml
+++ b/com.avaloq.tools.ddk.check.ui/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.3-SNAPSHOT</version>
+  <version>17.3.4-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.check.ui</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckMarkerHelpExtensionHelper.java
+++ b/com.avaloq.tools.ddk.check.ui/src/com/avaloq/tools/ddk/check/ui/builder/util/CheckMarkerHelpExtensionHelper.java
@@ -13,7 +13,6 @@ package com.avaloq.tools.ddk.check.ui.builder.util;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
@@ -138,7 +137,6 @@ public class CheckMarkerHelpExtensionHelper extends AbstractCheckDocumentationEx
   }
 
   @Override
-  @SuppressWarnings("PMD.UnusedReturnValue") // Preserve the existing exception-based existence check.
   public boolean isExtensionUpdateRequired(final CheckCatalog catalog, final IPluginExtension extension, final Iterable<IPluginElement> elements) {
     // TODO should check if this check is too expensive; consider rewriting contents instead
     if (!super.isExtensionUpdateRequired(catalog, extension, elements)) {
@@ -179,20 +177,8 @@ public class CheckMarkerHelpExtensionHelper extends AbstractCheckDocumentationEx
       final Iterable<String> allModelIssueCodes = getIssueCodeValues(check);
       for (final String issueCode : allModelIssueCodes) {
         final String contextId = getQualifiedContextId(extension, check);
-        if (contextToValue.containsKey(contextId)) {
-          Set<Pair<String, String>> modeToValues = contextToValue.get(contextId);
-          try {
-            Iterables.find(modeToValues, new Predicate<Pair<String, String>>() {
-              @Override
-              public boolean apply(final Pair<String, String> input) {
-                return input.getFirst().equals(getCheckType(check)) && input.getSecond().equals(issueCode);
-              }
-            });
-          } catch (NoSuchElementException e) {
-            return true;
-          }
-        } else {
-          return true; // context id not present in extension model
+        if (!contextToValue.containsEntry(contextId, Tuples.create(getCheckType(check), issueCode))) {
+          return true;
         }
       }
     }

--- a/com.avaloq.tools.ddk.checkcfg.ide/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.checkcfg.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.checkcfg.ide
 Bundle-SymbolicName: com.avaloq.tools.ddk.checkcfg.ide;singleton:=true
-Bundle-Version: 17.3.2.qualifier
+Bundle-Version: 17.3.3.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/com.avaloq.tools.ddk.checkcfg.ide/pom.xml
+++ b/com.avaloq.tools.ddk.checkcfg.ide/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.2-SNAPSHOT</version>
+  <version>17.3.3-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.checkcfg.ide</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/contentassist/CheckCfgIdeContentProposalProvider.java
+++ b/com.avaloq.tools.ddk.checkcfg.ide/src/com/avaloq/tools/ddk/checkcfg/ide/contentassist/CheckCfgIdeContentProposalProvider.java
@@ -12,7 +12,6 @@
 package com.avaloq.tools.ddk.checkcfg.ide.contentassist;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.StringJoiner;
 
 import org.eclipse.emf.ecore.EObject;
@@ -304,23 +303,15 @@ public class CheckCfgIdeContentProposalProvider extends XbaseIdeContentProposalP
    *          the catalog
    * @return true, if is catalog configured
    */
-  @SuppressWarnings("PMD.UnusedReturnValue") // Preserve the existing exception-based existence check.
   private boolean isCatalogConfigured(final CheckConfiguration conf, final CheckCatalog catalog) {
-    try {
-      Iterables.find(conf.getLegacyCatalogConfigurations(), new Predicate<ConfiguredCatalog>() {
-        @Override
-        public boolean apply(final ConfiguredCatalog input) {
-          if (input.getCatalog() == null || input.getCatalog().getName() == null || input.getCatalog().getPackageName() == null) {
-            return false;
-          }
-          return catalog == input.getCatalog()
-              || (input.getCatalog().getName().equals(catalog.getName()) && input.getCatalog().getPackageName().equals(catalog.getPackageName()));
-        }
-      });
-    } catch (NoSuchElementException e) {
-      return false;
-    }
-    return true;
+    return Iterables.any(conf.getLegacyCatalogConfigurations(), input -> {
+      CheckCatalog configured = input.getCatalog();
+      if (configured == null || configured.getName() == null || configured.getPackageName() == null) {
+        return false;
+      }
+      return catalog == configured
+          || (configured.getName().equals(catalog.getName()) && configured.getPackageName().equals(catalog.getPackageName()));
+    });
   }
 
   private void addEmptyCheckConfig(final ContentAssistContext context, final IIdeContentProposalAcceptor acceptor) {

--- a/com.avaloq.tools.ddk.checkcfg.ui/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.checkcfg.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.checkcfg.ui
 Bundle-SymbolicName: com.avaloq.tools.ddk.checkcfg.ui;singleton:=true
-Bundle-Version: 17.3.3.qualifier
+Bundle-Version: 17.3.4.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-Activator: com.avaloq.tools.ddk.checkcfg.ui.internal.Activator

--- a/com.avaloq.tools.ddk.checkcfg.ui/pom.xml
+++ b/com.avaloq.tools.ddk.checkcfg.ui/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.3-SNAPSHOT</version>
+  <version>17.3.4-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.checkcfg.ui</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.checkcfg.ui/src/com/avaloq/tools/ddk/checkcfg/ui/templates/CheckCfgTemplateProposalProvider.java
+++ b/com.avaloq.tools.ddk.checkcfg.ui/src/com/avaloq/tools/ddk/checkcfg/ui/templates/CheckCfgTemplateProposalProvider.java
@@ -11,7 +11,6 @@
 package com.avaloq.tools.ddk.checkcfg.ui.templates;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.StringJoiner;
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -43,7 +42,6 @@ import com.avaloq.tools.ddk.checkcfg.checkcfg.ConfiguredCheck;
 import com.avaloq.tools.ddk.checkcfg.ui.labeling.CheckCfgImages;
 import com.avaloq.tools.ddk.xtext.ui.templates.TemplateProposalProviderHelper;
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -175,23 +173,15 @@ public class CheckCfgTemplateProposalProvider extends DefaultTemplateProposalPro
    *          the catalog
    * @return true, if is catalog configured
    */
-  @SuppressWarnings("PMD.UnusedReturnValue") // Preserve the existing exception-based existence check.
   private boolean isCatalogConfigured(final CheckConfiguration conf, final CheckCatalog catalog) {
-    try {
-      Iterables.find(conf.getLegacyCatalogConfigurations(), new Predicate<ConfiguredCatalog>() {
-        @Override
-        public boolean apply(final ConfiguredCatalog input) {
-          if (input.getCatalog() == null || input.getCatalog().getName() == null || input.getCatalog().getPackageName() == null) {
-            return false;
-          }
-          return catalog == input.getCatalog()
-              || (input.getCatalog().getName().equals(catalog.getName()) && input.getCatalog().getPackageName().equals(catalog.getPackageName()));
-        }
-      });
-    } catch (NoSuchElementException e) {
-      return false;
-    }
-    return true;
+    return Iterables.any(conf.getLegacyCatalogConfigurations(), input -> {
+      CheckCatalog configured = input.getCatalog();
+      if (configured == null || configured.getName() == null || configured.getPackageName() == null) {
+        return false;
+      }
+      return catalog == configured
+          || (configured.getName().equals(catalog.getName()) && configured.getPackageName().equals(catalog.getPackageName()));
+    });
   }
 
   /**

--- a/com.avaloq.tools.ddk.feature/feature.xml
+++ b/com.avaloq.tools.ddk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.avaloq.tools.ddk.feature"
       label="com.avaloq.tools.ddk.feature"
-      version="19.1.2.qualifier"
+      version="19.1.3.qualifier"
       provider-name="Avaloq Group AG">
 
    <description>

--- a/com.avaloq.tools.ddk.feature/pom.xml
+++ b/com.avaloq.tools.ddk.feature/pom.xml
@@ -7,7 +7,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>19.1.2-SNAPSHOT</version>
+  <version>19.1.3-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/com.avaloq.tools.ddk.runtime.feature/feature.xml
+++ b/com.avaloq.tools.ddk.runtime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.avaloq.tools.ddk.runtime.feature"
       label="com.avaloq.tools.ddk.runtime.feature"
-      version="19.1.1.qualifier"
+      version="19.1.2.qualifier"
       provider-name="Avaloq Group AG">
 
    <description>

--- a/com.avaloq.tools.ddk.runtime.feature/pom.xml
+++ b/com.avaloq.tools.ddk.runtime.feature/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>19.1.1-SNAPSHOT</version>
+  <version>19.1.2-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.runtime.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.xtext
 Bundle-SymbolicName: com.avaloq.tools.ddk.xtext;singleton:=true
-Bundle-Version: 17.3.3.qualifier
+Bundle-Version: 17.3.4.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
@@ -48,4 +48,3 @@ Export-Package: com.avaloq.tools.ddk.xtext.build,
 Import-Package: org.apache.logging.log4j,
  org.apache.logging.log4j.util
 Automatic-Module-Name: com.avaloq.tools.ddk.xtext
-

--- a/com.avaloq.tools.ddk.xtext/pom.xml
+++ b/com.avaloq.tools.ddk.xtext/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.3-SNAPSHOT</version>
+  <version>17.3.4-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.xtext</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
+++ b/com.avaloq.tools.ddk.xtext/src/com/avaloq/tools/ddk/xtext/resource/persistence/DirectLinkingResourceStorageLoadable.java
@@ -86,18 +86,11 @@ public class DirectLinkingResourceStorageLoadable extends ResourceStorageLoadabl
       return super.readCompressedInt();
     }
 
-    @SuppressWarnings("PMD.UnusedFormalParameter")
-    private void handleLoadEObject(final InternalEObject loaded, final BinaryResourceImpl.EObjectInputStream input) throws IOException {
-      if (modificationTrackingAdapter != null) {
-        loaded.eAdapters().add(modificationTrackingAdapter);
-      }
-    }
-
     @Override
     public InternalEObject loadEObject() throws IOException {
       final InternalEObject result = super.loadEObject();
-      if (result != null) {
-        handleLoadEObject(result, this);
+      if (result != null && modificationTrackingAdapter != null) {
+        result.eAdapters().add(modificationTrackingAdapter);
       }
       return result;
     }

--- a/ddk-repository/category.xml
+++ b/ddk-repository/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.avaloq.tools.ddk.feature_19.1.2.qualifier.jar" id="com.avaloq.tools.ddk.feature" version="19.1.2.qualifier">
+   <feature url="features/com.avaloq.tools.ddk.feature_19.1.3.qualifier.jar" id="com.avaloq.tools.ddk.feature" version="19.1.3.qualifier">
       <category name="com.avaloq.tools.ddk.sdk"/>
    </feature>
-   <feature url="features/com.avaloq.tools.ddk.runtime.feature_19.1.1.qualifier.jar" id="com.avaloq.tools.ddk.runtime.feature" version="19.1.1.qualifier">
+   <feature url="features/com.avaloq.tools.ddk.runtime.feature_19.1.2.qualifier.jar" id="com.avaloq.tools.ddk.runtime.feature" version="19.1.2.qualifier">
       <category name="com.avaloq.tools.ddk.runtime"/>
    </feature>
    <category-def name="com.avaloq.tools.ddk.sdk" label="DSL Developer Kit"/>


### PR DESCRIPTION
## Summary

Optional simplifications deliberately separated from PMD-only #1515. This PR is based on `codex/pmd-7.27-base`, an upstream mirror of the narrowed #1515 head, so the review diff contains only this follow-up. After #1515 merges, retarget this PR to master and rerun checks before merging.

## Changes

- Replace exception-driven existence searches with boolean predicates; simplify both catalog checks with lambdas and one local catalog reference while retaining completeness checks before identity comparison.
- Replace marker-help key lookup plus predicate scanning with direct multimap entry membership. Xtext pairs use value-based equality and hashing.
- Inline the private loading helper, removing its unused parameter, unnecessary exception declaration, and suppression while preserving adapter attachment behavior.
- Add six tests in the existing aggregate suite for matching entries/default check kind, missing context with equal issue count, wrong marker type, wrong issue code, null marker type, and null issue code.
- Advance affected runtime plugin/feature versions independently of #1515.

## Behavioral boundaries

This is not claimed to be strictly exception-equivalent. The former searches caught NoSuchElementException from the entire find call, including predicate evaluation; the new checks do not intentionally swallow predicate exceptions. Null-valued marker-help pair components are non-matches against expected non-null values instead of potentially throwing NullPointerException. The new regression tests cover these null-valued entries at the Eclipse model level. Normal Check kinds default to FAST, including when set to null, and successfully generated issue-code values are non-null strings.

## Validation

Local full verification and quality checks passed on head `21e9bae62`: Maven verify, Checkstyle, PMD, CPD, and SpotBugs using Java 21 on macOS. The aggregate suite reported 360 tests, 0 failures, 0 errors, and 2 skipped. All 11 CheckMarkerHelpExtensionTest cases passed, including the six new cases. They run through the existing aggregate suite; no separate test runtime configuration is added. This draft must receive its own fresh green CI before merge.

Keep draft with no reviewer requests. Review independently from #1515; do not merge before its dependency.
