### PR TITLE
fix(format): stabilize fingerprints without losing inherited changes

### DIFF
--- a/com.avaloq.tools.ddk.feature/feature.xml
+++ b/com.avaloq.tools.ddk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.avaloq.tools.ddk.feature"
       label="com.avaloq.tools.ddk.feature"
-      version="19.2.0.qualifier"
+      version="19.2.1.qualifier"
       provider-name="Avaloq Group AG">
 
    <description>

--- a/com.avaloq.tools.ddk.feature/pom.xml
+++ b/com.avaloq.tools.ddk.feature/pom.xml
@@ -7,7 +7,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>19.2.0-SNAPSHOT</version>
+  <version>19.2.1-SNAPSHOT</version>
 
   <artifactId>com.avaloq.tools.ddk.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/format/builder/FormatIncrementalBuildTest.java
+++ b/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/format/builder/FormatIncrementalBuildTest.java
@@ -1,0 +1,242 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Group AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.format.builder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.xtext.builder.builderState.IBuilderState;
+import org.eclipse.xtext.resource.IResourceDescription;
+import org.eclipse.xtext.resource.IResourceDescription.Event.Listener;
+import org.eclipse.xtext.ui.XtextProjectHelper;
+import org.eclipse.xtext.ui.shared.Access;
+import org.eclipse.xtext.ui.testing.util.JavaProjectSetupUtil;
+import org.eclipse.xtext.ui.util.PluginProjectFactory;
+import org.junit.jupiter.api.Test;
+
+import com.avaloq.tools.ddk.xtext.format.FormatConstants;
+import com.avaloq.tools.ddk.xtext.format.ui.internal.FormatActivator;
+import com.google.inject.Injector;
+
+/** Exercises the real index, linking and builder with a three-level Format inheritance chain. */
+@SuppressWarnings("nls")
+public class FormatIncrementalBuildTest {
+
+  private static final String PROJECT = "format.fingerprint.regression";
+  private static final String BASE = "formatter for org.eclipse.xtext.xbase.Xtype\nconst int SPACING = 1;\nID { rule : no_space around; }\n";
+  private static final String CHILD = "formatter for org.eclipse.xtext.xbase.Xbase with org.eclipse.xtext.xbase.Xtype\n";
+  private static final String GRANDCHILD = "formatter for org.eclipse.xtext.xbase.annotations.XbaseWithAnnotations with org.eclipse.xtext.xbase.Xbase\nconst int LOCAL = 3;\n";
+
+  private static final String BASE_PATH = "src/repro/Xtype.format";
+
+  private static final String CHILD_FILE = "Xbase.format";
+
+  private static final String GRANDCHILD_FILE = "XbaseWithAnnotations.format";
+
+  private static final String LF = "\n";
+
+  private static final String CRLF = "\r\n";
+
+  @Test
+  public void incrementalOutputMatchesFullBuildAndIdenticalSavesStayLocal() throws Exception {
+    final boolean autoBuild = setAutoBuilding(false);
+    IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
+    List<String> indexed = new ArrayList<>();
+    Listener listener = event -> {
+      for (IResourceDescription.Delta delta : event.getDeltas()) {
+        if (delta.getUri().isPlatformResource() && PROJECT.equals(delta.getUri().segment(1)) && "format".equals(delta.getUri().fileExtension())) {
+          indexed.add(delta.getUri().lastSegment());
+        }
+      }
+    };
+    IBuilderState index = Access.getIBuilderState().get();
+    index.addListener(listener);
+    try {
+      createFixture(project);
+
+      indexed.clear();
+      write(project, BASE_PATH, BASE);
+      build(IncrementalProjectBuilder.INCREMENTAL_BUILD);
+      assertFalse(indexed.contains(CHILD_FILE) || indexed.contains(GRANDCHILD_FILE),
+          "identical save must not rebuild descendants: " + indexed);
+      assertMatchesFullBuild(project);
+
+      for (String source : List.of(BASE.replace("SPACING = 1", "SPACING = 2"),
+          "// shifted source location\n" + BASE, BASE.replace("no_space around", "linewrap before"),
+          BASE.replace(LF, CRLF), BASE.replace("ID {", "const int ADDED = 4;\nID {"), BASE.replace("SPACING", "RENAMED"), BASE)) {
+        write(project, BASE_PATH, source);
+        build(IncrementalProjectBuilder.INCREMENTAL_BUILD);
+        assertMatchesFullBuild(project);
+      }
+      String crlf = BASE.replace(LF, CRLF);
+      write(project, BASE_PATH, crlf);
+      build(IncrementalProjectBuilder.INCREMENTAL_BUILD);
+      assertMatchesFullBuild(project);
+      indexed.clear();
+      final Map<String, String> unchanged = outputs(project);
+      write(project, BASE_PATH, crlf);
+      build(IncrementalProjectBuilder.INCREMENTAL_BUILD);
+      assertFalse(indexed.contains(CHILD_FILE) || indexed.contains(GRANDCHILD_FILE), "identical CRLF save must stay local");
+      assertEquals(unchanged, outputs(project), "identical save must preserve all generated bytes");
+    } finally {
+      index.removeListener(listener);
+      if (project.exists()) {
+        project.delete(true, true, null);
+      }
+      setAutoBuilding(autoBuild);
+    }
+  }
+
+  @Test
+  public void renamedBaseWithUnchangedContentMatchesFullBuild() throws Exception {
+    final boolean autoBuild = setAutoBuilding(false);
+    IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
+    try {
+      createFixture(project);
+      // The with clause names the grammar, not the file, so the dependents still resolve after the rename.
+      IFile renamed = project.getFile("src/repro/XtypeRenamed.format");
+      project.getFile(BASE_PATH).move(renamed.getFullPath(), IResource.FORCE, null);
+      assertTrue(renamed.exists() && !project.getFile(BASE_PATH).exists(), "rename must move the base file");
+      build(IncrementalProjectBuilder.INCREMENTAL_BUILD);
+      assertMatchesFullBuild(project);
+    } finally {
+      if (project.exists()) {
+        project.delete(true, true, null);
+      }
+      setAutoBuilding(autoBuild);
+    }
+  }
+
+  private boolean setAutoBuilding(final boolean enabled) throws CoreException, InterruptedException {
+    IWorkspace workspace = ResourcesPlugin.getWorkspace();
+    IWorkspaceDescription description = workspace.getDescription();
+    final boolean previous = description.isAutoBuilding();
+    description.setAutoBuilding(enabled);
+    workspace.setDescription(description);
+    Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+    return previous;
+  }
+
+  private void createFixture(final IProject project) throws CoreException {
+    if (project.exists()) {
+      project.delete(true, true, null);
+    }
+    createProject();
+    write(project, BASE_PATH, BASE);
+    write(project, "src/repro/Xbase.format", CHILD);
+    write(project, "src/repro/XbaseWithAnnotations.format", GRANDCHILD);
+    for (String language : List.of("Xtype", "Xbase", "annotations.XbaseWithAnnotations")) {
+      String simple = language.substring(language.lastIndexOf('.') + 1);
+      String pkg = "org.eclipse.xtext.xbase." + (language.startsWith("annotations.") ? "annotations." : "") + "formatting";
+      write(project, "src/" + pkg.replace('.', '/') + "/" + simple + "Formatter.java",
+          "package " + pkg + ";\npublic abstract class " + simple + "Formatter extends Abstract" + simple + "Formatter {}\n");
+    }
+    build(IncrementalProjectBuilder.FULL_BUILD);
+    build(IncrementalProjectBuilder.INCREMENTAL_BUILD);
+    assertNoErrors(project);
+    assertFalse(outputs(project).isEmpty(), "fixture must produce Java and traces");
+    assertTrue(outputs(project).keySet().stream().anyMatch(n -> n.endsWith("._trace")), "trace comparison must not be vacuous");
+  }
+
+  private void createProject() throws CoreException {
+    Injector injector = FormatActivator.getInstance().getInjector(FormatConstants.GRAMMAR);
+    PluginProjectFactory factory = injector.getInstance(PluginProjectFactory.class);
+    factory.setProjectName(PROJECT);
+    factory.addFolders(List.of("src", "src-gen"));
+    factory.addBuilderIds(JavaCore.BUILDER_ID, "org.eclipse.pde.ManifestBuilder", "org.eclipse.pde.SchemaBuilder", XtextProjectHelper.BUILDER_ID);
+    factory.addProjectNatures(JavaCore.NATURE_ID, "org.eclipse.pde.PluginNature", XtextProjectHelper.NATURE_ID);
+    factory.addRequiredBundles(List.of("org.eclipse.xtext", "org.eclipse.xtext.xbase", "org.eclipse.xtext.xbase.lib", "org.eclipse.emf.ecore",
+        "com.avaloq.tools.ddk.xtext", "com.avaloq.tools.ddk.xtext.format", "org.eclipse.core.runtime"));
+    IProject project = factory.createProject(new NullProgressMonitor(), null);
+    JavaProjectSetupUtil.addJreClasspathEntry(JavaCore.create(project));
+  }
+
+  private void assertMatchesFullBuild(final IProject project) throws CoreException {
+    assertNoErrors(project);
+    Map<String, String> incremental = outputs(project);
+    build(IncrementalProjectBuilder.FULL_BUILD);
+    assertNoErrors(project);
+    assertEquals(outputs(project), incremental, "incremental Java and trace bytes must match full-build output");
+  }
+
+  private void assertNoErrors(final IProject project) throws CoreException {
+    List<String> errors = new ArrayList<>();
+    for (IMarker marker : project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE)) {
+      if (marker.getAttribute(IMarker.SEVERITY, 0) == IMarker.SEVERITY_ERROR) {
+        errors.add(marker.getResource().getProjectRelativePath() + ": " + marker.getAttribute(IMarker.MESSAGE, ""));
+      }
+    }
+    assertTrue(errors.isEmpty(), "fixture must build without errors: " + errors);
+  }
+
+  private Map<String, String> outputs(final IProject project) throws CoreException {
+    Map<String, String> result = new TreeMap<>();
+    project.getFolder("src-gen").accept(resource -> {
+      if (resource instanceof IFile file) {
+        try (InputStream in = file.getContents()) {
+          result.put(file.getProjectRelativePath().toString(), HexFormat.of().formatHex(in.readAllBytes()));
+        } catch (java.io.IOException exception) {
+          throw new java.io.UncheckedIOException(exception);
+        }
+      }
+      return true;
+    });
+    return result;
+  }
+
+  private void build(final int kind) throws CoreException {
+    ResourcesPlugin.getWorkspace().build(kind, new NullProgressMonitor());
+  }
+
+  private void write(final IProject project, final String path, final String content) throws CoreException {
+    IFile file = project.getFile(path);
+    createFolder(file.getParent());
+    try (InputStream in = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))) {
+      if (file.exists()) {
+        file.setContents(in, IResource.FORCE, null);
+      } else {
+        file.create(in, true, null);
+      }
+    } catch (java.io.IOException exception) {
+      throw new java.io.UncheckedIOException(exception);
+    }
+  }
+
+  private void createFolder(final org.eclipse.core.resources.IContainer container) throws CoreException {
+    if (container instanceof IFolder folder && !folder.exists()) {
+      createFolder(folder.getParent());
+      folder.create(true, true, null);
+    }
+  }
+}

