### PR TITLE
fix(scope): defer provider inference during model linking

### DIFF
--- a/com.avaloq.tools.ddk.xtext.generator.test/src/com/avaloq/tools/ddk/xtext/generator/expression/ScopeInferenceTest.java
+++ b/com.avaloq.tools.ddk.xtext.generator.test/src/com/avaloq/tools/ddk/xtext/generator/expression/ScopeInferenceTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Group AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.generator.expression;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.xtext.common.types.JvmGenericType;
+import org.eclipse.xtext.common.types.JvmOperation;
+import org.eclipse.xtext.common.types.xtext.JvmMemberInitializableResource;
+import org.eclipse.xtext.generator.IGenerator;
+import org.eclipse.xtext.generator.InMemoryFileSystemAccess;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.resource.XtextResourceSet;
+import org.junit.jupiter.api.Test;
+
+import com.avaloq.tools.ddk.xtext.scope.ScopeStandaloneSetup;
+import com.avaloq.tools.ddk.xtext.scope.scope.ScopeModel;
+import com.avaloq.tools.ddk.xtext.scope.scope.ScopeFactory;
+import com.google.inject.Injector;
+
+/** Tests Scope inference while model classifiers are temporarily unavailable. */
+@SuppressWarnings("nls")
+public class ScopeInferenceTest {
+
+  /** Reading resource roots must not compile bodies or resolve method signatures. */
+  @Test
+  public void testResourceTraversalDuringModelLinking() throws IOException {
+    assertRecovery(false, false);
+  }
+
+  /** An early member query must not make missing scope methods permanent. */
+  @Test
+  public void testEarlyMemberAccessRecoversBeforeGeneration() throws IOException {
+    assertRecovery(true, false);
+  }
+
+  /** Invalid input must not write Java; repairing it in place must recover. */
+  @Test
+  public void testUnresolvedGenerationFailsWithoutWritingFiles() throws IOException {
+    assertRecovery(true, true);
+  }
+
+  private void assertRecovery(final boolean accessMembers, final boolean generateWhileInvalid) throws IOException {
+    final Injector injector = new ScopeStandaloneSetup().createInjectorAndDoEMFRegistration();
+    final XtextResourceSet resources = injector.getInstance(XtextResourceSet.class);
+    final XtextResource resource = (XtextResource) resources.createResource(URI.createURI("synthetic:/Example.scope"));
+    final String source = "scoping repro.Example\n"
+        + "import \"http://www.eclipse.org/emf/2002/Ecore\" as ecore\n"
+        + "scope ecore::EClass { context ecore::EPackage = eClassifiers; }\n";
+    resource.load(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)), null);
+    final ScopeModel model = (ScopeModel) resource.getParseResult().getRootASTElement();
+    final EClass detached = EcoreFactory.eINSTANCE.createEClass();
+    detached.setName("EClass");
+    model.getScopes().get(0).setTargetType(detached);
+    assertEquals(3, resource.getContents().size(), "Root traversal must retain both inferred provider types");
+    if (accessMembers) {
+      ((JvmMemberInitializableResource) resource).ensureJvmMembersInitialized();
+    }
+    if (generateWhileInvalid) {
+      final InMemoryFileSystemAccess invalidFiles = new InMemoryFileSystemAccess();
+      assertThrows(IllegalStateException.class, () -> injector.getInstance(IGenerator.class).doGenerate(resource, invalidFiles));
+      assertTrue(invalidFiles.getTextFiles().isEmpty(), "Incomplete providers must never be emitted");
+    }
+    model.getScopes().get(0).setTargetType(EcorePackage.Literals.ECLASS);
+    final InMemoryFileSystemAccess files = new InMemoryFileSystemAccess();
+    injector.getInstance(IGenerator.class).doGenerate(resource, files);
+    final String generated = files.getTextFiles().values().toString();
+    assertEquals(2, files.getTextFiles().size(), "Both providers must be generated after model linking finishes");
+    assertHelperDeclared(resource, "scope_ecore_EClass");
+    assertTrue(generated.contains("IScope scope_ecore_EClass("), "The helper must be declared, not merely called");
+    assertTrue((generated.contains("EcorePackage.Literals.ECLASS") || generated.contains("EcorePackage.eINSTANCE.getEClass()")), "Generation must render the repaired model type");
+  }
+
+  /** An include that resolves after an early member query must contribute both methods and injections. */
+  @Test
+  public void testUnresolvedIncludeRecoversBeforeGeneration() throws IOException {
+    final Injector injector = new ScopeStandaloneSetup().createInjectorAndDoEMFRegistration();
+    final XtextResourceSet resources = injector.getInstance(XtextResourceSet.class);
+    final XtextResource base = load(resources, "Base", "scoping repro.Base\n"
+        + "import \"http://www.eclipse.org/emf/2002/Ecore\" as ecore\n"
+        + "inject java.lang.String as inheritedField\n"
+        + "scope (inherited) ecore::EPackage#eClassifiers { context ecore::EPackage = eClassifiers; }\n");
+    final XtextResource child = load(resources, "Child", "scoping repro.Child\n");
+    final ScopeModel model = (ScopeModel) child.getParseResult().getRootASTElement();
+    final ScopeModel unavailable = ScopeFactory.eINSTANCE.createScopeModel();
+    ((InternalEObject) unavailable).eSetProxyURI(base.getURI().appendFragment("not-yet-linked"));
+    model.getIncludedScopes().add(unavailable);
+    assertEquals(3, child.getContents().size(), "Both provider roots must survive an unavailable include");
+    ((JvmMemberInitializableResource) child).ensureJvmMembersInitialized();
+    model.getIncludedScopes().set(0, (ScopeModel) base.getParseResult().getRootASTElement());
+    final InMemoryFileSystemAccess files = new InMemoryFileSystemAccess();
+    injector.getInstance(IGenerator.class).doGenerate(child, files);
+    assertHelperDeclared(child, "inherited_ecore_EPackage_eClassifiers");
+    final String generated = files.getTextFiles().values().toString();
+    assertTrue(generated.contains("IScope inherited_ecore_EPackage_eClassifiers("), "The inherited reference helper must be declared");
+    assertTrue(generated.contains("String inheritedField"), "The inherited injection must be declared");
+  }
+
+  private XtextResource load(final XtextResourceSet resources, final String name, final String source) throws IOException {
+    final XtextResource resource = (XtextResource) resources.createResource(URI.createURI("synthetic:/" + name + ".scope"));
+    resource.load(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)), null);
+    return resource;
+  }
+
+  private void assertHelperDeclared(final XtextResource resource, final String name) {
+    final JvmGenericType provider = (JvmGenericType) resource.getContents().get(1);
+    assertEquals(1, provider.getMembers().stream().filter(JvmOperation.class::isInstance)
+        .filter(member -> name.equals(member.getSimpleName())).count(), "Exactly one helper declaration must exist");
+  }
+
+}

