### PR TITLE
fix(scope): defer inference work until model linking completes

### DIFF
--- a/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/jvmmodel/ScopeJvmModelInferrer.xtend
+++ b/com.avaloq.tools.ddk.xtext.scope/src/com/avaloq/tools/ddk/xtext/scope/jvmmodel/ScopeJvmModelInferrer.xtend
@@ -21,8 +21,8 @@ import com.avaloq.tools.ddk.xtext.scoping.AbstractPolymorphicScopeProvider
 import com.avaloq.tools.ddk.xtext.scoping.AbstractScopeNameProvider
 import com.avaloq.tools.ddk.xtext.scoping.INameFunction
 import com.google.inject.Inject
+import com.google.inject.Provider
 import com.google.inject.Singleton
-import java.util.Map
 import org.apache.logging.log4j.Logger
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.ResourcesPlugin
@@ -35,6 +35,7 @@ import org.eclipse.xtext.common.types.JvmAnnotationType
 import org.eclipse.xtext.common.types.JvmGenericType
 import org.eclipse.xtext.common.types.JvmVisibility
 import org.eclipse.xtext.common.types.TypesFactory
+import org.eclipse.xtext.common.types.xtext.JvmMemberInitializableResource
 import org.eclipse.xtext.scoping.IScope
 import org.eclipse.xtext.xbase.compiler.output.ITreeAppendable
 import org.eclipse.xtext.xbase.jvmmodel.AbstractModelInferrer
@@ -57,8 +58,8 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
   @Inject extension ScopeProviderX
 
   @Inject TypesFactory typesFactory
-  @Inject ScopeProviderGenerator providerGenerator
-  @Inject ScopeNameProviderGenerator nameProviderGenerator
+  @Inject Provider<ScopeProviderGenerator> providerGenerators
+  @Inject Provider<ScopeNameProviderGenerator> nameProviderGenerators
   @Inject GenModelUtilX genModelUtil
   @Inject GeneratorSupport generatorSupport
   @Inject JavaBodyAppender bodyAppender
@@ -77,24 +78,6 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
     if (isPreIndexingPhase) {
       return
     }
-    genModelUtil.resource = element.eResource
-    providerGenerator.configure(nameProviderGenerator, genModelUtil, element)
-    nameProviderGenerator.configure(genModelUtil, element)
-
-    // The method body strings are produced eagerly here (inside the project resource loader required by the
-    // expression compiler) rather than from within the deferred body closures, which run later during emission.
-    val Map<String, String> bodies = newHashMap
-    generatorSupport.executeWithProjectResourceLoader(element.projectOf, [
-      bodies.put('doGetScopeRef', providerGenerator.doGetScopeByReferenceBody(element).toString)
-      bodies.put('doGetScopeType', providerGenerator.doGetScopeByTypeBody(element).toString)
-      bodies.put('doGlobalCacheRef', providerGenerator.doGlobalCacheByReferenceBody(element).toString)
-      bodies.put('doGlobalCacheType', providerGenerator.doGlobalCacheByTypeBody(element).toString)
-      for (scope : element.allScopes) {
-        bodies.put('scope:' + scope.scopeMethodName, providerGenerator.scopeMethodBody(scope, element).toString)
-      }
-      bodies.put('nameFunctions', nameProviderGenerator.internalGetNameFunctionsBody(element).toString)
-    ])
-
     val providerName = element.scopeProvider
     acceptor.accept(element.toClass(providerName)) [
       superTypes += typeRef(AbstractPolymorphicScopeProvider)
@@ -118,8 +101,7 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
         parameters += element.toParameter('reference', typeRef(EReference))
         parameters += element.toParameter('scopeName', typeRef(String))
         parameters += element.toParameter('originalResource', typeRef(Resource))
-        val text = bodies.get('doGetScopeRef')
-        body = [appendJava(text, element)]
+        body = [appendJava(renderBody(element, [provider, names | provider.doGetScopeByReferenceBody(element)]), element)]
       ]
       members += element.toMethod('doGetScope', typeRef(IScope)) [
         visibility = JvmVisibility.PROTECTED
@@ -128,8 +110,7 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
         parameters += element.toParameter('type', typeRef(EClass))
         parameters += element.toParameter('scopeName', typeRef(String))
         parameters += element.toParameter('originalResource', typeRef(Resource))
-        val text = bodies.get('doGetScopeType')
-        body = [appendJava(text, element)]
+        body = [appendJava(renderBody(element, [provider, names | provider.doGetScopeByTypeBody(element)]), element)]
       ]
       members += element.toMethod('doGlobalCache', typeRef(Boolean.TYPE)) [
         visibility = JvmVisibility.PROTECTED
@@ -138,8 +119,7 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
         parameters += element.toParameter('reference', typeRef(EReference))
         parameters += element.toParameter('scopeName', typeRef(String))
         parameters += element.toParameter('originalResource', typeRef(Resource))
-        val text = bodies.get('doGlobalCacheRef')
-        body = [appendJava(text, element)]
+        body = [appendJava(renderBody(element, [provider, names | provider.doGlobalCacheByReferenceBody(element)]), element)]
       ]
       members += element.toMethod('doGlobalCache', typeRef(Boolean.TYPE)) [
         visibility = JvmVisibility.PROTECTED
@@ -148,11 +128,9 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
         parameters += element.toParameter('type', typeRef(EClass))
         parameters += element.toParameter('scopeName', typeRef(String))
         parameters += element.toParameter('originalResource', typeRef(Resource))
-        val text = bodies.get('doGlobalCacheType')
-        body = [appendJava(text, element)]
+        body = [appendJava(renderBody(element, [provider, names | provider.doGlobalCacheByTypeBody(element)]), element)]
       ]
       for (scope : element.allScopes) {
-        val text = bodies.get('scope:' + scope.scopeMethodName)
         val hasReference = scope.reference !== null
         members += element.toMethod(scope.scopeMethodName, typeRef(IScope)) [
           visibility = JvmVisibility.PROTECTED
@@ -163,7 +141,7 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
             parameters += element.toParameter('type', typeRef(EClass))
           }
           parameters += element.toParameter('originalResource', typeRef(Resource))
-          body = [appendJava(text, element)]
+          body = [appendJava(renderBody(element, [provider, names | provider.scopeMethodBody(scope, element)]), element)]
         ]
       }
     ]