--- a/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/format/resource/FormatResourceDescriptionStrategyTest.java
+++ b/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/format/resource/FormatResourceDescriptionStrategyTest.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Avaloq Group AG and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Avaloq Group AG - initial API and implementation
+ *******************************************************************************/
+package com.avaloq.tools.ddk.xtext.format.resource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.xtext.resource.IDefaultResourceDescriptionStrategy;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import org.eclipse.xtext.resource.XtextResourceSet;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.extensions.InjectionExtension;
+import org.eclipse.xtext.testing.util.ParseHelper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.avaloq.tools.ddk.xtext.format.FormatInjectorProvider;
+import com.avaloq.tools.ddk.xtext.format.format.FormatConfiguration;
+import com.avaloq.tools.ddk.xtext.format.format.FormatFactory;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+/** Regression fixtures for stable exports and transitive Format configuration changes. */
+@ExtendWith(InjectionExtension.class)
+@InjectWith(FormatInjectorProvider.class)
+@SuppressWarnings("nls")
+public class FormatResourceDescriptionStrategyTest {
+
+  private static final String LF = "\n";
+
+  private static final String CRLF = "\r\n";
+
+  private static final String BASE_NAME = "Base";
+
+  private static final String CHILD_NAME = "Child";
+
+  private static final String EMPTY_NAME = "Empty";
+
+  @Inject
+  private ParseHelper<FormatConfiguration> parser;
+
+  @Inject
+  private IDefaultResourceDescriptionStrategy strategy;
+
+  @Inject
+  private Provider<XtextResourceSet> resourceSets;
+
+  @Test
+  public void identicalReloadsHaveIdenticalExports() throws Exception {
+    for (String newline : List.of(LF, CRLF)) {
+      String source = "formatter for example.Base" + newline + "const int SPACING = 1;" + newline;
+      assertEquals(exports(parse(BASE_NAME, source)), exports(parse(BASE_NAME, source)), "object identity must not affect the index");
+    }
+  }
+
+  @Test
+  public void inheritedChangesPropagateThroughEmptyIntermediateFormats() throws Exception {
+    FormatConfiguration base = parse(BASE_NAME, "formatter for example.Base\nconst int SPACING = 1;\n");
+    FormatConfiguration child = parse(CHILD_NAME, "formatter for example.Child with example.Base\n");
+    FormatConfiguration grandchild = parse("Grandchild", "formatter for example.Grandchild with example.Child\n");
+    child.setExtendedFormatConfiguration(base);
+    grandchild.setExtendedFormatConfiguration(child);
+    List<String> before = exports(grandchild);
+    FormatConfiguration changed = parse(BASE_NAME, "formatter for example.Base\nconst int SPACING = 2;\n");
+    child.setExtendedFormatConfiguration(changed);
+    assertNotEquals(before, exports(grandchild), "a real change must reach the grandchild, even through an empty child");
+  }
+
+  @Test
+  public void inheritedSourceLocationsParticipateInExports() throws Exception {
+    String source = "formatter for example.Base\nconst int SPACING = 1;\n";
+    FormatConfiguration child = parse(CHILD_NAME, "formatter for example.Child with example.Base\nconst int LOCAL = 0;\n");
+    child.setExtendedFormatConfiguration(parse(BASE_NAME, source));
+    List<String> before = exports(child);
+    child.setExtendedFormatConfiguration(parse(BASE_NAME, "// inserted line\n" + source));
+    assertNotEquals(before, exports(child), "inherited source references must be regenerated after a line shift");
+    before = exports(child);
+    child.setExtendedFormatConfiguration(parse(BASE_NAME, ("// inserted line\n" + source).replace(LF, CRLF)));
+    assertNotEquals(before, exports(child), "line-ending changes affect trace offsets");
+  }
+
+  @Test
+  public void configurationWithoutLocalDeclarationsStillHasAContentFingerprint() throws Exception {
+    assertNotEquals(exports(parse(EMPTY_NAME, "formatter for example.Empty\n")),
+        exports(parse(EMPTY_NAME, "// inserted line\nformatter for example.Empty\n")));
+  }
+
+  @Test
+  public void cyclicInheritanceTerminates() throws Exception {
+    FormatConfiguration first = parse("First", "formatter for example.First\n");
+    FormatConfiguration second = parse("Second", "formatter for example.Second\n");
+    first.setExtendedFormatConfiguration(second);
+    second.setExtendedFormatConfiguration(first);
+    assertTimeoutPreemptively(Duration.ofSeconds(5), () -> assertEquals(exports(first), exports(first)));
+  }
+
+  @Test
+  public void unresolvedBaseCanBecomeResolvedWithoutLosingItsContentChange() throws Exception {
+    FormatConfiguration child = parse(CHILD_NAME, "formatter for example.Child with example.Base\n");
+    FormatConfiguration proxy = FormatFactory.eINSTANCE.createFormatConfiguration();
+    ((InternalEObject) proxy).eSetProxyURI(URI.createURI("synthetic:/Base.format#/0"));
+    child.setExtendedFormatConfiguration(proxy);
+    List<String> unresolved = exports(child);
+    assertEquals(unresolved, exports(child), "unresolved proxies must have a stable fingerprint");
+    child.setExtendedFormatConfiguration(parse(BASE_NAME, "formatter for example.Base\nconst int SPACING = 1;\n"));
+    assertNotEquals(unresolved, exports(child), "resolved base content must enter the fingerprint");
+  }
+
+  @Test
+  public void baseSelectionAndSuperclassArePartOfTheConfiguration() throws Exception {
+    String source = "formatter for example.Child with example.First\n";
+    assertNotEquals(exports(parse(CHILD_NAME, source)), exports(parse(CHILD_NAME, source.replace("First", "Second"))));
+    assertNotEquals(exports(parse(CHILD_NAME, "formatter for example.Child\n")),
+        exports(parse(CHILD_NAME, "formatter for example.Child extends example.CustomFormatter\n")));
+  }
+
+  private FormatConfiguration parse(final String name, final String source) {
+    return assertDoesNotThrow(() -> parser.parse(source, URI.createURI("synthetic:/" + name + ".format"), resourceSets.get()));
+  }
+
+  private List<String> exports(final FormatConfiguration format) {
+    List<IEObjectDescription> descriptions = new ArrayList<>();
+    strategy.createEObjectDescriptions(format, descriptions::add);
+    for (EObject child : format.eContents()) {
+      strategy.createEObjectDescriptions(child, descriptions::add);
+    }
+    return descriptions.stream().map(d -> d.getName().toString() + "@" + d.getEObjectURI()).sorted().toList();
+  }
+}