--- a/com.avaloq.tools.ddk.xtext.generator.test/src/com/avaloq/tools/ddk/xtext/generator/test/generator/GeneratorTestSuite.java
+++ b/com.avaloq.tools.ddk.xtext.generator.test/src/com/avaloq/tools/ddk/xtext/generator/test/generator/GeneratorTestSuite.java
@@ -16,6 +16,7 @@ import org.junit.platform.suite.api.Suite;
 import com.avaloq.tools.ddk.xtext.generator.expression.ExportExpressionCodeGenerationTest;
 import com.avaloq.tools.ddk.xtext.generator.expression.ExpressionsExtentionsTest;
 import com.avaloq.tools.ddk.xtext.generator.expression.ScopeExpressionCodeGenerationTest;
+import com.avaloq.tools.ddk.xtext.generator.expression.ScopeInferenceTest;
 import com.avaloq.tools.ddk.xtext.generator.test.util.EClassComparatorTest;
 import com.avaloq.tools.ddk.xtext.generator.test.util.GraphTest;
 import com.avaloq.tools.ddk.xtext.generator.xbase.test.XbaseGeneratorFragmentTest;
@@ -30,6 +31,7 @@ import com.avaloq.tools.ddk.xtext.generator.xbase.test.XbaseGeneratorFragmentTes
   ExportExpressionCodeGenerationTest.class,
   ExpressionsExtentionsTest.class,
   ScopeExpressionCodeGenerationTest.class,