@@ -178,10 +156,34 @@ class ScopeJvmModelInferrer extends AbstractModelInferrer {
         visibility = JvmVisibility.PUBLIC
         annotations += typeOnlyAnnotation(Override)
         parameters += element.toParameter('eClass', typeRef(EClass))
-        val text = bodies.get('nameFunctions')
-        body = [appendJava(text, element)]
+        body = [appendJava(renderBody(element, [provider, names | names.internalGetNameFunctionsBody(element)]), element)]
       ]
     ]
+    // Acceptor initializers alone run before infer returns to resource loading. Register after both roots
+    // have been accepted so Xtext marks both types for demand-driven member initialization.
+    val resource = element.eResource
+    if (resource instanceof JvmMemberInitializableResource) {
+      resource.addJvmMemberInitializer([])
+    }
+  }
+
+  /** Renders only during emission, with fresh model-specific generators and a restored resource context. */
+  def private String renderBody(ScopeModel model, (ScopeProviderGenerator, ScopeNameProviderGenerator)=>CharSequence producer) {
+    val previousContext = genModelUtil.context
+    val result = newArrayList('')
+    try {
+      generatorSupport.executeWithProjectResourceLoader(model.projectOf, [
+        genModelUtil.resource = model.eResource
+        val provider = providerGenerators.get
+        val names = nameProviderGenerators.get
+        provider.configure(names, genModelUtil, model)
+        names.configure(genModelUtil, model)
+        result.set(0, producer.apply(provider, names).toString)
+      ])
+      result.get(0)
+    } finally {
+      genModelUtil.resource = previousContext
+    }
   }
 
   /**


### PR DESCRIPTION
Scope inference can run while grammar linking traverses resource roots. Since #1405, the inferrer renders Java bodies before accepting either provider type. If rendering encounters a classifier without an EPackage, inference throws and neither provider is retained.

Defer member initialization through Xtext's existing resource mechanism and render bodies only during Java emission, with model-specific generator instances and restored resource context. The only file changed is `ScopeJvmModelInferrer.xtend`; the standard Xtext generator remains in use.

This is the smaller alternative to #1522, which remains open for comparison. It addresses the demonstrated timing failure without adding generation-time reinference or incomplete-model markers.

Validation:
- A separate synthetic timing probe failed against public DDK 19.1 (`expected 3 resource roots, got 1`) and passed with this production change. The probe is not included in this PR.
- The standalone reproducer was packaged, extracted, and tested. Both generated provider classes also compile with Java 21.
- Before removing the synthetic test, full local `mvn verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check` succeeded: 355 tests, zero failures/errors, two skipped. Production code is unchanged since that run. The test and its suite registration have been removed; the suite has not been rerun after that removal.

The separate probe deliberately stages a detached classifier before resource-root traversal, then restores it before generation. It demonstrates the failure mechanism and postponement fix, not the complete downstream Eclipse build sequence, retry after failed member initialization, or the cause of all Windows slowness. The reported stack establishes inference during grammar processing; why the particular classifier had no package remains unproven.

The standalone reproducer is kept outside this PR and is available as a separate ZIP for attachment. The four-test ZIP on #1522 tests the broader proposal and is not the fixture for this PR.