--- a/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/test/format/FormatTestSuite.java
+++ b/com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/test/format/FormatTestSuite.java
@@ -16,8 +16,10 @@ import org.junit.platform.suite.api.Suite;
 import com.avaloq.tools.ddk.xtext.format.FormatLineSeparatorBindingTest;
 import com.avaloq.tools.ddk.xtext.format.FormatParsingTest;
 import com.avaloq.tools.ddk.xtext.format.builder.FormatBuilderParticipantTest;
+import com.avaloq.tools.ddk.xtext.format.builder.FormatIncrementalBuildTest;
 import com.avaloq.tools.ddk.xtext.format.formatting.FormatFormattingTest;
 import com.avaloq.tools.ddk.xtext.format.jvmmodel.FormatJvmModelInferrerTest;
+import com.avaloq.tools.ddk.xtext.format.resource.FormatResourceDescriptionStrategyTest;
 import com.avaloq.tools.ddk.xtext.format.scoping.FormatScopingTest;
 import com.avaloq.tools.ddk.xtext.format.validation.FormatValidationTest;
 
@@ -26,7 +28,7 @@ import com.avaloq.tools.ddk.xtext.format.validation.FormatValidationTest;
  * Empty class serving only as holder for JUnit5 annotations.
  */
 @Suite