+  ScopeInferenceTest.class,
   EClassComparatorTest.class,
   GraphTest.class,
   XbaseGeneratorFragmentTest.class

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/ScopeRuntimeModule.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/ScopeRuntimeModule.java
@@ -29,6 +29,12 @@ import com.avaloq.tools.ddk.xtext.scope.resource.ScopeResourceDescriptionStrateg
 public class ScopeRuntimeModule extends AbstractScopeRuntimeModule {
 
   @Override
+  public Class<? extends org.eclipse.xtext.generator.IGenerator> bindIGenerator() {
+    return com.avaloq.tools.ddk.xtext.scope.jvmmodel.ScopeJvmModelGenerator.class;
+  }
+
+
+  @Override
   public Class<? extends IValueConverterService> bindIValueConverterService() {
     return ScopeValueConverterService.class;
   }

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/jvmmodel/ScopeJvmModelGenerator.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/jvmmodel/ScopeJvmModelGenerator.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Group AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.scope.jvmmodel;
+
+import org.eclipse.emf.common.notify.impl.AdapterImpl;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.common.types.xtext.JvmMemberInitializableResource;
+import org.eclipse.xtext.generator.IFileSystemAccess;
+import org.eclipse.xtext.resource.DerivedStateAwareResource;
+import org.eclipse.xtext.xbase.compiler.JvmModelGenerator;
+
+/** Rebuilds an incomplete editor model before generating Scope providers. */
+public class ScopeJvmModelGenerator extends JvmModelGenerator {
+
+  /**
+   * Marks member inference that encountered an unresolved model signature.
+   *
+   * @param resource
+   *          the resource whose provider members are incomplete
+   */
+  public static void markIncomplete(final Resource resource) {
+    if (!isIncomplete(resource)) {
+      resource.eAdapters().add(new IncompleteInference());
+    }
+  }
+
+  /**
+   * Clears a marker after all provider members have been inferred successfully.
+   *
+   * @param resource
+   *          the resource whose provider members are complete
+   */
+  public static void clearIncomplete(final Resource resource) {
+    resource.eAdapters().removeIf(IncompleteInference.class::isInstance);
+  }
+
+  private static boolean isIncomplete(final Resource resource) {
+    return resource.eAdapters().stream().anyMatch(IncompleteInference.class::isInstance);
+  }
+
+  @Override
+  public void doGenerate(final Resource input, final IFileSystemAccess fsa) {
+    input.getContents();
+    if (input instanceof JvmMemberInitializableResource initializable) {
+      initializable.ensureJvmMembersInitialized();
+    }
+    if (isIncomplete(input) && input instanceof DerivedStateAwareResource resource) {
+      clearIncomplete(resource);
+      resource.discardDerivedState();
+      resource.installDerivedState(false);
+      if (resource instanceof JvmMemberInitializableResource initializable) {
+        initializable.ensureJvmMembersInitialized();
+      }
+    }
+    if (isIncomplete(input)) {
+      throw new IllegalStateException("Cannot generate Scope providers with unresolved model signatures"); //$NON-NLS-1$
+    }
+    super.doGenerate(input, fsa);
+  }
+
+  /** Resource-local marker, never copied to another resource or persisted. */
+  private static final class IncompleteInference extends AdapterImpl {
+  }
+}

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/jvmmodel/ScopeJvmModelInferrer.xtend
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/jvmmodel/ScopeJvmModelInferrer.xtend
@@ -16,13 +16,15 @@ import com.avaloq.tools.ddk.xtext.expression.generator.JavaBodyAppender
 import com.avaloq.tools.ddk.xtext.scope.generator.ScopeNameProviderGenerator
 import com.avaloq.tools.ddk.xtext.scope.generator.ScopeProviderGenerator
 import com.avaloq.tools.ddk.xtext.scope.generator.ScopeProviderX
+import com.avaloq.tools.ddk.xtext.scope.scope.ScopeDefinition
 import com.avaloq.tools.ddk.xtext.scope.scope.ScopeModel
 import com.avaloq.tools.ddk.xtext.scoping.AbstractPolymorphicScopeProvider
 import com.avaloq.tools.ddk.xtext.scoping.AbstractScopeNameProvider
 import com.avaloq.tools.ddk.xtext.scoping.INameFunction
 import com.google.inject.Inject
+import com.google.inject.Provider
 import com.google.inject.Singleton
-import java.util.Map
+import java.util.Set
 import org.apache.logging.log4j.Logger
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.ResourcesPlugin
@@ -35,6 +37,7 @@ import org.eclipse.xtext.common.types.JvmAnnotationType
 import org.eclipse.xtext.common.types.JvmGenericType
 import org.eclipse.xtext.common.types.JvmVisibility
 import org.eclipse.xtext.common.types.TypesFactory
+import org.eclipse.xtext.common.types.xtext.JvmMemberInitializableResource
 import org.eclipse.xtext.scoping.IScope
 import org.eclipse.xtext.xbase.compiler.output.ITreeAppendable
 import org.eclipse.xtext.xbase.jvmmodel.AbstractModelInferrer
@@ -57,8 +60,8 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
   @Inject extension ScopeProviderX
 
   @Inject TypesFactory typesFactory
-  @Inject ScopeProviderGenerator providerGenerator
-  @Inject ScopeNameProviderGenerator nameProviderGenerator
+  @Inject Provider<ScopeProviderGenerator> providerGenerators
+  @Inject Provider<ScopeNameProviderGenerator> nameProviderGenerators
   @Inject GenModelUtilX genModelUtil
   @Inject GeneratorSupport generatorSupport
   @Inject JavaBodyAppender bodyAppender
@@ -77,26 +80,12 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
     if (isPreIndexingPhase) {
       return
     }
-    genModelUtil.resource = element.eResource
-    providerGenerator.configure(nameProviderGenerator, genModelUtil, element)
-    nameProviderGenerator.configure(genModelUtil, element)
-
-    // The method body strings are produced eagerly here (inside the project resource loader required by the
-    // expression compiler) rather than from within the deferred body closures, which run later during emission.
-    val Map<String, String> bodies = newHashMap
-    generatorSupport.executeWithProjectResourceLoader(element.projectOf, [
-      bodies.put('doGetScopeRef', providerGenerator.doGetScopeByReferenceBody(element).toString)
-      bodies.put('doGetScopeType', providerGenerator.doGetScopeByTypeBody(element).toString)
-      bodies.put('doGlobalCacheRef', providerGenerator.doGlobalCacheByReferenceBody(element).toString)
-      bodies.put('doGlobalCacheType', providerGenerator.doGlobalCacheByTypeBody(element).toString)
-      for (scope : element.allScopes) {
-        bodies.put('scope:' + scope.scopeMethodName, providerGenerator.scopeMethodBody(scope, element).toString)
-      }
-      bodies.put('nameFunctions', nameProviderGenerator.internalGetNameFunctionsBody(element).toString)
-    ])
-
     val providerName = element.scopeProvider
     acceptor.accept(element.toClass(providerName)) [
+      ScopeJvmModelGenerator.markIncomplete(element.eResource)
+      if (!hasResolvedModel(element, newHashSet)) {
+        return
+      }
       superTypes += typeRef(AbstractPolymorphicScopeProvider)
       addSuppressWarningsAll
       documentation = '''The scope provider for «element.name».'''
@@ -118,8 +107,7 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
         parameters += element.toParameter('reference', typeRef(EReference))
         parameters += element.toParameter('scopeName', typeRef(String))
         parameters += element.toParameter('originalResource', typeRef(Resource))
-        val text = bodies.get('doGetScopeRef')
-        body = [appendJava(text, element)]
+        body = [appendJava(renderBody(element, [provider, names | provider.doGetScopeByReferenceBody(element)]), element)]
       ]
       members += element.toMethod('doGetScope', typeRef(IScope)) [
         visibility = JvmVisibility.PROTECTED
@@ -128,8 +116,7 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
         parameters += element.toParameter('type', typeRef(EClass))
         parameters += element.toParameter('scopeName', typeRef(String))
         parameters += element.toParameter('originalResource', typeRef(Resource))
-        val text = bodies.get('doGetScopeType')
-        body = [appendJava(text, element)]
+        body = [appendJava(renderBody(element, [provider, names | provider.doGetScopeByTypeBody(element)]), element)]
       ]
       members += element.toMethod('doGlobalCache', typeRef(Boolean.TYPE)) [
         visibility = JvmVisibility.PROTECTED
@@ -138,8 +125,7 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
         parameters += element.toParameter('reference', typeRef(EReference))
         parameters += element.toParameter('scopeName', typeRef(String))
         parameters += element.toParameter('originalResource', typeRef(Resource))
-        val text = bodies.get('doGlobalCacheRef')
-        body = [appendJava(text, element)]
+        body = [appendJava(renderBody(element, [provider, names | provider.doGlobalCacheByReferenceBody(element)]), element)]
       ]
       members += element.toMethod('doGlobalCache', typeRef(Boolean.TYPE)) [
         visibility = JvmVisibility.PROTECTED
@@ -148,11 +134,9 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
         parameters += element.toParameter('type', typeRef(EClass))
         parameters += element.toParameter('scopeName', typeRef(String))
         parameters += element.toParameter('originalResource', typeRef(Resource))
-        val text = bodies.get('doGlobalCacheType')
-        body = [appendJava(text, element)]
+        body = [appendJava(renderBody(element, [provider, names | provider.doGlobalCacheByTypeBody(element)]), element)]
       ]
       for (scope : element.allScopes) {
-        val text = bodies.get('scope:' + scope.scopeMethodName)
         val hasReference = scope.reference !== null
         members += element.toMethod(scope.scopeMethodName, typeRef(IScope)) [
           visibility = JvmVisibility.PROTECTED
@@ -163,9 +147,10 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
             parameters += element.toParameter('type', typeRef(EClass))
           }
           parameters += element.toParameter('originalResource', typeRef(Resource))
-          body = [appendJava(text, element)]
+          body = [appendJava(renderBody(element, [provider, names | provider.scopeMethodBody(scope, element)]), element)]
         ]
       }
