### PR TITLE
build: prepare DDK release 19.2.0

### DIFF
--- a/com.avaloq.tools.ddk.feature/feature.xml
+++ b/com.avaloq.tools.ddk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.avaloq.tools.ddk.feature"
       label="com.avaloq.tools.ddk.feature"
-      version="19.1.2.qualifier"
+      version="19.2.0.qualifier"
       provider-name="Avaloq Group AG">
 
    <description>

--- a/com.avaloq.tools.ddk.feature/pom.xml
+++ b/com.avaloq.tools.ddk.feature/pom.xml
@@ -7,7 +7,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>19.1.2-SNAPSHOT</version>
+  <version>19.2.0-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/com.avaloq.tools.ddk.runtime.feature/feature.xml
+++ b/com.avaloq.tools.ddk.runtime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.avaloq.tools.ddk.runtime.feature"
       label="com.avaloq.tools.ddk.runtime.feature"
-      version="19.1.1.qualifier"
+      version="19.2.0.qualifier"
       provider-name="Avaloq Group AG">
 
    <description>

--- a/com.avaloq.tools.ddk.runtime.feature/pom.xml
+++ b/com.avaloq.tools.ddk.runtime.feature/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>19.1.1-SNAPSHOT</version>
+  <version>19.2.0-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.runtime.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/ddk-repository/category.xml
+++ b/ddk-repository/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.avaloq.tools.ddk.feature_19.1.2.qualifier.jar" id="com.avaloq.tools.ddk.feature" version="19.1.2.qualifier">
+   <feature url="features/com.avaloq.tools.ddk.feature_19.2.0.qualifier.jar" id="com.avaloq.tools.ddk.feature" version="19.2.0.qualifier">
       <category name="com.avaloq.tools.ddk.sdk"/>
    </feature>
-   <feature url="features/com.avaloq.tools.ddk.runtime.feature_19.1.1.qualifier.jar" id="com.avaloq.tools.ddk.runtime.feature" version="19.1.1.qualifier">
+   <feature url="features/com.avaloq.tools.ddk.runtime.feature_19.2.0.qualifier.jar" id="com.avaloq.tools.ddk.runtime.feature" version="19.2.0.qualifier">
       <category name="com.avaloq.tools.ddk.runtime"/>
    </feature>
    <category-def name="com.avaloq.tools.ddk.sdk" label="DSL Developer Kit"/>


### PR DESCRIPTION
## Problem

The `v19.2.0` release dispatch failed at `create_tag`. The release workflow requires every `feature.xml` to declare the release version — [`release.yml:87-104`](https://github.com/dsldevkit/dsl-devkit/blob/master/.github/workflows/release.yml#L87-L104) fails unless each one reads `<release>.qualifier`:

```
com.avaloq.tools.ddk.runtime.feature: feature.xml version is '19.1.1.qualifier', expected '19.2.0.qualifier'
com.avaloq.tools.ddk.feature: feature.xml version is '19.1.2.qualifier', expected '19.2.0.qualifier'
```

The two features had drifted apart, and neither matched the release version.

## Why they drifted

Individual PRs bump a feature whenever a bundle it contains changes, because Tycho's `compare-version-with-baselines` fails on unchanged versions with changed content. That is *per-change* versioning, and the two features accumulate bumps at different rates depending on which bundles a PR touches — hence 19.1.2 versus 19.1.1.

The release expects something different: both features at the release version, in lockstep. That reconciliation is what a `build: prepare DDK release …` commit does.

## Fix

Set both features and their poms to `19.2.0`, and update the two `ddk-repository/category.xml` pins (`url` and `version`) to match. Same five files and the same shape as `c6e568436` (release 19.1.0).

## Verification

- The workflow's own check re-run locally over every `feature.xml`: both now report `19.2.0.qualifier`, gate passes. (Note the workflow's `awk` uses GNU three-argument `match()`, so it only runs under gawk on the CI image, not BSD awk on macOS.)
- Full local build: `clean verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check`.

## Follow-up worth considering

This reconciliation will be needed before every release as long as per-PR feature bumps continue. Either the release gate accepts a version *at or above* the release version, or feature bumps are deferred to release-prep only. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