-@SelectClasses({FormatParsingTest.class, FormatLineSeparatorBindingTest.class, FormatFormattingTest.class, FormatValidationTest.class, FormatScopingTest.class, FormatBuilderParticipantTest.class, FormatJvmModelInferrerTest.class})
+@SelectClasses({FormatIncrementalBuildTest.class, FormatResourceDescriptionStrategyTest.class, FormatParsingTest.class, FormatLineSeparatorBindingTest.class, FormatFormattingTest.class, FormatValidationTest.class, FormatScopingTest.class, FormatBuilderParticipantTest.class, FormatJvmModelInferrerTest.class})
 public class FormatTestSuite {
 
 }

--- a/com.avaloq.tools.ddk.xtext.format/META-INF/MANIFEST.MF
+++ b/com.avaloq.tools.ddk.xtext.format/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: com.avaloq.tools.ddk.xtext.format
 Bundle-SymbolicName: com.avaloq.tools.ddk.xtext.format;singleton:=true
-Bundle-Version: 17.3.3.qualifier
+Bundle-Version: 17.3.4.qualifier
 Bundle-Vendor: Avaloq Group AG
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy

--- a/com.avaloq.tools.ddk.xtext.format/pom.xml
+++ b/com.avaloq.tools.ddk.xtext.format/pom.xml
@@ -6,7 +6,7 @@
     <version>18.0.1-SNAPSHOT</version>
     <relativePath>../ddk-parent</relativePath>
   </parent>