+      ScopeJvmModelGenerator.clearIncomplete(element.eResource)
     ]
 
     val nameProviderName = element.scopeNameProvider
@@ -178,10 +163,53 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
         visibility = JvmVisibility.PUBLIC
         annotations += typeOnlyAnnotation(Override)
         parameters += element.toParameter('eClass', typeRef(EClass))
-        val text = bodies.get('nameFunctions')
-        body = [appendJava(text, element)]
+        body = [appendJava(renderBody(element, [provider, names | names.internalGetNameFunctionsBody(element)]), element)]
       ]
     ]
+    // Acceptor initializers alone run before infer returns to resource loading. Register after both roots
+    // have been accepted so Xtext marks both types for demand-driven member initialization.
+    val resource = element.eResource
+    if (resource instanceof JvmMemberInitializableResource) {
+      resource.addJvmMemberInitializer([])
+    }
+  }
+
+  /** Checks includes and signatures before inheritance merging can dereference an unavailable EPackage. */
+  def private boolean hasResolvedModel(ScopeModel model, Set<ScopeModel> visited) {
+    if (model === null || model.eIsProxy) {
+      return false
+    }
+    if (!visited.add(model)) {
+      return true
+    }
+    model.scopes.forall[hasResolvedSignature] && model.includedScopes.forall[hasResolvedModel(visited)]
+  }
+
+  /** Returns whether the existing method name can be computed without unresolved model types. */
+  def private boolean hasResolvedSignature(ScopeDefinition scope) {
+    val type = if (scope.targetType !== null) scope.targetType else scope.contextType
+    val reference = scope.reference
+    type !== null && !type.eIsProxy && type.EPackage !== null && !type.EPackage.eIsProxy && type.EPackage.name !== null &&
+      type.name !== null && (scope.targetType !== null || (reference !== null && !reference.eIsProxy && reference.name !== null))
+  }
+
+  /** Renders only during emission, with fresh model-specific generators and a restored resource context. */
+  def private String renderBody(ScopeModel model, (ScopeProviderGenerator, ScopeNameProviderGenerator)=>CharSequence producer) {
+    val previousContext = genModelUtil.context
+    val result = newArrayList('')
+    try {
+      generatorSupport.executeWithProjectResourceLoader(model.projectOf, [
+        genModelUtil.resource = model.eResource
+        val provider = providerGenerators.get
+        val names = nameProviderGenerators.get
+        provider.configure(names, genModelUtil, model)
+        names.configure(genModelUtil, model)
+        result.set(0, producer.apply(provider, names).toString)
+      ])
+      result.get(0)
+    } finally {
+      genModelUtil.resource = previousContext
+    }
   }
 
   /**

--- a/reproducers/scope-inference/.classpath
+++ b/reproducers/scope-inference/.classpath
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath><classpathentry kind="src" path="src"/><classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/><classpathentry kind="output" path="bin"/></classpath>

--- a/reproducers/scope-inference/.gitignore
+++ b/reproducers/scope-inference/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/target-platform/
+/bin/
+/reproducer.target

--- a/reproducers/scope-inference/.project
+++ b/reproducers/scope-inference/.project
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription><name>repro.scope.lifecycle</name><buildSpec>
+<buildCommand><name>org.eclipse.jdt.core.javabuilder</name><arguments/></buildCommand>
+<buildCommand><name>org.eclipse.pde.ManifestBuilder</name><arguments/></buildCommand>
+<buildCommand><name>org.eclipse.pde.SchemaBuilder</name><arguments/></buildCommand>
+</buildSpec><natures><nature>org.eclipse.pde.PluginNature</nature><nature>org.eclipse.jdt.core.javanature</nature></natures></projectDescription>

--- a/reproducers/scope-inference/META-INF/MANIFEST.MF
+++ b/reproducers/scope-inference/META-INF/MANIFEST.MF
@@ -1,0 +1,18 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Public Scope lifecycle reproducer
+Bundle-SymbolicName: repro.scope.lifecycle
+Bundle-Version: 1.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Require-Bundle: com.avaloq.tools.ddk.xtext.scope,
+ org.eclipse.xtext.xbase,
+ org.eclipse.xtext,
+ org.eclipse.xtext.common.types,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.common,
+ org.eclipse.emf.codegen.ecore,
+ org.eclipse.emf.mwe.utils,
+ org.eclipse.emf.mwe2.launch,
+ com.google.inject,
+ junit-jupiter-api,
+ junit-jupiter-engine

--- a/reproducers/scope-inference/README.md
+++ b/reproducers/scope-inference/README.md
@@ -1,0 +1,46 @@
+# Scope inference regression reproducer
+
+This is a public, synthetic Eclipse plug-in test project for the Scope lifecycle regression introduced by [DDK PR #1405](https://github.com/dsldevkit/dsl-devkit/pull/1405), merged on 19 August 2026. It uses Ecore types and contains no downstream sources, workspace metadata, or machine-specific paths.
+
+It reproduces the failure mechanism, not a multi-hour Windows build. The tests deliberately make a classifier or included Scope model temporarily unavailable, then exercise real Xtext resource loading and DDK generation. See [ROOT-CAUSE.md](ROOT-CAUSE.md) for the evidence and limits.
+
+## Run against DDK 19.1
+
+Prerequisites: JDK 21, Maven, Python 3.9 or newer, and network access to GitHub and the public Eclipse repositories. Use a fresh directory or workspace.
+
+1. Extract the ZIP and open a terminal in this directory.
+2. Run `python prepare.py` (or `python3 prepare.py` on macOS/Linux). This downloads the public DDK 19.1 release, verifies its SHA-256, and writes a local target definition. It does not clone a repository.
+3. Run `mvn clean verify`.
+4. Examine `target/surefire-reports`. Failures against 19.1 are expected; the tests express the corrected behavior.
+
+If Python reports a certificate error, configure its trusted CA certificates. Do not disable certificate verification. Alternatively, download the [public release ZIP](https://github.com/dsldevkit/dsl-devkit/releases/download/v19.1.0/p2-update-site.zip), extract it, and run `python prepare.py --ddk-repository /path/to/extracted/repository`.
+
+## Run against the fix
+
+Build the fix checkout using `mvn verify -DskipTests -f ddk-parent/pom.xml`. Then, from this reproducer directory:
+
+```text
+python prepare.py --ddk-repository /path/to/fix-checkout/ddk-repository/target/repository
+mvn clean verify
+```
+
+Replace the path with your local location; Windows paths can be quoted. The test project is unchanged between runs. The selected target is the only difference.
+
+## Run in Eclipse
+
+Import this directory using **Existing Projects into Workspace**. Run the preparation step first, open `reproducer.target`, and select **Set as Active Target Platform**. After resolution completes, run `Scope regression.launch` as a JUnit plug-in test. The launch uses a dedicated `.scope-reproducer-runtime` directory within the chosen workspace. Use a new workspace for this reproducer.
+
+The Maven run is headless and needs no SWT startup option. For the interactive launch on macOS, add `-XstartOnFirstThread` to the JDK's default VM arguments, as usual for Eclipse PDE launches. Do not add that option on Windows or Linux.
+
+## Correct behavior
+
+- Reading resource roots preserves both provider types without compiling bodies against an unavailable model.
+- Early member access does not permanently lose helpers: after the model becomes available, generation declares the expected helper method, with its historical name, and generates both provider files.
+- An unresolved include later contributes its reference-scope helper and injected field.
+- Generation while signatures remain unavailable fails explicitly and writes no Java; repairing the same resource permits generation.
+
+The test checks actual inferred method declarations as well as generated text, so a dangling dispatch call alone cannot pass.
+
+Local checks against the public 19.1 target produced four expected test failures; the same four tests passed against the fixed target. The four generated provider classes also compiled successfully with Java 21.
+
+The fixture is designed for Windows, macOS, and Linux. Local validation is on macOS/JDK 21; Windows execution must still be confirmed on Ruben's machine. It does not benchmark antivirus or file-system performance and does not establish why a particular downstream model became unavailable.

--- a/reproducers/scope-inference/ROOT-CAUSE.md
+++ b/reproducers/scope-inference/ROOT-CAUSE.md
@@ -1,0 +1,48 @@
+# Root cause and scope of the fix
+
+## Confirmed regression
+
+[PR #1405](https://github.com/dsldevkit/dsl-devkit/pull/1405), commit `2973c5b2f75af1029602b5ee4b4c771309a21e95`, moved Scope generation from `IGenerator2.doGenerate` into JVM model inference on **19 August 2026**. The affected code is present in DDK 19.1.
+
+The inferrer eagerly rendered every provider method body before accepting either JVM type. Rendering a type dispatch body calls `GenModelUtilX.literalIdentifier(EClass)`, which requires an attached EPackage. A temporarily detached classifier or unresolved model reference therefore throws before either provider is accepted.
+
+Xtext's `BatchLinkableResource.getContents()` can install derived state. Its `JvmModelAssociator` catches and logs inference exceptions; the resource can remain initialized without the missing provider types. Repeated root reads do not automatically repeat inference.
+
+The reported stack enters this path from Export inference, grammar linking, and `Xtext2EcoreTransformer.removeGeneratedPackages()`. That transformer traverses other resources' contents while processing generated packages. Thus, a read during linking unexpectedly triggers Scope body compilation.
+
+The standalone baseline test against the public 19.1 binaries produces the same DDK exception chain:
+
+```text
+GenModelUtilX.qualifiedPackageInterfaceName
+GenModelUtilX.literalIdentifier
+ScopeProviderGenerator.doGetScopeByTypeBody
+ScopeJvmModelInferrer.infer
+JvmModelAssociator.installDerivedState
+BatchLinkableResource.getContents
+```
+
+It leaves one source root instead of the source root plus two provider types.
+
+## Why delaying only the bodies is insufficient
+
+Provider member declarations also depend on model resolution. The historical helper name includes the model package and classifier names. Inheritance merging additionally compares classifiers' package namespaces. Unavailable includes can otherwise silently contribute empty scope and injection collections.
+
+An acceptor initializer is not, by itself, delayed beyond inference: Xtext normally executes it immediately. The fix registers actual demand-driven JVM member initialization after accepting both provider roots. This postpones model-dependent work during plain root traversal, but does not claim that member demand is a global linking-completion barrier.
+
+## Fix
+
+1. Accept both provider type roots without compiling Java bodies.
+2. Initialize members on demand. Before inheritance traversal, check that included models and scope signatures are available. Keep an incomplete marker until member construction succeeds.
+3. Render bodies only during Java emission, with fresh model-specific generators, the project resource loader, and restoration of the previous GenModel resource context.
+4. If an early member query observed incomplete input, rebuild the derived model before generation traverses JVM types. If it is still incomplete, fail before writing any Java.
+5. Preserve the existing resolved helper names and generation algorithms.
+
+Regression tests cover plain root traversal, early member demand and repair, unresolved generation with no output, and include repair with inherited methods and injections. Tests run through the repository's existing central suite. The separate public test project runs the same scenarios against a selected p2 target.
+
+Two independent adversarial Astra reviews challenged the diagnosis and recovery design. Their findings led to explicit late member initialization, incomplete-inference recovery, include checks before inheritance merging, and assertions of actual method declarations rather than method-name substrings alone.
+
+## Limits
+
+The reproducer intentionally stages unavailable model objects. It proves the DDK lifecycle failure and recovery behavior without private sources. It does not reproduce the entire downstream grammar/Export load sequence, prove that a previously valid target became unresolved because of DDK, or explain every hour of Windows build time. The model-availability trigger and Windows performance remain separate unproven questions.
+
+No line-ending, Format, Check, Xtend, JDT, or antivirus change is included in this fix.

--- a/reproducers/scope-inference/Scope regression.launch
+++ b/reproducers/scope-inference/Scope regression.launch
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="false"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/.scope-reproducer-runtime"/>
+<booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/repro.scope.lifecycle/src/repro/ScopeInferenceTest.java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit6"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="repro.ScopeInferenceTest"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="repro.scope.lifecycle"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx1g&#13;&#10;-ea"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="org.eclipse.platform.ide"/>
+<booleanAttribute key="run_in_ui_thread" value="false"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="true"/>
+</launchConfiguration>

--- a/reproducers/scope-inference/build.properties
+++ b/reproducers/scope-inference/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/reproducers/scope-inference/pom.xml
+++ b/reproducers/scope-inference/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>repro</groupId><artifactId>repro.scope.lifecycle</artifactId><version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-test-plugin</packaging>
+  <properties><project.build.sourceEncoding>UTF-8</project.build.sourceEncoding></properties>
+  <build><plugins>
+    <plugin><groupId>org.eclipse.tycho</groupId><artifactId>tycho-maven-plugin</artifactId><version>5.0.4</version><extensions>true</extensions></plugin>
+    <plugin><groupId>org.eclipse.tycho</groupId><artifactId>target-platform-configuration</artifactId><version>5.0.4</version>
+      <configuration><target><file>reproducer.target</file></target></configuration>
+    </plugin>
+    <plugin><groupId>org.eclipse.tycho</groupId><artifactId>tycho-surefire-plugin</artifactId><version>5.0.4</version>
+      <configuration><useUIHarness>false</useUIHarness><useUIThread>false</useUIThread><providerHint>junit6</providerHint><testClass>repro.ScopeInferenceTest</testClass><failIfNoTests>true</failIfNoTests></configuration>
+    </plugin>
+  </plugins></build>
+</project>

--- a/reproducers/scope-inference/prepare.py
+++ b/reproducers/scope-inference/prepare.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Prepare the pinned public target, or use a locally built DDK p2 repository."""
+import argparse
+import hashlib
+from pathlib import Path
+import urllib.request
+import zipfile
+
+ROOT = Path(__file__).resolve().parent
+URL = "https://github.com/dsldevkit/dsl-devkit/releases/download/v19.1.0/p2-update-site.zip"
+SHA256 = "3f785c0690762503de1bc7d173a770531537264030e1ed23675ddf31f0b40971"
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--ddk-repository", type=Path, help="Use an extracted local p2 repository (for the fixed build)")
+args = parser.parse_args()
+if args.ddk_repository:
+    repository = args.ddk_repository.resolve()
+else:
+    archive = ROOT / "target-platform" / "ddk-19.1.zip"
+    archive.parent.mkdir(exist_ok=True)
+    if not archive.exists():
+        print("Downloading public DDK 19.1 release...")
+        urllib.request.urlretrieve(URL, archive)
+    if hashlib.sha256(archive.read_bytes()).hexdigest() != SHA256:
+        raise SystemExit("DDK release checksum mismatch; remove target-platform/ddk-19.1.zip and retry")
+    repository = archive.parent / "ddk-19.1"
+    repository.mkdir(exist_ok=True)
+    with zipfile.ZipFile(archive) as bundle:
+        for member in bundle.infolist():
+            if not (repository / member.filename).resolve().is_relative_to(repository.resolve()):
+                raise SystemExit("Unsafe archive member")
+        bundle.extractall(repository)
+    if (repository / "repository").is_dir():
+        repository = repository / "repository"
+if not any((repository / name).exists() for name in ("content.jar", "content.xml", "content.xml.xz")):
+    raise SystemExit("The supplied directory does not contain p2 metadata")
+template = (ROOT / "reproducer.target.in").read_text(encoding="utf-8")
+(ROOT / "reproducer.target").write_text(template.replace("@DDK_REPOSITORY@", repository.as_uri()), encoding="utf-8")
+print("Prepared reproducer.target. Run mvn verify, or open it in Eclipse and select Set as Active Target Platform.")

--- a/reproducers/scope-inference/reproducer.target.in
+++ b/reproducers/scope-inference/reproducer.target.in
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<target name="Scope regression — DDK 19.1">
+<locations>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+  <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
+  <unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
+  <unit id="org.eclipse.swtbot.ide.feature.group" version="0.0.0"/>
+  <repository location="http://download.eclipse.org/technology/swtbot/releases/4.3.0/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.pde.core" version="0.0.0"/>
+    <unit id="org.eclipse.pde.ui" version="0.0.0"/>
+    <unit id="org.eclipse.pde.ua.core" version="0.0.0"/>
+    <unit id="org.eclipse.pde.junit.runtime" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.junit.runtime" version="0.0.0"/>
+    <unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/releases/2026-06/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+  <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+  <repository location="https://download.eclipse.org/modeling/emf/emf/builds/release/2.39.0/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <unit id="org.eclipse.emf.mwe2.runtime.sdk.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.25.0/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+    <unit id="org.eclipse.xtext.xtext.generator" version="0.0.0"/>
+    <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.43.0/"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <repository location="https://download.eclipse.org/lsp4j/updates/releases/1.0.0/"/>
+    <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.40.0"/>
+    <unit id="net.bytebuddy.byte-buddy" version="1.18.8"/>
+    <unit id="org.objenesis" version="3.5.0"/>
+    <unit id="org.mockito.mockito-core" version="5.23.0"/>
+    <unit id="org.hamcrest" version="3.0.0"/>
+    <unit id="org.apache.commons.logging" version="1.2.0"/>
+    <unit id="org.apache.commons.text" version="1.15.0"/>
+    <unit id="org.apache.commons.lang3" version="3.20.0"/>
+    <unit id="org.apache.logging.log4j.core" version="2.26.0"/>
+    <unit id="org.apache.logging.log4j.api" version="2.26.0"/>
+    <unit id="org.apache.log4j" version="1.2.26"/> <!--use reload4j 1.2.26 for org.eclipse.xtext dependencies to log4j-->
+    <unit id="junit-jupiter-api" version="6.1.0"/>
+    <unit id="junit-jupiter-engine" version="6.1.0"/>
+    <unit id="junit-jupiter-params" version="6.1.0"/>
+    <unit id="junit-platform-commons" version="6.1.0"/>
+    <unit id="junit-platform-engine" version="6.1.0"/>
+    <unit id="junit-platform-launcher" version="6.1.0"/>
+    <unit id="junit-platform-suite-api" version="6.1.0"/>
+    <unit id="junit-platform-suite-engine" version="6.1.0"/>
+  </location>
+  <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+    <unit id="com.avaloq.tools.ddk.xtext.scope" version="0.0.0"/>
+    <repository location="@DDK_REPOSITORY@"/>
+  </location>
+</locations>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+</target>

--- a/reproducers/scope-inference/src/repro/ScopeInferenceTest.java
+++ b/reproducers/scope-inference/src/repro/ScopeInferenceTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Group AG - initial API and implementation
+ *******************************************************************************/
+package repro;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.xtext.common.types.JvmGenericType;
+import org.eclipse.xtext.common.types.JvmOperation;
+import org.eclipse.xtext.common.types.xtext.JvmMemberInitializableResource;
+import org.eclipse.xtext.generator.IGenerator;
+import org.eclipse.xtext.generator.InMemoryFileSystemAccess;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.resource.XtextResourceSet;
+import org.junit.jupiter.api.Test;
+
+import com.avaloq.tools.ddk.xtext.scope.ScopeStandaloneSetup;
+import com.avaloq.tools.ddk.xtext.scope.scope.ScopeModel;
+import com.avaloq.tools.ddk.xtext.scope.scope.ScopeFactory;
+import com.google.inject.Injector;
+
+/** Tests Scope inference while model classifiers are temporarily unavailable. */
+@SuppressWarnings("nls")
+public class ScopeInferenceTest {
+
+  /** Reading resource roots must not compile bodies or resolve method signatures. */
+  @Test
+  public void testResourceTraversalDuringModelLinking() throws IOException {
+    assertRecovery(false, false);
+  }
+
+  /** An early member query must not make missing scope methods permanent. */
+  @Test
+  public void testEarlyMemberAccessRecoversBeforeGeneration() throws IOException {
+    assertRecovery(true, false);
+  }
+
+  /** Invalid input must not write Java; repairing it in place must recover. */
+  @Test
+  public void testUnresolvedGenerationFailsWithoutWritingFiles() throws IOException {
+    assertRecovery(true, true);
+  }
+
+  private void assertRecovery(final boolean accessMembers, final boolean generateWhileInvalid) throws IOException {
+    final Injector injector = new ScopeStandaloneSetup().createInjectorAndDoEMFRegistration();
+    final XtextResourceSet resources = injector.getInstance(XtextResourceSet.class);
+    final XtextResource resource = (XtextResource) resources.createResource(URI.createURI("synthetic:/Example.scope"));
+    final String source = "scoping repro.Example\n"
+        + "import \"http://www.eclipse.org/emf/2002/Ecore\" as ecore\n"
+        + "scope ecore::EClass { context ecore::EPackage = eClassifiers; }\n";
+    resource.load(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)), null);
+    final ScopeModel model = (ScopeModel) resource.getParseResult().getRootASTElement();
+    final EClass detached = EcoreFactory.eINSTANCE.createEClass();
+    detached.setName("EClass");
+    model.getScopes().get(0).setTargetType(detached);
+    assertEquals(3, resource.getContents().size(), "Root traversal must retain both inferred provider types");
+    if (accessMembers) {
+      ((JvmMemberInitializableResource) resource).ensureJvmMembersInitialized();
+    }
+    if (generateWhileInvalid) {
+      final InMemoryFileSystemAccess invalidFiles = new InMemoryFileSystemAccess();
+      assertThrows(IllegalStateException.class, () -> injector.getInstance(IGenerator.class).doGenerate(resource, invalidFiles));
+      assertTrue(invalidFiles.getTextFiles().isEmpty(), "Incomplete providers must never be emitted");
+    }
+    model.getScopes().get(0).setTargetType(EcorePackage.Literals.ECLASS);
+    final InMemoryFileSystemAccess files = new InMemoryFileSystemAccess();
+    injector.getInstance(IGenerator.class).doGenerate(resource, files);
+    final String generated = files.getTextFiles().values().toString();
+    assertEquals(2, files.getTextFiles().size(), "Both providers must be generated after model linking finishes");
+    assertHelperDeclared(resource, "scope_ecore_EClass");
+    assertTrue(generated.contains("IScope scope_ecore_EClass("), "The helper must be declared, not merely called");
+    assertTrue((generated.contains("EcorePackage.Literals.ECLASS") || generated.contains("EcorePackage.eINSTANCE.getEClass()")), "Generation must render the repaired model type");
+  }
+
+  /** An include that resolves after an early member query must contribute both methods and injections. */
+  @Test
+  public void testUnresolvedIncludeRecoversBeforeGeneration() throws IOException {
+    final Injector injector = new ScopeStandaloneSetup().createInjectorAndDoEMFRegistration();
+    final XtextResourceSet resources = injector.getInstance(XtextResourceSet.class);
+    final XtextResource base = load(resources, "Base", "scoping repro.Base\n"
+        + "import \"http://www.eclipse.org/emf/2002/Ecore\" as ecore\n"
+        + "inject java.lang.String as inheritedField\n"
+        + "scope (inherited) ecore::EPackage#eClassifiers { context ecore::EPackage = eClassifiers; }\n");
+    final XtextResource child = load(resources, "Child", "scoping repro.Child\n");
+    final ScopeModel model = (ScopeModel) child.getParseResult().getRootASTElement();
+    final ScopeModel unavailable = ScopeFactory.eINSTANCE.createScopeModel();
+    ((InternalEObject) unavailable).eSetProxyURI(base.getURI().appendFragment("not-yet-linked"));
+    model.getIncludedScopes().add(unavailable);
+    assertEquals(3, child.getContents().size(), "Both provider roots must survive an unavailable include");
+    ((JvmMemberInitializableResource) child).ensureJvmMembersInitialized();
+    model.getIncludedScopes().set(0, (ScopeModel) base.getParseResult().getRootASTElement());
+    final InMemoryFileSystemAccess files = new InMemoryFileSystemAccess();
+    injector.getInstance(IGenerator.class).doGenerate(child, files);
+    assertHelperDeclared(child, "inherited_ecore_EPackage_eClassifiers");
+    final String generated = files.getTextFiles().values().toString();
+    assertTrue(generated.contains("IScope inherited_ecore_EPackage_eClassifiers("), "The inherited reference helper must be declared");
+    assertTrue(generated.contains("String inheritedField"), "The inherited injection must be declared");
+  }
+
+  private XtextResource load(final XtextResourceSet resources, final String name, final String source) throws IOException {
+    final XtextResource resource = (XtextResource) resources.createResource(URI.createURI("synthetic:/" + name + ".scope"));
+    resource.load(new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8)), null);
+    return resource;
+  }
+
+  private void assertHelperDeclared(final XtextResource resource, final String name) {
+    final JvmGenericType provider = (JvmGenericType) resource.getContents().get(1);
+    assertEquals(1, provider.getMembers().stream().filter(JvmOperation.class::isInstance)
+        .filter(member -> name.equals(member.getSimpleName())).count(), "Exactly one helper declaration must exist");
+  }
+
+}


