### PR TITLE
refactor(scope): clarify generated method bodies

### DIFF
--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopeNameProviderGenerator.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopeNameProviderGenerator.java
@@ -43,8 +43,6 @@ import com.google.inject.Inject;
 @SuppressWarnings({"checkstyle:MethodName", "nls", "PMD.UnusedFormalParameter"})
 public class ScopeNameProviderGenerator {
 
-  // CPD-OFF — migrated Xtend generator code, kept faithful; de-dup is a migration follow-up (#1339)
-
   @Inject
   private GeneratorUtilX generatorUtilX;
 
@@ -79,63 +77,64 @@ public class ScopeNameProviderGenerator {
    * Produces the body of the {@code internalGetNameFunctions(EClass)} method. Extracted so the Xbase based
    * {@code ScopeJvmModelInferrer} can attach it directly as a method body.
    *
-   * @param it
+   * @param model
    *          the scope model, must not be {@code null}
    * @return the method body, never {@code null}
    */
-  public CharSequence internalGetNameFunctionsBody(final ScopeModel it) {
+  public CharSequence internalGetNameFunctionsBody(final ScopeModel model) {
     final StringConcatenation builder = new StringConcatenation();
-    if (it.getNaming() != null) {
+    if (model.getNaming() != null) {
       final Set<EPackage> packages = new LinkedHashSet<>();
-      for (final NamingDefinition naming : it.getNaming().getNamings()) {
-        packages.add(naming.getType().getEPackage());
+      for (final NamingDefinition definition : model.getNaming().getNamings()) {
+        packages.add(definition.getType().getEPackage());
       }
-      for (final EPackage p : packages) {
-        builder.append("if (");
-        builder.append(genModelUtil.qualifiedPackageInterfaceName(p));
-        builder.append(".eINSTANCE == eClass.getEPackage()) {");
-        builder.newLineIfNotEmpty();
-        builder.append("  ");
-        builder.append("switch (eClass.getClassifierID()) {");
-        builder.newLine();
-        builder.newLine();
-        for (final NamingDefinition n : it.getNaming().getNamings()) {
-          if (!Objects.equals(n.getType().getEPackage(), p)) {
-            continue;
-          }
-          builder.append("  ");
-          builder.append("case ");
-          builder.append(genModelUtil.classifierIdLiteral(n.getType()), "  ");
-          builder.append(":");
-          builder.newLineIfNotEmpty();
-          builder.append("  ");
-          builder.append("  ");
-          builder.append(generatorUtilX.javaContributorComment(generatorUtilX.location(n)), "    ");
-          builder.newLineIfNotEmpty();
-          builder.append("  ");
-          builder.append("  ");
-          builder.append("return ");
-          builder.append(nameFunctions(n.getNaming(), it), "    ");
-          builder.append(";");
-          builder.newLineIfNotEmpty();
-        }
-        builder.newLine();
-        builder.append("  ");
-        builder.append("default:");
-        builder.newLine();
-        builder.append("    ");
-        builder.append("return !eClass.getESuperTypes().isEmpty() ? getNameFunctions(eClass.getESuperTypes().get(0)) : null;");
-        builder.newLine();
-        builder.append("  ");
-        builder.append("}");
-        builder.newLine();
-        builder.append("}");
-        builder.newLine();
+      for (final EPackage ePackage : packages) {
+        appendPackageSwitch(builder, ePackage, model);
       }
     }
     builder.append("return !eClass.getESuperTypes().isEmpty() ? getNameFunctions(eClass.getESuperTypes().get(0)) : null;");
     builder.newLine();
     return builder;
+  }
+
+  /** Emits naming cases for one package, retaining definition order. */
+  private void appendPackageSwitch(final StringConcatenation builder, final EPackage ePackage, final ScopeModel model) {
+    builder.append("if (");
+    builder.append(genModelUtil.qualifiedPackageInterfaceName(ePackage));
+    builder.append(".eINSTANCE == eClass.getEPackage()) {");
+    builder.newLineIfNotEmpty();
+    builder.append("""
+          switch (eClass.getClassifierID()) {
+
+        """);
+    for (final NamingDefinition definition : model.getNaming().getNamings()) {
+      if (!Objects.equals(definition.getType().getEPackage(), ePackage)) {
+        continue;
+      }
+      appendNamingCase(builder, definition, model);
+    }
+    builder.newLine();
+    builder.append("""
+          default:
+            return !eClass.getESuperTypes().isEmpty() ? getNameFunctions(eClass.getESuperTypes().get(0)) : null;
+          }
+        }
+        """);
+  }
+
+  /** Emits a classifier case, including indentation of multiline comments and name functions. */
+  private void appendNamingCase(final StringConcatenation builder, final NamingDefinition definition, final ScopeModel model) {
+    builder.append("  case ");
+    builder.append(genModelUtil.classifierIdLiteral(definition.getType()), "  ");
+    builder.append(":");
+    builder.newLineIfNotEmpty();
+    builder.append("    ");
+    builder.append(generatorUtilX.javaContributorComment(generatorUtilX.location(definition)), "    ");
+    builder.newLineIfNotEmpty();
+    builder.append("    return ");
+    builder.append(nameFunctions(definition.getNaming(), model), "    ");
+    builder.append(";");
+    builder.newLineIfNotEmpty();
   }
 
   public CharSequence nameFunctions(final Naming it, final ScopeModel model) {
@@ -189,8 +188,7 @@ public class ScopeNameProviderGenerator {
     return "com.avaloq.tools.ddk.xtext.scoping.NameFunctions.fromConstant(String.valueOf(" + it.getVal() + "))";
   }
 
-  protected String _nameFunction(final FeatureCall it, final ScopeModel model, final String contextName,
-      final EClass contextType) {
+  protected String _nameFunction(final FeatureCall it, final ScopeModel model, final String contextName, final EClass contextType) {
     final StringConcatenation builder = new StringConcatenation();
     final ScopeTranslationContext currentContext = newContext(it, contextName, contextType);
     builder.newLineIfNotEmpty();
@@ -200,23 +198,7 @@ public class ScopeNameProviderGenerator {
       builder.append(")");
     } else if (compiler.isSimpleNavigation(it, currentContext)) {
       builder.newLineIfNotEmpty();
-      builder.append("object -> {");
-      builder.newLine();
-      builder.append("    ");
-      builder.append("final ");
-      builder.append(genModelUtil.instanceClassName(scopeProviderX.scopeType(it)), "    ");
-      builder.append(" obj = (");
-      builder.append(genModelUtil.instanceClassName(scopeProviderX.scopeType(it)), "    ");
-      builder.append(") object;");
-      builder.newLineIfNotEmpty();
-      builder.append("    ");
-      builder.append("return toQualifiedName(");
-      builder.append(compiler.javaExpression(it, currentContext), "    ");
-      builder.append(");");
-      builder.newLineIfNotEmpty();
-      builder.append("  ");
-      builder.append("}");
-      builder.newLine();
+      appendNameFunctionLambda(builder, it, currentContext);
     } else {
       builder.append("EXPRESSION_NOT_SUPPORTED(\"");
       builder.append(ExpressionExtensions.serialize(it));
@@ -225,29 +207,12 @@ public class ScopeNameProviderGenerator {
     return builder.toString();
   }
 
-  protected String _nameFunction(final OperationCall it, final ScopeModel model, final String contextName,
-      final EClass contextType) {
+  protected String _nameFunction(final OperationCall it, final ScopeModel model, final String contextName, final EClass contextType) {
     final StringConcatenation builder = new StringConcatenation();
     final ScopeTranslationContext currentContext = newContext(it, contextName, contextType);
     builder.newLineIfNotEmpty();
     if (compiler.isCompilable(it, currentContext)) {
-      builder.append("object -> {");
-      builder.newLine();
-      builder.append("    ");
-      builder.append("final ");
-      builder.append(genModelUtil.instanceClassName(scopeProviderX.scopeType(it)), "    ");
-      builder.append(" obj = (");
-      builder.append(genModelUtil.instanceClassName(scopeProviderX.scopeType(it)), "    ");
-      builder.append(") object;");
-      builder.newLineIfNotEmpty();
-      builder.append("    ");
-      builder.append("return toQualifiedName(");
-      builder.append(compiler.javaExpression(it, currentContext), "    ");
-      builder.append(");");
-      builder.newLineIfNotEmpty();
-      builder.append("  ");
-      builder.append("}");
-      builder.newLine();
+      appendNameFunctionLambda(builder, it, currentContext);
       builder.append("    ");
     } else {
       builder.append("EXPRESSION_NOT_SUPPORTED(\"");
@@ -255,6 +220,24 @@ public class ScopeNameProviderGenerator {
       builder.append("\")");
     }
     return builder.toString();
+  }
+
+  /** Emits a typed receiver lambda that converts the expression result to a qualified name. */
+  private void appendNameFunctionLambda(final StringConcatenation builder, final Expression expression, final ScopeTranslationContext context) {
+    builder.append("object -> {");
+    builder.newLine();
+    builder.append("    final ");
+    builder.append(genModelUtil.instanceClassName(scopeProviderX.scopeType(expression)), "    ");
+    builder.append(" obj = (");
+    builder.append(genModelUtil.instanceClassName(scopeProviderX.scopeType(expression)), "    ");
+    builder.append(") object;");
+    builder.newLineIfNotEmpty();
+    builder.append("    return toQualifiedName(");
+    builder.append(compiler.javaExpression(expression, context), "    ");
+    builder.append(");");
+    builder.newLineIfNotEmpty();
+    builder.append("  }");
+    builder.newLine();
   }
   // CHECKSTYLE:CONSTANTS-ON
 

--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopeProviderGenerator.java
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/generator/ScopeProviderGenerator.java
@@ -18,9 +18,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.ENamedElement;
 import org.eclipse.xtend2.lib.StringConcatenation;
 import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.lib.Pair;
@@ -57,8 +59,6 @@ import com.google.inject.Inject;
 
 @SuppressWarnings({"checkstyle:MethodName", "nls", "PMD.UnusedFormalParameter"})
 public class ScopeProviderGenerator {
-
-  // CPD-OFF — migrated Xtend generator code, kept faithful; de-dup is a migration follow-up (#1339)
 
   @Inject
   private GeneratorUtilX generatorUtilX;
@@ -98,74 +98,36 @@ public class ScopeProviderGenerator {
    * Produces the body of the {@code doGetScope(EObject, EReference, String, Resource)} method. Extracted so the
    * Xbase based {@code ScopeJvmModelInferrer} can attach it directly as a method body.
    *
-   * @param it
+   * @param model
    *          the scope model, must not be {@code null}
    * @return the method body, never {@code null}
    */
-  public CharSequence doGetScopeByReferenceBody(final ScopeModel it) {
-    final StringConcatenation builder = new StringConcatenation();
-    final List<ScopeDefinition> scopes = scopesWithReference(it, true);
-    if (!scopes.isEmpty()) {
-      builder.append("if (scopeName == null) {");
-      builder.newLine();
-      builder.append("  ");
-      builder.append("return null;");
-      builder.newLine();
-      builder.append("}");
-      builder.newLine();
-      builder.newLine();
-      builder.append("switch (scopeName) {");
-      builder.newLine();
-      for (final String name : scopeNames(scopes)) {
-        builder.append("case \"");
-        builder.append(name);
-        builder.append("\":");
-        builder.newLineIfNotEmpty();
-        for (final ScopeDefinition scope : namedScopes(scopes, name)) {
-          builder.append("  ");
-          builder.append("if (reference == ");
-          builder.append(genModelUtil.literalIdentifier(scope.getReference()), "  ");
-          builder.append(") return ");
-          builder.append(scopeProviderX.scopeMethodName(scope), "  ");
-          builder.append("(context, reference, originalResource);");
-          builder.newLineIfNotEmpty();
-        }
-        builder.append("  ");
-        builder.append("break;");
-        builder.newLine();
-      }
-      builder.append("  ");
-      builder.append("default: break;");
-      builder.newLine();
-      builder.append("}");
-      builder.newLine();
-    }
-    builder.append("return null;");
-    builder.newLine();
-    return builder;
+  public CharSequence doGetScopeByReferenceBody(final ScopeModel model) {
+    return renderScopeDispatch(scopesWithReference(model, true), "reference", ScopeDefinition::getReference);
   }
 
   /**
    * Produces the body of the {@code doGetScope(EObject, EClass, String, Resource)} method.
    *
-   * @param it
+   * @param model
    *          the scope model, must not be {@code null}
    * @return the method body, never {@code null}
    */
-  public CharSequence doGetScopeByTypeBody(final ScopeModel it) {
+  public CharSequence doGetScopeByTypeBody(final ScopeModel model) {
+    return renderScopeDispatch(scopesWithReference(model, false), "type", ScopeDefinition::getTargetType);
+  }
+
+  /** Emits the name switch while retaining the reference/type distinction at each case. */
+  private CharSequence renderScopeDispatch(final List<ScopeDefinition> scopes, final String argumentName, final Function<ScopeDefinition, ENamedElement> target) {
     final StringConcatenation builder = new StringConcatenation();
-    final List<ScopeDefinition> scopes = scopesWithReference(it, false);
     if (!scopes.isEmpty()) {
-      builder.append("if (scopeName == null) {");
-      builder.newLine();
-      builder.append("  ");
-      builder.append("return null;");
-      builder.newLine();
-      builder.append("}");
-      builder.newLine();
-      builder.newLine();
-      builder.append("switch (scopeName) {");
-      builder.newLine();
+      builder.append("""
+          if (scopeName == null) {
+            return null;
+          }
+
+          switch (scopeName) {
+          """);
       for (final String name : scopeNames(scopes)) {
         builder.append("case \"");
         builder.append(name);
@@ -173,22 +135,20 @@ public class ScopeProviderGenerator {
         builder.newLineIfNotEmpty();
         for (final ScopeDefinition scope : namedScopes(scopes, name)) {
           builder.append("  ");
-          builder.append("if (type == ");
-          builder.append(genModelUtil.literalIdentifier(scope.getTargetType()), "  ");
+          builder.append("if (" + argumentName + " == ");
+          builder.append(genModelUtil.literalIdentifier(target.apply(scope)), "  ");
           builder.append(") return ");
           builder.append(scopeProviderX.scopeMethodName(scope), "  ");
-          builder.append("(context, type, originalResource);");
+          builder.append("(context, " + argumentName + ", originalResource);");
           builder.newLineIfNotEmpty();
         }
-        builder.append("  ");
-        builder.append("break;");
+        builder.append("  break;");
         builder.newLine();
       }
-      builder.append("  ");
-      builder.append("default: break;");
-      builder.newLine();
-      builder.append("}");
-      builder.newLine();
+      builder.append("""
+            default: break;
+          }
+          """);
     }
     builder.append("return null;");
     builder.newLine();
@@ -198,76 +158,35 @@ public class ScopeProviderGenerator {
   /**
    * Produces the body of the {@code doGlobalCache(EObject, EReference, String, Resource)} method.
    *
-   * @param it
+   * @param model
    *          the scope model, must not be {@code null}
    * @return the method body, never {@code null}
    */
-  public CharSequence doGlobalCacheByReferenceBody(final ScopeModel it) {
-    final StringConcatenation builder = new StringConcatenation();
-    final List<ScopeDefinition> scopes = scopesWithReference(it, true);
-    final List<ScopeDefinition> globalScopes = scopes.stream().filter(s -> !globalRules(s).isEmpty()).toList();
-    if (!globalScopes.isEmpty()) {
-      builder.append("if (scopeName != null && context.eContainer() == null) {");
-      builder.newLine();
-      builder.append("  ");
-      builder.append("switch (scopeName) {");
-      builder.newLine();
-      builder.append("  ");
-      for (final String name : scopeNames(globalScopes)) {
-        builder.append("case \"");
-        builder.append(name, "  ");
-        builder.append("\":");
-        builder.newLineIfNotEmpty();
-        for (final ScopeDefinition scope : namedScopes(scopes, name)) {
-          builder.append("  ");
-          builder.append("  ");
-          final List<ScopeRule> globalRules = globalRules(scope);
-          builder.newLineIfNotEmpty();
-          if (!globalRules.isEmpty()) {
-            builder.append("  ");
-            builder.append("  ");
-            builder.append("if (reference == ");
-            builder.append(genModelUtil.literalIdentifier(scope.getReference()), "    ");
-            builder.append(") return true;");
-            builder.newLineIfNotEmpty();
-          }
-        }
-        builder.append("  ");
-        builder.append("  ");
-        builder.append("break;");
-        builder.newLine();
-      }
-      builder.append("    ");
-      builder.append("default: break;");
-      builder.newLine();
-      builder.append("  ");
-      builder.append("}");
-      builder.newLine();
-      builder.append("}");
-      builder.newLine();
-    }
-    builder.append("return false;");
-    builder.newLine();
-    return builder;
+  public CharSequence doGlobalCacheByReferenceBody(final ScopeModel model) {
+    return renderGlobalCache(scopesWithReference(model, true), "reference", ScopeDefinition::getReference, "scopeName != null && context.eContainer() == null");
   }
 
   /**
    * Produces the body of the {@code doGlobalCache(EObject, EClass, String, Resource)} method.
    *
-   * @param it
+   * @param model
    *          the scope model, must not be {@code null}
    * @return the method body, never {@code null}
    */
-  public CharSequence doGlobalCacheByTypeBody(final ScopeModel it) {
+  public CharSequence doGlobalCacheByTypeBody(final ScopeModel model) {
+    return renderGlobalCache(scopesWithReference(model, false), "type", ScopeDefinition::getTargetType, "context.eContainer() == null");
+  }
+
+  /** Emits cache eligibility using the entry condition and target of the selected variant. */
+  private CharSequence renderGlobalCache(final List<ScopeDefinition> scopes, final String argumentName, final Function<ScopeDefinition, ENamedElement> target, final String entryCondition) {
     final StringConcatenation builder = new StringConcatenation();
-    final List<ScopeDefinition> scopes = scopesWithReference(it, false);
     final List<ScopeDefinition> globalScopes = scopes.stream().filter(s -> !globalRules(s).isEmpty()).toList();
     if (!globalScopes.isEmpty()) {
-      builder.append("if (context.eContainer() == null) {");
+      builder.append("if (" + entryCondition + ") {");
       builder.newLine();
-      builder.append("  ");
-      builder.append("switch (scopeName) {");
-      builder.newLine();
+      builder.append("""
+            switch (scopeName) {
+          """);
       builder.append("  ");
       for (final String name : scopeNames(globalScopes)) {
         builder.append("case \"");
@@ -275,32 +194,23 @@ public class ScopeProviderGenerator {
         builder.append("\":");
         builder.newLineIfNotEmpty();
         for (final ScopeDefinition scope : namedScopes(scopes, name)) {
-          builder.append("  ");
-          builder.append("  ");
           final List<ScopeRule> globalRules = globalRules(scope);
-          builder.newLineIfNotEmpty();
           if (!globalRules.isEmpty()) {
-            builder.append("  ");
-            builder.append("  ");
-            builder.append("if (type == ");
-            builder.append(genModelUtil.literalIdentifier(scope.getTargetType()), "    ");
+            builder.append("    ");
+            builder.append("if (" + argumentName + " == ");
+            builder.append(genModelUtil.literalIdentifier(target.apply(scope)), "    ");
             builder.append(") return true;");
             builder.newLineIfNotEmpty();
           }
         }
-        builder.append("  ");
-        builder.append("  ");
-        builder.append("break;");
+        builder.append("    break;");
         builder.newLine();
       }
-      builder.append("    ");
-      builder.append("default: break;");
-      builder.newLine();
-      builder.append("  ");
-      builder.append("}");
-      builder.newLine();
-      builder.append("}");
-      builder.newLine();
+      builder.append("""
+              default: break;
+            }
+          }
+          """);
     }
     builder.append("return false;");
     builder.newLine();
@@ -313,102 +223,108 @@ public class ScopeProviderGenerator {
    *
    * @param scope
    *          the scope definition the method is generated for, must not be {@code null}
-   * @param it
+   * @param model
    *          the scope model, must not be {@code null}
    * @return the method body, never {@code null}
    * @throws RuntimeException
    *           if the scope definition declares more than one global rule
    */
-  public CharSequence scopeMethodBody(final ScopeDefinition scope, final ScopeModel it) {
+  public CharSequence scopeMethodBody(final ScopeDefinition scope, final ScopeModel model) {
     final StringConcatenation builder = new StringConcatenation();
-    final List<ScopeRule> localRules = scopeProviderX.allScopeRules(scope).stream().filter(r -> !r.getContext().isGlobal()).toList();
-    builder.newLineIfNotEmpty();
+    final List<ScopeRule> localRules = scopeProviderX.allScopeRules(scope).stream().filter(rule -> !rule.getContext().isGlobal()).toList();
     final List<ScopeRule> globalRules = globalRules(scope);
-    builder.newLineIfNotEmpty();
     if (globalRules.size() > 1) {
       throw new RuntimeException("only one global rule allowed"); // NOPMD the raw type is the contract the generated scope providers were built against
     }
-    builder.newLineIfNotEmpty();
-    for (final ScopeRule r : scopeProviderX.sortedRules(scopeProviderX.filterUniqueRules(localRules))) {
-      final EClass ruleContextType = r.getContext().getContextType();
-      builder.append(generatorUtilX.javaContributorComment(generatorUtilX.location(r)));
-      builder.newLineIfNotEmpty();
-      builder.append("if (");
-      if (EClassComparator.isEObjectType(ruleContextType)) {
-        builder.append("true");
-      } else {
-        builder.append("context instanceof ");
-        builder.append(genModelUtil.instanceClassName(ruleContextType));
-      }
-      builder.append(") {");
-      builder.newLineIfNotEmpty();
-      builder.append("  ");
-      builder.append("final ");
-      builder.append(genModelUtil.instanceClassName(ruleContextType), "  ");
-      builder.append(" ctx = (");
-      builder.append(genModelUtil.instanceClassName(ruleContextType), "  ");
-      builder.append(") context;");
-      builder.newLineIfNotEmpty();
-      builder.append(" ");
-      final List<ScopeRule> rulesForTypeAndContext = localRules.stream().filter(r2 -> scopeProviderX.hasSameContext(r2, r)).toList();
-      builder.newLineIfNotEmpty();
-      builder.append("  ");
-      final String typeOrRef = scopeProviderX.contextRef(r) != null ? "ref" : "type";
-      builder.append(scopeRuleBlock(rulesForTypeAndContext, it, typeOrRef, ruleContextType, r.getContext().isGlobal()), "  ");
-      builder.newLineIfNotEmpty();
-      builder.append("}");
-      builder.newLine();
+    for (final ScopeRule rule : scopeProviderX.sortedRules(scopeProviderX.filterUniqueRules(localRules))) {
+      appendLocalScopeRule(builder, rule, localRules, model);
     }
     if (!localRules.isEmpty() || !globalRules.isEmpty()) {
-      builder.newLine();
-      builder.append("final EObject eContainer = context.eContainer();");
-      builder.newLine();
-      builder.append("if (eContainer != null) {");
-      builder.newLine();
-      builder.append("  ");
-      builder.append("return internalGetScope(");
-      if (!localRules.isEmpty()) {
-        builder.append("eContainer");
-      } else {
-        builder.append("getRootObject(eContainer)");
-      }
-      builder.append(", ");
-      if (scope.getReference() != null) {
-        builder.append("ref");
-      } else {
-        builder.append("type");
-      }
-      builder.append(", \"");
-      builder.append(scopeProviderX.getScopeName(scope), "  ");
-      builder.append("\", originalResource);");
-      builder.newLineIfNotEmpty();
-      builder.append("}");
-      builder.newLine();
-      builder.newLine();
+      appendContainerFallback(builder, scope, !localRules.isEmpty());
     }
     if (!globalRules.isEmpty()) {
-      final ScopeRule r = globalRules.get(0);
-      builder.newLineIfNotEmpty();
-      final List<ScopeRule> rulesForTypeAndContext = List.of(r);
-      builder.newLineIfNotEmpty();
-      builder.append(generatorUtilX.javaContributorComment(generatorUtilX.location(r)));
-      builder.newLineIfNotEmpty();
-      builder.append("if (context.eResource() != null) {");
-      builder.newLine();
-      builder.append("  ");
-      builder.append("final Resource ctx = context.eResource();");
-      builder.newLine();
-      builder.append("  ");
-      final String typeOrRef = scopeProviderX.contextRef(r) != null ? "ref" : "type";
-      builder.append(scopeRuleBlock(rulesForTypeAndContext, it, typeOrRef, r.getContext().getContextType(), r.getContext().isGlobal()), "  ");
-      builder.newLineIfNotEmpty();
-      builder.append("}");
-      builder.newLine();
-      builder.newLine();
+      appendGlobalScopeRule(builder, globalRules.get(0), model);
     }
     builder.append("return null;");
     builder.newLine();
     return builder;
+  }
+
+  /** Emits the matching local rules for one context type. */
+  private void appendLocalScopeRule(final StringConcatenation builder, final ScopeRule rule, final List<ScopeRule> localRules, final ScopeModel model) {
+    final EClass ruleContextType = rule.getContext().getContextType();
+    builder.append(generatorUtilX.javaContributorComment(generatorUtilX.location(rule)));
+    builder.newLineIfNotEmpty();
+    builder.append("if (");
+    if (EClassComparator.isEObjectType(ruleContextType)) {
+      builder.append("true");
+    } else {
+      builder.append("context instanceof ");
+      builder.append(genModelUtil.instanceClassName(ruleContextType));
+    }
+    builder.append(") {");
+    builder.newLineIfNotEmpty();
+    builder.append("  final ");
+    builder.append(genModelUtil.instanceClassName(ruleContextType), "  ");
+    builder.append(" ctx = (");
+    builder.append(genModelUtil.instanceClassName(ruleContextType), "  ");
+    builder.append(") context;");
+    builder.newLineIfNotEmpty();
+    final List<ScopeRule> rulesForTypeAndContext = localRules.stream().filter(candidate -> scopeProviderX.hasSameContext(candidate, rule)).toList();
+    builder.append("  ");
+    final String typeOrRef = scopeProviderX.contextRef(rule) != null ? "ref" : "type";
+    builder.append(scopeRuleBlock(rulesForTypeAndContext, model, typeOrRef, ruleContextType, rule.getContext().isGlobal()), "  ");
+    builder.newLineIfNotEmpty();
+    builder.append("}");
+    builder.newLine();
+  }
+
+  /** Emits the enclosing-object lookup before attempting a global rule. */
+  private void appendContainerFallback(final StringConcatenation builder, final ScopeDefinition scope, final boolean hasLocalRules) {
+    builder.newLine();
+    builder.append("""
+        final EObject eContainer = context.eContainer();
+        if (eContainer != null) {
+        """);
+    builder.append("  return internalGetScope(");
+    if (hasLocalRules) {
+      builder.append("eContainer");
+    } else {
+      builder.append("getRootObject(eContainer)");
+    }
+    builder.append(", ");
+    if (scope.getReference() != null) {
+      builder.append("ref");
+    } else {
+      builder.append("type");
+    }
+    builder.append(", \"");
+    builder.append(scopeProviderX.getScopeName(scope), "  ");
+    builder.append("\", originalResource);");
+    builder.newLineIfNotEmpty();
+    builder.append("""
+        }
+
+        """);
+  }
+
+  /** Emits the global rule in the resource context. */
+  private void appendGlobalScopeRule(final StringConcatenation builder, final ScopeRule rule, final ScopeModel model) {
+    final List<ScopeRule> rulesForTypeAndContext = List.of(rule);
+    builder.append(generatorUtilX.javaContributorComment(generatorUtilX.location(rule)));
+    builder.newLineIfNotEmpty();
+    builder.append("""
+        if (context.eResource() != null) {
+          final Resource ctx = context.eResource();
+        """);
+    builder.append("  ");
+    final String typeOrRef = scopeProviderX.contextRef(rule) != null ? "ref" : "type";
+    builder.append(scopeRuleBlock(rulesForTypeAndContext, model, typeOrRef, rule.getContext().getContextType(), rule.getContext().isGlobal()), "  ");
+    builder.newLineIfNotEmpty();
+    builder.append("""
+        }
+
+        """);
   }
 
   /**
@@ -447,82 +363,85 @@ public class ScopeProviderGenerator {
     return compiler.javaExpression(expr, translator.newCompilationContext("ctx", contextType, List.of(), expr));
   }
 
-  public CharSequence scopeRuleBlock(final List<ScopeRule> it, final ScopeModel model, final String typeOrRef, final EClass contextType,
-      final Boolean isGlobal) {
+  public CharSequence scopeRuleBlock(final List<ScopeRule> rules, final ScopeModel model, final String typeOrRef, final EClass contextType, final Boolean isGlobal) {
     final StringConcatenation builder = new StringConcatenation();
-    builder.append("IScope scope = IScope.NULLSCOPE;");
-    builder.newLine();
-    builder.append("try {");
-    builder.newLine();
-    if (it.stream().anyMatch(r -> r.getContext().getGuard() != null)) {
+    builder.append("""
+        IScope scope = IScope.NULLSCOPE;
+        try {
+        """);
+    if (rules.stream().anyMatch(rule -> rule.getContext().getGuard() != null)) {
+      appendGuardedScopeRules(builder, rules, model, typeOrRef, isGlobal);
+    } else if (rules.size() == 1) {
       builder.append("  ");
-      final List<ScopeRule> sorted = new ArrayList<>(it);
-      sorted.sort(Comparator.comparingInt((ScopeRule r) -> r.getContext().getGuard() == null ? it.size() : it.indexOf(r)));
-      boolean hasElements = false;
-      for (final ScopeRule r : sorted) {
-        if (hasElements) {
-          builder.appendImmediate(" else ", "  ");
-        } else {
-          hasElements = true;
-        }
-        if (r.getContext().getGuard() != null) {
-          builder.append("if (");
-          builder.append(guardExpression(r), "  ");
-          builder.append(") ");
-        }
-        builder.append("{");
-        builder.newLineIfNotEmpty();
-        builder.append("  ");
-        builder.append("  ");
-        if (it.size() > 1) {
-          builder.append(generatorUtilX.javaContributorComment(generatorUtilX.location(r)), "    ");
-          builder.newLineIfNotEmpty();
-          builder.append("  ");
-          builder.append("  ");
-        }
-        for (final ScopeExpression e : reversed(r.getExprs())) {
-          builder.append(scopeExpression(e, model, typeOrRef, scopeProviderX.getScope(r), isGlobal), "    ");
-        }
-        builder.newLineIfNotEmpty();
-        builder.append("  ");
-        builder.append("}");
-      }
-      if (it.stream().noneMatch(r -> r.getContext().getGuard() == null)) {
-        builder.append(" else {");
-        builder.newLineIfNotEmpty();
-        builder.append("  ");
-        builder.append("  ");
-        builder.append("throw new UnsupportedOperationException(); // continue matching other definitions");
-        builder.newLine();
-        builder.append("  ");
-        builder.append("}");
-      }
-      builder.newLineIfNotEmpty();
-    } else if (it.size() == 1) {
-      builder.append("  ");
-      for (final ScopeExpression e : reversed(it.get(0).getExprs())) {
-        builder.append(scopeExpression(e, model, typeOrRef, scopeProviderX.getScope(it.get(0)), isGlobal), "  ");
+      for (final ScopeExpression expression : reversed(rules.get(0).getExprs())) {
+        builder.append(scopeExpression(expression, model, typeOrRef, scopeProviderX.getScope(rules.get(0)), isGlobal), "  ");
       }
       builder.newLineIfNotEmpty();
     } else {
       builder.append("  ");
-      error("scope context not unique for definitions: " + it.stream().map(generatorUtilX::location).collect(Collectors.joining(", ")));
+      error("scope context not unique for definitions: " + rules.stream().map(generatorUtilX::location).collect(Collectors.joining(", ")));
       builder.newLineIfNotEmpty();
     }
+    appendScopeFailureHandler(builder, rules, contextType, isGlobal);
+    return builder;
+  }
+
+  /** Emits guarded rules in declaration order, with the unguarded fallback last. */
+  private void appendGuardedScopeRules(final StringConcatenation builder, final List<ScopeRule> rules, final ScopeModel model, final String typeOrRef, final Boolean isGlobal) {
+    builder.append("  ");
+    final List<ScopeRule> sorted = new ArrayList<>(rules);
+    sorted.sort(Comparator.comparingInt((ScopeRule rule) -> rule.getContext().getGuard() == null ? rules.size() : rules.indexOf(rule)));
+    boolean hasElements = false;
+    for (final ScopeRule rule : sorted) {
+      if (hasElements) {
+        // Keep the preceding closing-brace segment separate from trailing whitespace.
+        builder.appendImmediate(" else ", "  ");
+      } else {
+        hasElements = true;
+      }
+      if (rule.getContext().getGuard() != null) {
+        builder.append("if (");
+        builder.append(guardExpression(rule), "  ");
+        builder.append(") ");
+      }
+      builder.append("{");
+      builder.newLineIfNotEmpty();
+      builder.append("    ");
+      if (rules.size() > 1) {
+        builder.append(generatorUtilX.javaContributorComment(generatorUtilX.location(rule)), "    ");
+        builder.newLineIfNotEmpty();
+        builder.append("    ");
+      }
+      for (final ScopeExpression expression : reversed(rule.getExprs())) {
+        builder.append(scopeExpression(expression, model, typeOrRef, scopeProviderX.getScope(rule), isGlobal), "    ");
+      }
+      builder.newLineIfNotEmpty();
+      builder.append("  }");
+    }
+    if (rules.stream().noneMatch(rule -> rule.getContext().getGuard() == null)) {
+      builder.append(" else {");
+      builder.newLineIfNotEmpty();
+      builder.append("    throw new UnsupportedOperationException(); // continue matching other definitions");
+      builder.newLine();
+      builder.append("  }");
+    }
+    builder.newLineIfNotEmpty();
+  }
+
+  /** Emits the diagnostic handler and final scope return. */
+  private void appendScopeFailureHandler(final StringConcatenation builder, final List<ScopeRule> rules, final EClass contextType, final Boolean isGlobal) {
     builder.append("} catch (Exception e) {");
     builder.newLine();
-    builder.append("  ");
-    builder.append("LOGGER.error(\"Error calculating scope for ");
+    builder.append("  LOGGER.error(\"Error calculating scope for ");
     builder.append(isGlobal ? "Resource. Context:" : contextType.getName(), "  ");
     builder.append(" \" + com.avaloq.tools.ddk.xtext.util.EObjectUtil.getLocationString(context) + \" (");
-    builder.append(scopeProviderX.locatorString(it.get(0)), "  ");
+    builder.append(scopeProviderX.locatorString(rules.get(0)), "  ");
     builder.append(")\", e);");
     builder.newLineIfNotEmpty();
-    builder.append("}");
-    builder.newLine();
-    builder.append("return scope;");
-    builder.newLine();
-    return builder;
+    builder.append("""
+        }
+        return scope;
+        """);
   }
 
   protected CharSequence _scopeExpression(final ScopeExpression it, final ScopeModel model, final String typeOrRef, final ScopeDefinition scope,

--- a/ddk-parent/pom.xml
+++ b/ddk-parent/pom.xml
@@ -273,6 +273,8 @@
               <goal>compare-version-with-baselines</goal>
             </goals>
             <configuration>
+              <!-- Compare archive contents: ZIP timestamps and compression can differ on a rebuild. -->
+              <comparator>zip</comparator>
               <baselines>
                 <url>${baseline.repo.url}</url>
               </baselines>


### PR DESCRIPTION
The migrated scope generators bury package switches, rule dispatch and lambda bodies in long sequences of small append calls. This refactor gives the emission phases named helpers, shares the reference/type switch scaffolding, and combines static source fragments into readable text blocks. Dynamic multiline fragments retain `StringConcatenation` indentation and separator handling.

Stacked on #1519, following #1517 and #1518. Merge the parent stack first. The generator refactoring changes `ScopeProviderGenerator.java` and `ScopeNameProviderGenerator.java`; their public method signatures and generated behavior are preserved. The parent POM also selects Tycho's archive-content comparator for the baseline gate, as described below. The remaining Xtend sources and compiler configuration stay in place. #1522 edits the scope inferrer, whose calls to these methods remain compatible.

Validation on Java 21:

- Clean unchanged-stack baseline build passed.
- The first full reactor test/quality run passed: 354 tests, zero failures/errors, two skipped. Two later full test runs each had one `testBulkApplyingQuickfix` UI timeout waiting for the table labelled `Select a fix:` (354 tests, zero failures, one error, two skipped). The final tree is therefore not claimed to have a fully green local test run.
- Final full-reactor build and all Checkstyle, PMD, CPD and SpotBugs gates passed with tests skipped to isolate the UI timeout. Both edited files now participate in CPD without file-wide suppression.
- JDT formatting, whitespace and repository line-ending checks passed.
- Throwaway differential tests against the saved #1519 generators: 4,636 direct comparisons (including 1,706 matching exceptions), 35,160 nested-composition comparisons and 11 independent assertions passed. Two representative generated Java classes containing ten emitted methods also compiled.
- Independent adversarial fidelity and readability reviews found no behavioral regression. Review fixes remove stale file-wide CPD suppressions and make reference/type differences explicit in the shared emitters. The coordinator checked these final corrections and reran the differential harness; the additional agent rereview did not complete.

The differential harness is intentionally outside the repository, as requested. It compiles saved originals alongside the refactored classes and uses the actual StringConcatenation and EMF libraries.

The differential harness covers generated text, indentation, ordering, collaborator traces and explicit exception messages using controlled fixtures. Leaf collaborators are stubbed; JVM-generated helpful NPE diagnostic wording is excluded. These tests support preservation for the exercised cases, rather than proving all possible inputs.


Baseline verification fix: `compare-version-with-baselines` now uses Tycho's `zip` comparator instead of its default whole-file byte comparison. A fresh local build with baseline replacement disabled reproduced the failure on an unchanged bundle: all archive entry contents matched the release, but ZIP timestamps differed. With the content comparator, the full reactor `clean verify -DskipTests -Dtycho.baseline.replace=none` passed, including `xtext.valid` and `test.core`, which failed in CI. A throwaway check against Tycho 5.0.4 confirmed timestamp-only changes are accepted and changed payload bytes are rejected. Version checks remain enabled; no bundle versions were bumped. The full test suite is left to the new CI run.