-  <version>17.3.3-SNAPSHOT</version>
+  <version>17.3.4-SNAPSHOT</version>
   <groupId>com.avaloq.tools.ddk</groupId>
   <artifactId>com.avaloq.tools.ddk.xtext.format</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/resource/FormatResourceDescriptionStrategy.java
+++ b/com.avaloq.tools.ddk.xtext.format/src/com/avaloq/tools/ddk/xtext/format/resource/FormatResourceDescriptionStrategy.java
@@ -10,7 +10,12 @@
  *******************************************************************************/
 package com.avaloq.tools.ddk.xtext.format.resource;
 
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.xtext.AbstractRule;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.Grammar;
@@ -35,25 +40,57 @@ import com.avaloq.tools.ddk.xtext.resource.IFingerprintComputer;
  * (not its name) would not trigger a cascade propagation of this change from the base format specification (.format file) to all dependent (child) format
  * specifications. Therefore, besides a standard export, all the objects are exported under their fingerprints. Therefore when the content (text, value) of the
  * object changes this would cause a proper invalidations of the dependent formats.
+ * <p>
+ * Invariant: the fingerprint of a {@link FormatConfiguration} is a function of the resource URI and source text of the configuration and of its resolved
+ * ancestors, and of nothing else. Object identity does not participate, so reloading unchanged sources yields identical exports, while any change to an
+ * inherited source (including comments and line endings, which move generated source locations) propagates to every dependent configuration. Renaming or
+ * moving an inherited source propagates as well, because the generated code records inherited source locations by file name.
  */
 @SuppressWarnings("nls")
 public class FormatResourceDescriptionStrategy extends DefaultResourceDescriptionStrategy {
 
+  /** Initial profile capacity; whole source texts of the inheritance chain are appended. */
+  private static final int PROFILE_CAPACITY = 8192;
+
   /**
-   * A fingerprint computer that computes the hash using the content (text) and the parent container of the given {@link EObject}.
+   * A fingerprint computer that computes the hash using the source text of the given {@link EObject}; a {@link FormatConfiguration} is hashed together with
+   * the source text of its whole inheritance chain.
    */
   private final IFingerprintComputer fingerprintComputer = new AbstractFingerprintComputer() {
 
     @Override
     protected ExportItem fingerprint(final EObject obj) {
-      final StringBuilder profile = new StringBuilder();
-      if (obj != null) {
-        if (obj.eContainer() != null) {
-          addProfile(profile, obj.eContainer().toString());
-        }
+      final StringBuilder profile = new StringBuilder(PROFILE_CAPACITY);
+      if (obj instanceof FormatConfiguration configuration) {
+        addInheritanceChain(profile, configuration);
+      } else if (obj != null) {
         addProfile(profile, NodeModelUtils.getTokenText(NodeModelUtils.getNode(obj)));
       }
       return new ExportItem(profile);
+    }
+
+    /**
+     * Adds the resource URI and root node text of the given configuration and of each resolved ancestor; a proxy ancestor contributes its proxy URI and ends
+     * the chain.
+     *
+     * @param profile
+     *          the string builder building the fingerprint
+     * @param configuration
+     *          the configuration whose inheritance chain is walked
+     */
+    private void addInheritanceChain(final StringBuilder profile, final FormatConfiguration configuration) {
+      final Set<FormatConfiguration> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+      FormatConfiguration current = configuration;
+      while (current != null && visited.add(current)) {
+        if (current.eIsProxy()) {
+          addProfile(profile, ((InternalEObject) current).eProxyURI().toString());
+          return;
+        }
+        addProfile(profile, current.eResource() == null ? "" : current.eResource().getURI().toString());
+        final INode node = NodeModelUtils.getNode(current);
+        addProfile(profile, node == null ? "" : node.getRootNode().getText());
+        current = current.getExtendedFormatConfiguration();
+      }
     }
   };
 
@@ -65,13 +102,8 @@ public class FormatResourceDescriptionStrategy extends DefaultResourceDescriptio
     }
 
     boolean indexObject = false;
-    String objectFingerprint = null;
-    if (fingerprintComputer != null && eObject.eContainer() instanceof FormatConfiguration && NodeModelUtils.getNode(eObject) != null) {
-      objectFingerprint = fingerprintComputer.computeFingerprint(eObject);
-    }
-
-    if (objectFingerprint != null && !"".equals(objectFingerprint) && eObject.eContainer() instanceof FormatConfiguration) {
-      acceptor.accept(EObjectDescription.create(objectFingerprint, eObject));
+    if (eObject instanceof FormatConfiguration || (eObject.eContainer() instanceof FormatConfiguration && NodeModelUtils.getNode(eObject) != null)) {
+      acceptor.accept(EObjectDescription.create(fingerprintComputer.computeFingerprint(eObject), eObject));
       indexObject = true;
     }
     boolean indexDefault = createDescriptionsForNonXbaseFormalParameters(eObject, acceptor);

--- a/ddk-repository/category.xml
+++ b/ddk-repository/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.avaloq.tools.ddk.feature_19.2.0.qualifier.jar" id="com.avaloq.tools.ddk.feature" version="19.2.0.qualifier">
+   <feature url="features/com.avaloq.tools.ddk.feature_19.2.1.qualifier.jar" id="com.avaloq.tools.ddk.feature" version="19.2.1.qualifier">
       <category name="com.avaloq.tools.ddk.sdk"/>
    </feature>
    <feature url="features/com.avaloq.tools.ddk.runtime.feature_19.2.0.qualifier.jar" id="com.avaloq.tools.ddk.runtime.feature" version="19.2.0.qualifier">

--- a/docs/reproducers/format-fingerprints/README.md
+++ b/docs/reproducers/format-fingerprints/README.md
@@ -1,0 +1,64 @@
+# Format dependency fingerprint reproducer
+
+This fixture exercises the production `FormatResourceDescriptionStrategy` using
+real parsed Format models. It is registered in `FormatTestSuite`, so the normal
+DDK test aggregator runs it. No private project or installed Eclipse workspace is
+required.
+
+## Run
+
+Use JDK 21 and Maven. A Git checkout is required by Tycho's version qualifier.
+When using the downloadable source ZIP, extract it and initialize it first:
+
+```sh
+git init
+git add .
+git -c commit.gpgsign=false -c user.name=Reproducer -c user.email=reproducer@example.invalid commit -m "Initialize reproducer"
+```
+
+From the root of the checkout:
+
+```sh
+mvn integration-test -f ddk-parent/pom.xml --batch-mode --fail-at-end
+```
+
+The `integration-test` phase runs the aggregator without the later release-baseline
+verification, which needs the original Git history. For a normal repository checkout,
+use `verify` when validating a fix.
+
+On Linux, prefix that command with `xvfb-run`. On macOS the Maven profile supplies
+the required SWT main-thread option. All tests run in the existing
+`com.avaloq.tools.ddk.xtext.test` aggregator; do not enable Surefire separately in
+the Format test bundle.
+
+The regression fixture is
+`com.avaloq.tools.ddk.xtext.format.test/src/com/avaloq/tools/ddk/xtext/format/resource/FormatResourceDescriptionStrategyTest.java`.
+
+It checks:
+
+- byte-identical LF and CRLF reloads have identical exported descriptions;
+- inherited changes reach a grandchild through an intermediate format with no
+  local declarations;
+- inserted comment lines and changed line endings invalidate inherited source
+  references;
+- formats without local declarations still expose configuration changes;
+- cyclic inheritance cannot make fingerprint calculation recurse indefinitely.
+
+The focused description tests deliberately connect parsed configurations directly
+for inheritance cases, isolating fingerprint behavior from scope resolution.
+They are not evidence of a complete Eclipse incremental-build lifecycle. The
+separate workspace regression tests cover that lifecycle and compare incremental
+Java/trace output to a full build.
+
+## Expected failure on the original implementation
+
+The original fingerprint contains `obj.eContainer().toString()`, including an EMF
+object's Java identity. Identical reloads therefore export different fingerprint
+names. Merely replacing identity with a URI is insufficient: inherited changes
+must continue propagating through formats without local changes/declarations.
+
+The original DDK 19.1 workspace experiment also showed that identical Format
+rewrites reindexed both a base and its dependent and produced change events for
+four unchanged generated Java/trace files. That experiment ran on macOS and
+settled when idle. It did not reproduce the private Windows workspace's endless
+build loop. This fix does not claim to solve every source of build churn.


### PR DESCRIPTION
Saving a byte-identical `.format` file currently changes its exported fingerprints because they contain the parent EMF object's Java identity. In the reproducer, saving unchanged `Xtype.format` also reindexes its dependent `Xbase.format`.

Derive every fingerprint from source text and resource location, never from object identity. A local declaration is fingerprinted by its own token text; a format configuration is fingerprinted by the resource URI and complete source text of its own resource and of every configuration it transitively extends. The URI participates because the generated code records inherited source locations by file name, so renaming a base must regenerate its dependents. This keeps identical reloads stable while propagating real changes through an intermediate format without local declarations. Raw comments and delimiters participate because they affect generated source locations. Inheritance cycles terminate through a visited set, and an unresolved base contributes its proxy URI and ends the traversal, so it stays distinguishable from an absent base.

Add focused description regressions and a real Eclipse workspace test. The latter checks identical LF/CRLF saves, a content-preserving rename of a base, and compares all generated Java and trace bytes between incremental and full builds after constant, rule, declaration, comment and line-ending edits. The focused tests additionally cover empty configurations, cycles, unresolved/resolved bases, base selection and superclass changes. The independently runnable failing baseline is pinned in the issue.

Bump the Format bundle from 17.3.3 to 17.3.4 and the SDK feature from 19.2.0 to 19.2.1, including its update-site entry.

Closes #1534.

Validation on macOS/JDK 21:

- Full CI-equivalent build (`mvn clean verify checkstyle:check pmd:pmd pmd:cpd pmd:check pmd:cpd-check spotbugs:check`) on the final commit: BUILD SUCCESS, 368 tests, 0 failures, 0 errors, 2 skipped; Checkstyle, PMD/CPD and SpotBugs clean.
- The rename case was first run against a text-only fingerprint and failed (dependents kept `// Xtype.format:N` source comments and stale trace offsets), then passed once ancestor resource URIs entered the fingerprint. That run is what justifies the URI component.
- Both focused description regressions and both workspace tests pass; the pre-fix baseline fails 7 of the 8 pre-existing regressions.

This addresses the demonstrated unnecessary rebuild propagation; it does not claim to reproduce or solve the reported endless Windows build loop.