### PR DESCRIPTION
Scope JVM inference can fail while a grammar is being linked, leaving the Scope resource initialized without its provider types. This fixes the lifecycle regression introduced by #1405 (merged 19 August 2026), present in DDK 19.1.

The migration rendered Java bodies eagerly before accepting either inferred type. A resource-content read during grammar linking could therefore reach `GenModelUtilX.literalIdentifier(EClass)` while the classifier had no EPackage. Delaying only bodies is insufficient: helper names and inheritance merging also resolve model types, and an early member query can leave incomplete declarations cached.

The fix accepts both type shells first, uses demand-driven member initialization, checks includes/signatures before inheritance traversal, and renders bodies during emission with fresh model-specific generators and restored resource-loader context. A resource whose earlier member initialization was incomplete is inferred again before generation; if it remains incomplete, no Java is written. Existing resolved helper names and generation algorithms are preserved.

The root-cause analysis and portable public Eclipse reproducer are included under [`reproducers/scope-inference`](https://github.com/dsldevkit/dsl-devkit/tree/codex/fix-scope-inference/reproducers/scope-inference). The four tests cover resource-root traversal, early member demand and repair, refusing generation while unresolved, and recovery of inherited reference helpers/injections. They assert actual method declarations, not merely dispatch-call text. Two independent adversarial reviews informed the recovery design; the final review found no remaining blocking defect in this scope.

Validation:

- GitHub CI passed for commit `cdb5869a6850b7867696806ce1fe05017dd5f8d7`: `maven-verify`, `pmd`, `checkstyle`, and `line-endings`. The local UI timeout noted above did not prevent a successful CI verification run.

- Public DDK 19.1 target: all four regression tests fail as expected.
- Fixed p2 target: the same four tests pass, including from a freshly extracted reproducer ZIP.
- Four generated provider Java classes compile with Java 21.
- Full suite, twice (including a fresh test workspace): 358 tests, zero assertion failures, two skipped, one error in the existing `testBulkApplyingQuickfix` UI test waiting for the “Select a fix” table. All four new Scope tests passed in both runs. This UI timeout remains unresolved.
- All repository Checkstyle, PMD, CPD, and SpotBugs checks passed.

The fixture stages unavailable model objects and proves this DDK failure and recovery mechanism. It does not reproduce the entire private downstream grammar/Export loading sequence or establish why its model became unavailable. Local runs were on macOS/JDK 21; Windows verification remains to be done. This PR contains only the Scope fix.
